### PR TITLE
S2 env simplification

### DIFF
--- a/.cursor/rules/CURSOR_RULES.md
+++ b/.cursor/rules/CURSOR_RULES.md
@@ -268,7 +268,7 @@ const account = await fetchAccountByOryId(oryId);
 ```typescript
 // ✅ Correct: Using CONFIG
 import { CONFIG } from '@/lib/config';
-const baseUrl = CONFIG.auth.publicBaseUrl;
+const baseUrl = CONFIG.auth.apiUrl;
 
 // ❌ Incorrect: Direct env access
 const baseUrl = process.env.NEXT_PUBLIC_ORY_BASE_URL;

--- a/.cursor/rules/CURSOR_RULES.md
+++ b/.cursor/rules/CURSOR_RULES.md
@@ -268,7 +268,7 @@ const account = await fetchAccountByOryId(oryId);
 ```typescript
 // ✅ Correct: Using CONFIG
 import { CONFIG } from '@/lib/config';
-const baseUrl = CONFIG.auth.apiUrl;
+const baseUrl = CONFIG.auth.api.frontendUrl;
 
 // ❌ Incorrect: Direct env access
 const baseUrl = process.env.NEXT_PUBLIC_ORY_BASE_URL;

--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,6 @@ AWS_REGION=us-west-2
 # Ory.sh configuration
 ORY_PROJECT_ID=your_ory_project_id
 ORY_PROJECT_SLUG=your_ory_project_slug
-ORY_API_URL=https://your-ory-project.projects.oryapis.com
 ORY_WORKSPACE_ID=your_ory_workspace_id
 ORY_PROJECT_API_KEY=your_ory_access_token
 
@@ -35,4 +34,4 @@ DYNAMODB_SECRET_ACCESS_KEY=local
 
 # Remove AWS credentials for public bucket access
 # AWS_ACCESS_KEY_ID=local
-# AWS_SECRET_ACCESS_KEY=local 
+# AWS_SECRET_ACCESS_KEY=local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
       - .:/app
     working_dir: /app
     environment:
+      - NEXT_PUBLIC_ORY_BASE_URL=http://localhost:4000
       - ORY_BASE_URL=http://ory-tunnel:4000
       - DYNAMODB_ENDPOINT=http://dynamodb:8000
     env_file:

