### PR TITLE
Update RepositoryBrowser.tsx

### DIFF
--- a/src/components/repository/RepositoryBrowser.tsx
+++ b/src/components/repository/RepositoryBrowser.tsx
@@ -370,7 +370,7 @@ export default function RepositoryBrowser({ account_id, repository_id }) {
               S3 URI
             </Text>
             <Text sx={{ color: "primary" }}>
-              s3://{account_id}/{repository_id}/{resultState.key}
+              s3://{account_id}/{resultState.key}
             </Text>
           </Grid>
           <Box sx={{ textAlign: "right" }}>


### PR DESCRIPTION
This should fix a bug that prints a duplicate repository ID when rendering an individual object's S3 URI.

**Related Issue(s):** #

None.

**Proposed Changes:**

This removes `${repositoryId}` from the template used to render the S3 URI for an individual object because the repository ID is returned by `{resultState.key}`. I have not been able to test this because I haven't created a dev environment, so please test this and run through the PR checklist before accepting.

**PR Checklist:**

- [X] This PR is made against the dev branch (all proposed changes except releases should be against dev, not main).
- [ ] This PR has **no** breaking changes.
- [X] This PR contains only one commit.
- [ ] I have updated or added new tests to cover the changes in this PR.
- [ ] I have updated the version in `package.json` to follow the [Semantic Versioning](https://semver.org/) guidelines.
- [ ] All tests are passing.
- [ ] I have added my changes to the [CHANGELOG](https://github.com/source-cooperative/source.coop/blob/dev/CHANGELOG.rst)
      **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [Source Cooperative Data Proxy](https://github.com/source-cooperative/data.source.coop),
      and I have opened issue/PR #XXX to track the change.
