### PR TITLE
we use squash merge -> not needed anymore

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,6 @@
 
 - [ ] This PR is made against the dev branch (all proposed changes except releases should be against dev, not main).
 - [ ] This PR has **no** breaking changes.
-- [ ] This PR contains only one commit.
 - [ ] I have updated or added new tests to cover the changes in this PR.
 - [ ] I have updated the version in `package.json` to follow the [Semantic Versioning](https://semver.org/) guidelines.
 - [ ] All tests are passing.


### PR DESCRIPTION
**Related Issue(s):** #


**Proposed Changes:**

1. remove "This PR contains only one commit." check when opening a pull request, since https://github.com/source-cooperative/source.coop/issues/39#issuecomment-2492638113 only enables squash merge for PRs, which means only one commit.

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not main).
- [x] This PR has **no** breaking changes.
- [x] This PR contains only one commit.
- [ ] I have updated or added new tests to cover the changes in this PR.
- [ ] I have updated the version in `package.json` to follow the [Semantic Versioning](https://semver.org/) guidelines.
- [ ] All tests are passing.
- [ ] I have added my changes to the [CHANGELOG](https://github.com/source-cooperative/source.coop/blob/dev/CHANGELOG.rst)
      **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [Source Cooperative Data Proxy](https://github.com/source-cooperative/data.source.coop),
      and I have opened issue/PR #XXX to track the change.
