### PR TITLE
Merge from DEV to Prod (#47)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,9 @@
 Changelog
 =========
+Version 0.1.4
+-------------
+* Fixed the default selection of Ap-South-1 in the source coop UI during new repository creation.
+
 
 Version 0.1.3
 -------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "source-cooperative",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "scripts": {
     "dev": "scripts/db_start.sh && next dev",

--- a/src/api/db/index.ts
+++ b/src/api/db/index.ts
@@ -510,7 +510,7 @@ export async function getDataConnections(): Promise<DataConnection[]> {
 
   try {
     const response = await docClient.send(command);
-    return response.Items?.map((item) => item as DataConnection) ?? [];
+    return response.Items?.sort((a,b) => b.data_connection_id.localeCompare(a.data_connection_id)).map((item) => item as DataConnection) ?? [];
   } catch (e) {
     logger.error(e);
     throw e;


### PR DESCRIPTION
* fix: Fixed the issues with getting the local s3 objects when running application locally.
* fix: fixed page loading issue.

* Update RepositoryBrowser.tsx

This should fix a bug that prints a duplicate repository ID when rendering an individual object's S3 URI.

* fix type

otherwise `npm run install-cli` does not work (see README)

* Update AccessData.tsx (#23)

* Update AccessData.tsx

Fixing instruction to upload data to a repository.

* Update AccessData.tsx

* nit: reflect package version in lock file

* ignore .env file to avoid leaking secrets

+ remove dump/ which is a duplicate line

* install CLI package

* add five missing environment variables to work locally

* add install instructions for aws + fix details (#40)

* we use squash merge -> not needed anymore (#41)

* fix: s3 uri to cloud uri. (#45)



* sorted data conections.

* fixed the build

* updated the version.

---------

**Related Issue(s):** #


**Proposed Changes:**

1.
2.

**PR Checklist:**

- [ ] This PR is made against the dev branch (all proposed changes except releases should be against dev, not main).
- [ ] This PR has **no** breaking changes.
- [ ] I have updated or added new tests to cover the changes in this PR.
- [ ] I have updated the version in `package.json` to follow the [Semantic Versioning](https://semver.org/) guidelines.
- [ ] All tests are passing.
- [ ] I have added my changes to the [CHANGELOG](https://github.com/source-cooperative/source.coop/blob/dev/CHANGELOG.rst)
      **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [Source Cooperative Data Proxy](https://github.com/source-cooperative/data.source.coop),
      and I have opened issue/PR #XXX to track the change.
