### PR TITLE
s2 - fix form

### DIFF
--- a/deploy/lib/database-construct.ts
+++ b/deploy/lib/database-construct.ts
@@ -46,7 +46,7 @@ export class DatabaseConstruct extends Construct {
         },
         {
           name: "identity_id",
-          partitionKey: "metadata_private.identity_id",
+          partitionKey: "identity_id",
         },
       ],
       removalPolicy,

--- a/deploy/lib/database-construct.ts
+++ b/deploy/lib/database-construct.ts
@@ -41,10 +41,13 @@ export class DatabaseConstruct extends Construct {
       partitionKey: "account_id",
       indexes: [
         {
+          // fetch all accounts of a given type
           name: "account_type",
           partitionKey: "type",
+          sortKey: "account_id",
         },
         {
+          // fetch an account by Ory identity_id
           name: "identity_id",
           partitionKey: "identity_id",
         },
@@ -58,6 +61,7 @@ export class DatabaseConstruct extends Construct {
       partitionKey: "access_key_id",
       indexes: [
         {
+          // fetch all API keys for a given account
           name: "account_id",
           partitionKey: "account_id",
         },
@@ -78,14 +82,12 @@ export class DatabaseConstruct extends Construct {
       partitionKey: "membership_id",
       indexes: [
         {
+          // fetch all memberships for a given account
           name: "account_id",
           partitionKey: "account_id",
         },
         {
-          name: "membership_account_id",
-          partitionKey: "membership_account_id",
-        },
-        {
+          // fetch all memberships for a given account and repository
           name: "membership_account_id_repository_id",
           partitionKey: "membership_account_id",
           sortKey: "repository_id",
@@ -101,11 +103,7 @@ export class DatabaseConstruct extends Construct {
       sortKey: "product_id",
       indexes: [
         {
-          name: "account_products",
-          partitionKey: "account_id",
-          sortKey: "product_id",
-        },
-        {
+          // fetch all public products
           name: "public_featured",
           partitionKey: "visibility",
           sortKey: {

--- a/scripts/migrate-simple.ts
+++ b/scripts/migrate-simple.ts
@@ -168,9 +168,8 @@ function convertAccountToNewSchema(oldAccount: any) {
     disabled: oldAccount.disabled || false,
     flags,
     metadata_public,
-    metadata_private: {
-      identity_id: oldAccount.identity_id,
-    },
+    metadata_private: {},
+    identity_id: oldAccount.identity_id,
   };
 
   // Clean any undefined values before returning
@@ -444,14 +443,27 @@ function parseDynamoDBItem(item: any): any {
       result[key] = value.BOOL;
     } else if (value && typeof value === "object" && "M" in value) {
       result[key] = parseDynamoDBItem(value.M);
-    } else if (value && typeof value === "object" && "L" in value && Array.isArray(value.L)) {
-      result[key] = value.L.map(item => 
-        item && typeof item === "object" && "S" in item ? item.S :
-        item && typeof item === "object" && "N" in item ? item.N :
-        item && typeof item === "object" && "BOOL" in item ? item.BOOL :
-        item
+    } else if (
+      value &&
+      typeof value === "object" &&
+      "L" in value &&
+      Array.isArray(value.L)
+    ) {
+      result[key] = value.L.map((item) =>
+        item && typeof item === "object" && "S" in item
+          ? item.S
+          : item && typeof item === "object" && "N" in item
+          ? item.N
+          : item && typeof item === "object" && "BOOL" in item
+          ? item.BOOL
+          : item
       );
-    } else if (value && typeof value === "object" && "NULL" in value && value.NULL === true) {
+    } else if (
+      value &&
+      typeof value === "object" &&
+      "NULL" in value &&
+      value.NULL === true
+    ) {
       result[key] = null;
     } else {
       result[key] = value;

--- a/src/app/api/accounts/[account_id]/route.ts
+++ b/src/app/api/accounts/[account_id]/route.ts
@@ -110,7 +110,6 @@ export async function PUT(
 ) {
   try {
     const session = await getApiSession(request);
-    console.log("api session", session);
     if (!session) {
       return NextResponse.json(
         {
@@ -123,12 +122,6 @@ export async function PUT(
         { status: 401 }
       );
     }
-
-    const { account_id } = await params;
-    console.log("API: Updating account:", account_id);
-
-    // Only allow the user to update their own account
-    const sessionAccountId = session?.account?.account_id;
 
     if (session.account?.disabled) {
       return NextResponse.json(
@@ -143,6 +136,9 @@ export async function PUT(
       );
     }
 
+    const { account_id } = await params;
+
+    const sessionAccountId = session?.account?.account_id;
     if (!sessionAccountId) {
       return NextResponse.json(
         {
@@ -180,17 +176,10 @@ export async function PUT(
     }
 
     const account = {
-      metadata_private: {}, // TODO: not getting metadata_private from ory, why?
       ...(await request.json()),
+      account_id,
+      identity_id: session.identity_id,
     };
-
-    // Verify the account_id matches the URL parameter
-    if (account.account_id !== account_id) {
-      return NextResponse.json(
-        { error: "Account ID mismatch" },
-        { status: 400 }
-      );
-    }
 
     // Update the account in DynamoDB
     try {

--- a/src/app/api/accounts/[account_id]/route.ts
+++ b/src/app/api/accounts/[account_id]/route.ts
@@ -110,6 +110,7 @@ export async function PUT(
 ) {
   try {
     const session = await getApiSession(request);
+    console.log("api session", session);
     if (!session) {
       return NextResponse.json(
         {
@@ -128,7 +129,6 @@ export async function PUT(
 
     // Only allow the user to update their own account
     const sessionAccountId = session?.account?.account_id;
-    console.log(session);
 
     if (session.account?.disabled) {
       return NextResponse.json(

--- a/src/app/api/accounts/onboarding/route.ts
+++ b/src/app/api/accounts/onboarding/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from "next/server";
 import type { IndividualAccount } from "@/types/account_v2";
 import { updateOryIdentity } from "@/lib/ory";
 import { accountsTable } from "@/lib/clients/database";
@@ -62,9 +62,8 @@ export async function POST(request: NextRequest) {
       metadata_public: {
         domains: [],
       },
-      metadata_private: {
-        identity_id: ory_id,
-      },
+      metadata_private: {},
+      identity_id: ory_id,
     };
 
     console.log("Attempting to create account in DynamoDB:", newAccount);
@@ -163,4 +162,4 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
-} 
+}

--- a/src/app/api/accounts/onboarding/route.ts
+++ b/src/app/api/accounts/onboarding/route.ts
@@ -101,10 +101,10 @@ export async function POST(request: NextRequest) {
 
         // If Ory update fails, delete the account from DynamoDB
         try {
-          await accountsTable.delete({
-            account_id,
-            type: AccountType.INDIVIDUAL,
-          });
+                          await accountsTable.delete({
+          account_id,
+          type: AccountType.INDIVIDUAL,
+        });
           console.log("Cleaned up DynamoDB account after Ory update failure");
         } catch (cleanupError) {
           console.error("Failed to clean up DynamoDB account:", cleanupError);

--- a/src/app/api/v1/accounts/[account_id]/profile/route.ts
+++ b/src/app/api/v1/accounts/[account_id]/profile/route.ts
@@ -54,9 +54,7 @@ export async function GET(
         { status: StatusCodes.UNAUTHORIZED }
       );
     }
-    const email = account.metadata_private?.identity_id
-      ? await getEmail(account.metadata_private.identity_id)
-      : null;
+    const email = await getEmail(account.identity_id);
     const profile: AccountProfileResponse = {
       ...account.metadata_public,
       profile_image: email ? getProfileImage(email) : undefined,

--- a/src/app/api/v1/accounts/route.ts
+++ b/src/app/api/v1/accounts/route.ts
@@ -62,12 +62,8 @@ export async function POST(request: NextRequest) {
       updated_at: new Date().toISOString(),
       disabled: false,
       flags,
-      metadata_private:
-        accountRequest.type === AccountType.INDIVIDUAL
-          ? {
-              identity_id: session?.identity_id ?? "",
-            }
-          : undefined,
+      metadata_private: {},
+      identity_id: session!.identity_id!,
     };
     if (!isAuthorized(session, newAccount, Actions.CreateAccount)) {
       return NextResponse.json(

--- a/src/lib/api/utils.mock.ts
+++ b/src/lib/api/utils.mock.ts
@@ -91,7 +91,7 @@ for (const account of accounts) {
 
   sessions[account.account_id] = {
     account: account,
-    identity_id: account.metadata_private?.identity_id,
+    identity_id: account.identity_id,
     memberships: accountMemberships,
   };
 }

--- a/src/lib/api/utils.ts
+++ b/src/lib/api/utils.ts
@@ -208,8 +208,8 @@ export async function getApiSession(
     return null;
   }
   console.log("ory session", session);
-  const identityId = session.identity?.id;
-  if (!identityId) {
+  const oryId = session.identity?.id;
+  if (!oryId) {
     logger.warn("No identity ID found in session", {
       operation: "getApiSession",
       context: "session",
@@ -218,37 +218,11 @@ export async function getApiSession(
   }
 
   // Fetch account information for the user
-  const account = await accountsTable.fetchById(identityId);
+  const account = await accountsTable.fetchByOryId(oryId);
 
   if (!account || account.disabled) {
-    return { identity_id: identityId };
+    return { identity_id: oryId };
   }
-
-  // // Transform the database account to the expected format
-  // const account = {
-  //   account_id: dbAccount.account_id,
-  //   disabled: dbAccount.disabled,
-  //   account_type:
-  //     dbAccount.type === "individual"
-  //       ? AccountType.INDIVIDUAL
-  //       : AccountType.ORGANIZATION,
-  //   profile: {
-  //     name: dbAccount.name,
-  //     bio: dbAccount.metadata_public.bio,
-  //     location: dbAccount.metadata_public.location,
-  //   },
-  //   flags: dbAccount.flags
-  //     .map(
-  //       (flag) =>
-  //         ({
-  //           admin: AccountFlags.ADMIN,
-  //           create_repositories: AccountFlags.CREATE_REPOSITORIES,
-  //           create_organizations: AccountFlags.CREATE_ORGANIZATIONS,
-  //         }[flag])
-  //     )
-  //     .filter((flag) => flag !== undefined),
-  //   identity_id: identityId,
-  // };
 
   // Retrieve and filter memberships for the user
   const memberships = await membershipsTable.listByUser(account.account_id);
@@ -258,7 +232,7 @@ export async function getApiSession(
 
   // Return the user session
   return {
-    identity_id: identityId,
+    identity_id: oryId,
     account,
     memberships: filteredMemberships,
   };

--- a/src/lib/api/utils.ts
+++ b/src/lib/api/utils.ts
@@ -207,6 +207,7 @@ export async function getApiSession(
   if (!session) {
     return null;
   }
+  console.log("ory session", session);
   const identityId = session.identity?.id;
   if (!identityId) {
     logger.warn("No identity ID found in session", {

--- a/src/lib/clients/database/accounts.ts
+++ b/src/lib/clients/database/accounts.ts
@@ -48,6 +48,34 @@ class AccountsTable extends BaseTable {
     }
   }
 
+  async fetchByOryId(identity_id: string): Promise<Account | null> {
+    try {
+      console.log(`DB: Trying to fetch account by Ory ID:`, identity_id);
+      const result = await this.client.send(
+        new QueryCommand({
+          TableName: this.table,
+          IndexName: "identity_id",
+          KeyConditionExpression: "metadata_private.identity_id = :identity_id",
+          ExpressionAttributeValues: {
+            ":identity_id": identity_id,
+          },
+        })
+      );
+
+      if (result.Items && result.Items.length > 0) {
+        console.log(`DB: Found account by Ory ID:`, identity_id);
+        return result.Items[0] as Account;
+      }
+
+      return null;
+    } catch (error) {
+      if (error instanceof ResourceNotFoundException) return null;
+
+      this.logError("fetchByOryId", error, { identity_id });
+      throw error;
+    }
+  }
+
   async create(account: Account): Promise<Account> {
     await this.client.send(
       new PutCommand({

--- a/src/lib/clients/database/accounts.ts
+++ b/src/lib/clients/database/accounts.ts
@@ -55,7 +55,7 @@ class AccountsTable extends BaseTable {
         new QueryCommand({
           TableName: this.table,
           IndexName: "identity_id",
-          KeyConditionExpression: "metadata_private.identity_id = :identity_id",
+          KeyConditionExpression: "identity_id = :identity_id",
           ExpressionAttributeValues: {
             ":identity_id": identity_id,
           },
@@ -96,7 +96,7 @@ class AccountsTable extends BaseTable {
           type: account.type,
         },
         UpdateExpression:
-          "SET #name = :name, emails = :emails, updated_at = :updated_at, disabled = :disabled, flags = :flags, metadata_public = :metadata_public, metadata_private = :metadata_private",
+          "SET #name = :name, emails = :emails, updated_at = :updated_at, disabled = :disabled, flags = :flags, metadata_public = :metadata_public, metadata_private = :metadata_private, identity_id = :identity_id",
         ExpressionAttributeNames: {
           "#name": "name", // name is a reserved word in DynamoDB
         },
@@ -108,6 +108,8 @@ class AccountsTable extends BaseTable {
           ":flags": account.flags,
           ":metadata_public": account.metadata_public,
           ":metadata_private": account.metadata_private,
+          ":identity_id":
+            account.identity_id || account.metadata_private?.identity_id,
         },
         ReturnValues: "ALL_NEW",
       })

--- a/src/lib/clients/database/memberships.ts
+++ b/src/lib/clients/database/memberships.ts
@@ -58,31 +58,26 @@ export class MembershipsTable extends BaseTable {
     repositoryId?: string
   ): Promise<Membership[]> {
     try {
-      let command: QueryCommand;
-
-      if (repositoryId) {
-        command = new QueryCommand({
-          TableName: this.table,
-          IndexName: "membership_account_id_repository_id",
-          KeyConditionExpression:
-            "membership_account_id = :membership_account_id AND repository_id = :repository_id",
-          ExpressionAttributeValues: {
-            ":membership_account_id": membershipAccountId,
-            ":repository_id": repositoryId,
-          },
-        });
-      } else {
-        command = new QueryCommand({
-          TableName: this.table,
-          IndexName: "membership_account_id",
-          KeyConditionExpression:
-            "membership_account_id = :membership_account_id",
-          ExpressionAttributeValues: {
-            ":membership_account_id": membershipAccountId,
-          },
-        });
-      }
-
+      const command = new QueryCommand({
+        TableName: this.table,
+        IndexName: "membership_account_id_repository_id",
+        ...(repositoryId
+          ? {
+              KeyConditionExpression:
+                "membership_account_id = :membership_account_id AND repository_id = :repository_id",
+              ExpressionAttributeValues: {
+                ":membership_account_id": membershipAccountId,
+                ":repository_id": repositoryId,
+              },
+            }
+          : {
+              KeyConditionExpression:
+                "membership_account_id = :membership_account_id",
+              ExpressionAttributeValues: {
+                ":membership_account_id": membershipAccountId,
+              },
+            }),
+      });
       const result = await this.client.send(command);
       return result.Items?.map((item) => item as Membership) ?? [];
     } catch (error) {

--- a/src/lib/clients/database/products.ts
+++ b/src/lib/clients/database/products.ts
@@ -51,21 +51,17 @@ class ProductsTable extends BaseTable {
     products: Product[];
     lastEvaluatedKey: any;
   }> {
-    const queryParams: any = {
-      TableName: this.table,
-      IndexName: "account_products",
-      KeyConditionExpression: "account_id = :account_id",
-      ExpressionAttributeValues: {
-        ":account_id": account_id,
-      },
-      Limit: limit,
-    };
-
-    if (lastEvaluatedKey) {
-      queryParams.ExclusiveStartKey = lastEvaluatedKey;
-    }
-
-    const result = await this.client.send(new QueryCommand(queryParams));
+    const result = await this.client.send(
+      new QueryCommand({
+        TableName: this.table,
+        KeyConditionExpression: "account_id = :account_id",
+        ExpressionAttributeValues: {
+          ":account_id": account_id,
+        },
+        Limit: limit,
+        ExclusiveStartKey: lastEvaluatedKey,
+      })
+    );
 
     return {
       products: (result.Items || []) as Product[],

--- a/src/mock/accounts.json
+++ b/src/mock/accounts.json
@@ -20,9 +20,8 @@
       "bio": "This is an admin user account",
       "location": "United States"
     },
-    "metadata_private": {
-      "identity_id": "admin_identity_id"
-    }
+    "metadata_private": {},
+    "identity_id": "admin_identity_id"
   },
   {
     "account_id": "disabled",
@@ -45,9 +44,8 @@
       "bio": "This is a disabled user account",
       "location": "United States"
     },
-    "metadata_private": {
-      "identity_id": "disabled_identity_id"
-    }
+    "metadata_private": {},
+    "identity_id": "disabled_identity_id"
   },
   {
     "account_id": "regular-user",
@@ -70,9 +68,8 @@
       "bio": "This is a regular user account",
       "location": "United States"
     },
-    "metadata_private": {
-      "identity_id": "regular_user_identity_id"
-    }
+    "metadata_private": {},
+    "identity_id": "regular_user_identity_id"
   },
   {
     "account_id": "create-repositories-user",
@@ -95,9 +92,8 @@
       "bio": "This is a user account which has the create_repositories flag",
       "location": "United States"
     },
-    "metadata_private": {
-      "identity_id": "create_repositories_user_identity_id"
-    }
+    "metadata_private": {},
+    "identity_id": "create_repositories_user_identity_id"
   },
   {
     "account_id": "organization-owner-user",
@@ -120,9 +116,7 @@
       "bio": "This is a user account which owns an organization",
       "location": "United States"
     },
-    "metadata_private": {
-      "identity_id": "organization_owner_user_identity_id"
-    }
+    "metadata_private": {}
   },
   {
     "account_id": "organization-maintainer-user",
@@ -145,9 +139,7 @@
       "bio": "This is a user account which maintains an organization",
       "location": "United States"
     },
-    "metadata_private": {
-      "identity_id": "organization_maintainer_user_identity_id"
-    }
+    "metadata_private": {}
   },
   {
     "account_id": "organization-read-data-user",
@@ -170,9 +162,7 @@
       "bio": "This is a user account which is a ReadData member of an organization",
       "location": "United States"
     },
-    "metadata_private": {
-      "identity_id": "organization_read_data_user_identity_id"
-    }
+    "metadata_private": {}
   },
   {
     "account_id": "repo-member-owner",
@@ -195,9 +185,7 @@
       "bio": "This is a user account which is an owner of a repository",
       "location": "United States"
     },
-    "metadata_private": {
-      "identity_id": "repo_member_owner_identity_id"
-    }
+    "metadata_private": {}
   },
   {
     "account_id": "repo-member-maintainer",
@@ -220,9 +208,7 @@
       "bio": "This is a user account which is a maintainer of a repository",
       "location": "United States"
     },
-    "metadata_private": {
-      "identity_id": "repo_member_maintainer_identity_id"
-    }
+    "metadata_private": {}
   },
   {
     "account_id": "repo-member-read-data",
@@ -245,9 +231,7 @@
       "bio": "This is a user account which is a read data member of a repository",
       "location": "United States"
     },
-    "metadata_private": {
-      "identity_id": "repo_member_read_data_identity_id"
-    }
+    "metadata_private": {}
   },
   {
     "account_id": "repo-member-write-data",
@@ -270,9 +254,7 @@
       "bio": "This is a user account which is a write data member of a repository",
       "location": "United States"
     },
-    "metadata_private": {
-      "identity_id": "repo_member_write_data_identity_id"
-    }
+    "metadata_private": {}
   },
   {
     "account_id": "repo-member-invited",
@@ -294,9 +276,7 @@
       "bio": "This is a user account which is an invited member of a repository",
       "location": "United States"
     },
-    "metadata_private": {
-      "identity_id": "repo_member_invited_identity_id"
-    }
+    "metadata_private": {}
   },
   {
     "account_id": "organization-write-data-user",
@@ -319,9 +299,7 @@
       "bio": "This is a user account which is a WriteData member of an organization",
       "location": "United States"
     },
-    "metadata_private": {
-      "identity_id": "organization_write_data_user_identity_id"
-    }
+    "metadata_private": {}
   },
   {
     "account_id": "organization",

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -110,6 +110,7 @@ export const AccountSchema = z
         identity_id: z.string().openapi({ example: "identity-id" }),
       })
     ),
+    identity_id: z.string().openapi({ example: "identity-id" }),
   })
   .openapi("Account");
 

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -105,11 +105,7 @@ export const AccountSchema = z
     disabled: z.boolean(),
     flags: AccountFlagsSchema,
     metadata_public: AccountProfileSchema,
-    metadata_private: z.optional(
-      z.object({
-        identity_id: z.string().openapi({ example: "identity-id" }),
-      })
-    ),
+    metadata_private: z.optional(z.record(z.object({}))),
     identity_id: z.string().openapi({ example: "identity-id" }),
   })
   .openapi("Account");

--- a/src/types/account_v2.ts
+++ b/src/types/account_v2.ts
@@ -30,7 +30,7 @@ interface BaseAccount {
     bio?: string;
     domains?: AccountDomain[];
   };
-  metadata_private: {};
+  metadata_private: { [key: string]: any };
   identity_id: string;
 }
 

--- a/src/types/account_v2.ts
+++ b/src/types/account_v2.ts
@@ -30,9 +30,8 @@ interface BaseAccount {
     bio?: string;
     domains?: AccountDomain[];
   };
-  metadata_private: {
-    identity_id: string;
-  };
+  metadata_private: {};
+  identity_id: string;
 }
 
 // Interface for individual accounts


### PR DESCRIPTION
Big change: we can't look up accounts by ory identity ID if the `identity_id` is stored in the `accounts` table within a `metadata_private` attribute. As such, we need to move it to a top-level  attribute so that we can index the value.

/cc @jedsundwall 