--- a/src/app/[account_id]/[repository_id]/page.tsx
+++ b/src/app/[account_id]/[repository_id]/page.tsx
@@ -28,7 +28,7 @@ interface RepositoryPageProps {
 
 export default async function RepositoryPage({ params }: RepositoryPageProps) {
   // Await params before destructuring as required by Next.js 15+
-  const { account_id, repository_id } = await Promise.resolve(params);
+  const { account_id, repository_id } = await params;
   
   try {
     const repository = await fetchRepository(account_id, repository_id);

--- a/src/app/[account_id]/organization/new/page.tsx
+++ b/src/app/[account_id]/organization/new/page.tsx
@@ -17,7 +17,7 @@ export default async function NewOrganizationPage({ params }: PageProps) {
     
     try {
       // TODO: Replace with actual organization creation
-      const response = await fetch(`${CONFIG.api.baseUrl}/accounts`, {
+      const response = await fetch(`${CONFIG.api.baseUrl}/api/accounts`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/src/app/[account_id]/organization/new/page.tsx
+++ b/src/app/[account_id]/organization/new/page.tsx
@@ -17,7 +17,7 @@ export default async function NewOrganizationPage({ params }: PageProps) {
     
     try {
       // TODO: Replace with actual organization creation
-      const response = await fetch(`${CONFIG.auth.apiBaseUrl}/accounts`, {
+      const response = await fetch(`${CONFIG.api.baseUrl}/accounts`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/src/app/api/accounts/email/[email]/route.ts
+++ b/src/app/api/accounts/email/[email]/route.ts
@@ -10,7 +10,7 @@ export async function GET(
     email = decodeURIComponent(email);
       
     // Call our database API to look up the account by email
-    const response = await fetch(`${CONFIG.auth.apiUrl}/api/accounts/email/${email}`, {
+    const response = await fetch(`${CONFIG.auth.api.backendUrl}/api/accounts/email/${email}`, {
       headers: {
         'Accept': 'application/json',
       },

--- a/src/app/api/accounts/onboarding/route.ts
+++ b/src/app/api/accounts/onboarding/route.ts
@@ -82,9 +82,9 @@ export async function POST(request: NextRequest) {
     }
     
     // Only try to update Ory identity if we have the required environment variables
-    if (CONFIG.auth.apiUrl && CONFIG.auth.accessToken) {
+    if (CONFIG.auth.api.backendUrl && CONFIG.auth.accessToken) {
       console.log('Attempting to update Ory identity:', { 
-        hasApiUrl: !!CONFIG.auth.apiUrl,
+        hasApiUrl: !!CONFIG.auth.api.backendUrl,
         hasAccessToken: !!CONFIG.auth.accessToken,
         oryId: ory_id 
       });

--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -1,13 +1,12 @@
 import { NextResponse } from 'next/server';
-import { ory } from '@/lib/ory';
+import { serverOry } from '@/lib/ory';
 import { CONFIG } from '@/lib/config';
 
 export async function POST(request: Request) {
   try {
     const data = await request.json();
-    
     // Verify the user is authenticated
-    const session = await ory.toSession();
+    const session = await serverOry.toSession();
     if (!session.data.active) {
       return NextResponse.json(
         { error: 'Unauthorized' },
@@ -34,7 +33,7 @@ export async function POST(request: Request) {
       type: 'individual' as const,
     };
 
-    const response = await fetch(`${CONFIG.auth.apiUrl}/api/accounts`, {
+    const response = await fetch(`${CONFIG.auth.api.backendUrl}/api/accounts`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/app/api/auth/logout/route.test.ts
+++ b/src/app/api/auth/logout/route.test.ts
@@ -44,7 +44,7 @@ describe('Logout API', () => {
     
     expect(data).toEqual({ success: true });
     expect(global.fetch).toHaveBeenCalledWith(
-      `${CONFIG.auth.apiUrl}/self-service/logout/browser`,
+      `${CONFIG.auth.api.frontendUrl}/self-service/logout/browser`,
       {
         method: 'POST',
         headers: {

--- a/src/app/api/auth/verification/code/route.ts
+++ b/src/app/api/auth/verification/code/route.ts
@@ -24,7 +24,7 @@ export async function POST(request: Request) {
     
     // When a code is sent during registration, Ory provides a specific endpoint
     // to verify that code without needing to create a new flow
-    const verifyResponse = await fetch(`${CONFIG.auth.apiUrl}/self-service/verification/methods/code/confirm`, {
+    const verifyResponse = await fetch(`${CONFIG.auth.api.backendUrl}/self-service/verification/methods/code/confirm`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/app/api/auth/verification/code/route.ts
+++ b/src/app/api/auth/verification/code/route.ts
@@ -24,7 +24,7 @@ export async function POST(request: Request) {
     
     // When a code is sent during registration, Ory provides a specific endpoint
     // to verify that code without needing to create a new flow
-    const verifyResponse = await fetch(`${CONFIG.auth.privateBaseUrl}/self-service/verification/methods/code/confirm`, {
+    const verifyResponse = await fetch(`${CONFIG.auth.apiUrl}/self-service/verification/methods/code/confirm`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/app/api/auth/verification/complete/route.ts
+++ b/src/app/api/auth/verification/complete/route.ts
@@ -27,7 +27,7 @@ export async function POST(request: Request) {
     }
     
     // Construct the correct endpoint with the flow ID as a query parameter
-    const completeUrl = `${CONFIG.auth.apiUrl}/self-service/verification?flow=${flow}`;
+    const completeUrl = `${CONFIG.auth.api.backendUrl}/self-service/verification?flow=${flow}`;
     
     console.log('Sending verification request to Ory:', {
       url: completeUrl,
@@ -92,7 +92,7 @@ export async function POST(request: Request) {
     // Check if we need to make an additional call to verify the identity
     try {
       const sessionResponse = await fetch(
-        `${CONFIG.auth.apiUrl}/sessions/whoami`,
+        `${CONFIG.auth.api.backendUrl}/sessions/whoami`,
         {
           headers: {
             Cookie: cookieHeader,

--- a/src/app/api/auth/verification/complete/route.ts
+++ b/src/app/api/auth/verification/complete/route.ts
@@ -27,7 +27,7 @@ export async function POST(request: Request) {
     }
     
     // Construct the correct endpoint with the flow ID as a query parameter
-    const completeUrl = `${CONFIG.auth.privateBaseUrl}/self-service/verification?flow=${flow}`;
+    const completeUrl = `${CONFIG.auth.apiUrl}/self-service/verification?flow=${flow}`;
     
     console.log('Sending verification request to Ory:', {
       url: completeUrl,
@@ -91,12 +91,15 @@ export async function POST(request: Request) {
     
     // Check if we need to make an additional call to verify the identity
     try {
-      const sessionResponse = await fetch(`${CONFIG.auth.privateBaseUrl}/sessions/whoami`, {
-        headers: {
-          Cookie: cookieHeader,
-          Accept: 'application/json',
-        },
-      });
+      const sessionResponse = await fetch(
+        `${CONFIG.auth.apiUrl}/sessions/whoami`,
+        {
+          headers: {
+            Cookie: cookieHeader,
+            Accept: "application/json",
+          },
+        }
+      );
       
       if (sessionResponse.ok) {
         const session = await sessionResponse.json();

--- a/src/app/api/auth/verification/init/route.ts
+++ b/src/app/api/auth/verification/init/route.ts
@@ -8,7 +8,7 @@ export async function GET(request: Request) {
     const cookieHeader = request.headers.get('cookie') || '';
     
     // Initialize a new verification flow
-    const response = await fetch(`${CONFIG.auth.apiUrl}/self-service/verification/flows?return_to=http://localhost:3000/onboarding`, {
+    const response = await fetch(`${CONFIG.auth.api.backendUrl}/self-service/verification/flows?return_to=http://localhost:3000/onboarding`, {
       method: 'GET',
       headers: {
         Cookie: cookieHeader,

--- a/src/app/api/auth/verification/init/route.ts
+++ b/src/app/api/auth/verification/init/route.ts
@@ -8,7 +8,7 @@ export async function GET(request: Request) {
     const cookieHeader = request.headers.get('cookie') || '';
     
     // Initialize a new verification flow
-    const response = await fetch(`${CONFIG.auth.privateBaseUrl}/self-service/verification/flows?return_to=http://localhost:3000/onboarding`, {
+    const response = await fetch(`${CONFIG.auth.apiUrl}/self-service/verification/flows?return_to=http://localhost:3000/onboarding`, {
       method: 'GET',
       headers: {
         Cookie: cookieHeader,

--- a/src/components/features/auth/LoginForm.tsx
+++ b/src/components/features/auth/LoginForm.tsx
@@ -75,16 +75,21 @@ export function LoginForm() {
         });
         throw new Error('Missing CSRF token');
       }
-      
-      await ory.updateLoginFlow({
-        flow: flow.id,
-        updateLoginFlowBody: {
-          method: 'password',
-          identifier: formData.get('identifier') as string,
-          password: formData.get('password') as string,
-          csrf_token: csrfToken,
+
+      await ory.updateLoginFlow(
+        {
+          flow: flow.id,
+          updateLoginFlowBody: {
+            method: "password",
+            identifier: formData.get("identifier") as string,
+            password: formData.get("password") as string,
+            csrf_token: csrfToken,
+          },
         },
-      });
+        {
+          withCredentials: true,
+        }
+      );
       
       // Check if login was successful and get account ID for redirect
       try {

--- a/src/components/features/onboarding/OnboardingForm.tsx
+++ b/src/components/features/onboarding/OnboardingForm.tsx
@@ -46,7 +46,7 @@ export function OnboardingForm() {
     () =>
       new FrontendApi(
         new Configuration({
-          basePath: CONFIG.auth.publicBaseUrl,
+          basePath: CONFIG.auth.apiUrl,
           baseOptions: {
             withCredentials: true,
           },

--- a/src/components/features/onboarding/OnboardingForm.tsx
+++ b/src/components/features/onboarding/OnboardingForm.tsx
@@ -46,7 +46,7 @@ export function OnboardingForm() {
     () =>
       new FrontendApi(
         new Configuration({
-          basePath: CONFIG.auth.apiUrl,
+          basePath: CONFIG.auth.api.frontendUrl,
           baseOptions: {
             withCredentials: true,
           },

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -150,7 +150,7 @@ export async function getServerSession(): Promise<ExtendedSession | null> {
     
     // Debug configuration
     console.log("Server-side Ory config:", {
-      apiUrl: CONFIG.auth.apiUrl,
+      backendApiUrl: CONFIG.auth.api.backendUrl,
       cookieHeader: cookieHeader.substring(0, 100) + "...",
     });
     
@@ -160,7 +160,7 @@ export async function getServerSession(): Promise<ExtendedSession | null> {
     console.log("Debug cookies:", {
       hasCookies: !!cookieHeader,
       cookieLength: cookieHeader.length,
-      apiUrl: CONFIG.auth.apiUrl,
+      backendApiUrl: CONFIG.auth.api.backendUrl,
       cookieNames,
       cookieHeader: cookieHeader.substring(0, 100) + "...",
     });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -83,7 +83,7 @@ function getApiBaseUrl() {
     return '';
   } else {
     // In server context, we need absolute URLs
-    return CONFIG.auth.apiBaseUrl;
+    return CONFIG.api.baseUrl;
   }
 }
 
@@ -149,20 +149,20 @@ export async function getServerSession(): Promise<ExtendedSession | null> {
     const cookieHeader = cookieStore.toString();
     
     // Debug configuration
-    console.log('Server-side Ory config:', {
-      privateBaseUrl: CONFIG.auth.privateBaseUrl,
-      cookieHeader: cookieHeader.substring(0, 100) + '...'
+    console.log("Server-side Ory config:", {
+      apiUrl: CONFIG.auth.apiUrl,
+      cookieHeader: cookieHeader.substring(0, 100) + "...",
     });
     
     // Debug cookie details
     const cookieList = cookieStore.getAll();
     const cookieNames = cookieList.map(c => c.name);
-    console.log('Debug cookies:', {
+    console.log("Debug cookies:", {
       hasCookies: !!cookieHeader,
       cookieLength: cookieHeader.length,
-      privateBaseUrl: CONFIG.auth.privateBaseUrl,
+      apiUrl: CONFIG.auth.apiUrl,
       cookieNames,
-      cookieHeader: cookieHeader.substring(0, 100) + '...'
+      cookieHeader: cookieHeader.substring(0, 100) + "...",
     });
     
     try {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,42 +1,35 @@
 import type { StorageConfig } from '@/types/storage';
 
-// Helper to ensure we don't get undefined values
-const getEnvVar = (key: string, defaultValue: string): string => {
-  return process.env[key] || defaultValue;
-};
-
 export const CONFIG = {
+  api: {
+    baseUrl: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000',
+  },
   storage: {
-    type: getEnvVar('STORAGE_TYPE', 'LOCAL'),
-    endpoint: getEnvVar('STORAGE_ENDPOINT', './test-storage'),
-    region: getEnvVar('AWS_REGION', 'us-east-1'),
+    type: process.env.STORAGE_TYPE || 'LOCAL',
+    endpoint: process.env.STORAGE_ENDPOINT || './test-storage',
+    region: process.env.AWS_REGION || 'us-east-1',
     credentials: {
-      access_key_id: getEnvVar('AWS_ACCESS_KEY_ID', ''),
-      secret_access_key: getEnvVar('AWS_SECRET_ACCESS_KEY', ''),
+      access_key_id: process.env.AWS_ACCESS_KEY_ID || '',
+      secret_access_key: process.env.AWS_SECRET_ACCESS_KEY || '',
     },
   } as StorageConfig,
   database: {
-    endpoint: getEnvVar('DYNAMODB_ENDPOINT', 'http://localhost:8000'),
-    region: getEnvVar('AWS_REGION', 'us-east-1'),
-    accessKeyId: getEnvVar('DYNAMODB_ACCESS_KEY_ID', 'local'),
-    secretAccessKey: getEnvVar('DYNAMODB_SECRET_ACCESS_KEY', 'local'),
+    endpoint: process.env.DYNAMODB_ENDPOINT || 'http://localhost:8000',
+    region: process.env.AWS_REGION || 'us-east-1',
+    accessKeyId: process.env.DYNAMODB_ACCESS_KEY_ID || 'local',
+    secretAccessKey: process.env.DYNAMODB_SECRET_ACCESS_KEY || 'local',
   },
   auth: {
-    // Public URLs for client-side
-    publicBaseUrl: getEnvVar('NEXT_PUBLIC_ORY_BASE_URL', 'http://localhost:4000'),
-    // Private URLs for server-side
-    privateBaseUrl: getEnvVar('ORY_BASE_URL', 'http://localhost:4000'),
     // Admin configuration
-    projectId: getEnvVar('ORY_PROJECT_ID', ''),
-    projectSlug: getEnvVar('ORY_PROJECT_SLUG', ''),
-    apiUrl: getEnvVar('ORY_API_URL', ''),
-    workspaceId: getEnvVar('ORY_WORKSPACE_ID', ''),
-    accessToken: getEnvVar('ORY_PROJECT_API_KEY', ''),
-    // API configuration
-    apiBaseUrl: getEnvVar('NEXT_PUBLIC_API_URL', 'http://localhost:3000'),
+    apiUrl: process.env.NEXT_PUBLIC_ORY_BASE_URL || '',
+    internalApiUrl: process.env.ORY_BASE_URL || process.env.NEXT_PUBLIC_ORY_BASE_URL || '',
+    accessToken: process.env.ORY_PROJECT_API_KEY || '',
+    projectId: process.env.ORY_PROJECT_ID || '',
+    projectSlug: process.env.ORY_PROJECT_SLUG || '',
+    workspaceId: process.env.ORY_WORKSPACE_ID || '',
   },
   google: {
-    siteVerification: getEnvVar('NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION', ''),
+    siteVerification: process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION || '',
   },
   environment: {
     isDevelopment: process.env.NODE_ENV === 'development',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -21,8 +21,10 @@ export const CONFIG = {
   },
   auth: {
     // Admin configuration
-    apiUrl: process.env.NEXT_PUBLIC_ORY_BASE_URL || '',
-    internalApiUrl: process.env.ORY_BASE_URL || process.env.NEXT_PUBLIC_ORY_BASE_URL || '',
+    api: {
+      frontendUrl: process.env.NEXT_PUBLIC_ORY_BASE_URL || '',
+      backendUrl: process.env.ORY_BASE_URL || '',
+    },
     accessToken: process.env.ORY_PROJECT_API_KEY || '',
     projectId: process.env.ORY_PROJECT_ID || '',
     projectSlug: process.env.ORY_PROJECT_SLUG || '',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -41,13 +41,20 @@ export const CONFIG = {
 // Add debug logging
 console.log('Loaded CONFIG:', {
   ...CONFIG,
+  database: {
+    ...CONFIG.database,
+    accessKeyId: CONFIG.database.accessKeyId ? '[REDACTED]' : undefined,
+    secretAccessKey: CONFIG.database.secretAccessKey ? '[REDACTED]' : undefined,
+  },
   auth: {
     ...CONFIG.auth,
     accessToken: CONFIG.auth.accessToken ? '[REDACTED]' : undefined,
   },
   storage: {
     ...CONFIG.storage,
-    accessKeyId: CONFIG.storage.credentials?.access_key_id ? '[REDACTED]' : undefined,
-    secretAccessKey: CONFIG.storage.credentials?.secret_access_key ? '[REDACTED]' : undefined,
+    credentials: {
+      access_key_id: CONFIG.storage.credentials?.access_key_id ? '[REDACTED]' : undefined,
+      secret_access_key: CONFIG.storage.credentials?.secret_access_key ? '[REDACTED]' : undefined,
+    },
   },
 });

--- a/src/lib/ory.ts
+++ b/src/lib/ory.ts
@@ -20,17 +20,17 @@ export type ExtendedSession = Session & {
 // Create a new Ory SDK instance for client-side use
 export const ory = new FrontendApi(
   new Configuration({
-    basePath: CONFIG.auth.publicBaseUrl,
+    basePath: CONFIG.auth.apiUrl,
     baseOptions: {
       withCredentials: true,
       headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json',
+        Accept: "application/json",
+        "Content-Type": "application/json",
       },
       validateStatus: () => {
         // Accept any status code to handle redirects
         return true;
-      }
+      },
     },
   })
 );
@@ -38,7 +38,7 @@ export const ory = new FrontendApi(
 // Create a server-side instance of the Ory SDK
 export const serverOry = new FrontendApi(
   new Configuration({
-    basePath: CONFIG.auth.privateBaseUrl,
+    basePath: CONFIG.auth.apiUrl,
     baseOptions: {
       withCredentials: true,
       headers: {
@@ -77,7 +77,7 @@ export async function getAccountId(): Promise<string | null> {
 
 // Helper to update Ory identity (admin operation)
 export async function updateOryIdentity(oryId: string, data: any) {
-  if (!CONFIG.auth.privateBaseUrl) {
+  if (!CONFIG.auth.apiUrl) {
     throw new Error('No Ory private base URL configured');
   }
 
@@ -87,7 +87,7 @@ export async function updateOryIdentity(oryId: string, data: any) {
 
   // First, get the current identity to understand its structure
   const getResponse = await fetch(
-    `${CONFIG.auth.privateBaseUrl}/admin/identities/${oryId}`,
+    `${CONFIG.auth.apiUrl}/admin/identities/${oryId}`,
     {
       method: 'GET',
       headers: {
@@ -104,7 +104,7 @@ export async function updateOryIdentity(oryId: string, data: any) {
       statusText: getResponse.statusText,
       error: errorText,
       url: getResponse.url,
-      baseUrl: CONFIG.auth.privateBaseUrl,
+      baseUrl: CONFIG.auth.apiUrl,
       hasAccessToken: !!CONFIG.auth.accessToken
     });
     throw new Error(errorText);
@@ -127,7 +127,7 @@ export async function updateOryIdentity(oryId: string, data: any) {
 
   // Now update with the properly structured data
   const response = await fetch(
-    `${CONFIG.auth.privateBaseUrl}/admin/identities/${oryId}`,
+    `${CONFIG.auth.apiUrl}/admin/identities/${oryId}`,
     {
       method: 'PUT',
       headers: {
@@ -146,7 +146,7 @@ export async function updateOryIdentity(oryId: string, data: any) {
       statusText: response.statusText,
       error: errorText,
       url: response.url,
-      baseUrl: CONFIG.auth.privateBaseUrl,
+      baseUrl: CONFIG.auth.apiUrl,
       hasAccessToken: !!CONFIG.auth.accessToken
     });
     throw new Error(errorText);

--- a/src/lib/ory.ts
+++ b/src/lib/ory.ts
@@ -20,7 +20,7 @@ export type ExtendedSession = Session & {
 // Create a new Ory SDK instance for client-side use
 export const ory = new FrontendApi(
   new Configuration({
-    basePath: CONFIG.auth.apiUrl,
+    basePath: CONFIG.auth.api.frontendUrl,
     baseOptions: {
       withCredentials: true,
       headers: {
@@ -38,7 +38,7 @@ export const ory = new FrontendApi(
 // Create a server-side instance of the Ory SDK
 export const serverOry = new FrontendApi(
   new Configuration({
-    basePath: CONFIG.auth.apiUrl,
+    basePath: CONFIG.auth.api.backendUrl,
     baseOptions: {
       withCredentials: true,
       headers: {
@@ -77,7 +77,7 @@ export async function getAccountId(): Promise<string | null> {
 
 // Helper to update Ory identity (admin operation)
 export async function updateOryIdentity(oryId: string, data: any) {
-  if (!CONFIG.auth.apiUrl) {
+  if (!CONFIG.auth.api.backendUrl) {
     throw new Error('No Ory private base URL configured');
   }
 
@@ -87,7 +87,7 @@ export async function updateOryIdentity(oryId: string, data: any) {
 
   // First, get the current identity to understand its structure
   const getResponse = await fetch(
-    `${CONFIG.auth.apiUrl}/admin/identities/${oryId}`,
+    `${CONFIG.auth.api.backendUrl}/admin/identities/${oryId}`,
     {
       method: 'GET',
       headers: {
@@ -104,7 +104,7 @@ export async function updateOryIdentity(oryId: string, data: any) {
       statusText: getResponse.statusText,
       error: errorText,
       url: getResponse.url,
-      baseUrl: CONFIG.auth.apiUrl,
+      baseUrl: CONFIG.auth.api.backendUrl,
       hasAccessToken: !!CONFIG.auth.accessToken
     });
     throw new Error(errorText);
@@ -127,7 +127,7 @@ export async function updateOryIdentity(oryId: string, data: any) {
 
   // Now update with the properly structured data
   const response = await fetch(
-    `${CONFIG.auth.apiUrl}/admin/identities/${oryId}`,
+    `${CONFIG.auth.api.backendUrl}/admin/identities/${oryId}`,
     {
       method: 'PUT',
       headers: {
@@ -146,7 +146,7 @@ export async function updateOryIdentity(oryId: string, data: any) {
       statusText: response.statusText,
       error: errorText,
       url: response.url,
-      baseUrl: CONFIG.auth.apiUrl,
+      baseUrl: CONFIG.auth.api.backendUrl,
       hasAccessToken: !!CONFIG.auth.accessToken
     });
     throw new Error(errorText);


### PR DESCRIPTION
## What I'm changing

Attempt to simplify and clarify auth URLs.

## How I did it

* `CONFIG.auth.apiBaseUrl` -> `CONFIG.api.baseUrl`
* `CONFIG.auth.privateBaseUrl` -> `CONFIG.auth.api.backendUrl`
* `CONFIG.auth.apiUrl` -> `CONFIG.auth.api.backendUrl` (duplicate of above)
* `CONFIG.auth.publicBaseUrl` -> `CONFIG.auth.api.frontendUrl`

There also seemed to be a big where Vercel would not pick up public environment variables within the client.

ie.

```js
// ❌ THIS DOES NOT WORK
let key = 'NEXT_PUBLIC_ORY_BASE_URL';
let val = process.env[key];

// ✅ This does work!
let val = process.env.NEXT_PUBLIC_ORY_BASE_URL;
```