### PR TITLE
Hyparquet iframe

### DIFF
--- a/src/components/features/products/ObjectBrowser.tsx
+++ b/src/components/features/products/ObjectBrowser.tsx
@@ -65,7 +65,7 @@ export async function ObjectBrowser({
           cloudUri={cloudUri}
         />
 
-        {cloudUri?.endsWith(".pmtiles") && (
+        {cloudUri?.endsWith(".pmtiles") ? (
           <Card style={{ marginTop: "2rem" }}>
             <SectionHeader title="Preview" />
             <iframe
@@ -77,7 +77,19 @@ export async function ObjectBrowser({
               Your browser does not support iframes.
             </iframe>
           </Card>
-        )}
+        ) : cloudUri?.endsWith(".parquet") ? (
+          <Card style={{ marginTop: "2rem" }}>
+            <SectionHeader title="Preview" />
+            <iframe
+              frameBorder="0"
+              width="100%"
+              height="600px"
+              src={`https://hyparam.github.io/demos/hyparquet/?key=${sourceUrl}`}
+            >
+              Your browser does not support iframes.
+            </iframe>
+          </Card>
+        ) : null}
       </>
     );
   }


### PR DESCRIPTION
A very quick test, to show that we can preview a parquet file in an iframe, using the hyparquet demo (hosted on github pages). I'm not sure it's what we want in source.coop: do we want to show external tools, or source.coop's own version of the viewer?

Also: the geometry column is not properly decoded, see https://github.com/hyparam/demos/issues/34 (I'll propose a fix for the hyparquet demo)

The branch is based on @bdon's one: see https://github.com/source-cooperative/source.coop/pull/125.

https://github.com/user-attachments/assets/798c9409-c556-4a08-bd82-aadbd4df3dfd


**Related Issue(s):** #


**Proposed Changes:**

1.
2.

**PR Checklist:**

- [ ] This PR is made against the dev branch (all proposed changes except releases should be against dev, not main).
- [ ] This PR has **no** breaking changes.
- [ ] I have updated or added new tests to cover the changes in this PR.
- [ ] I have updated the version in `package.json` to follow the [Semantic Versioning](https://semver.org/) guidelines.
- [ ] All tests are passing.
- [ ] I have added my changes to the [CHANGELOG](https://github.com/source-cooperative/source.coop/blob/dev/CHANGELOG.rst)
      **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [Source Cooperative Data Proxy](https://github.com/source-cooperative/data.source.coop),
      and I have opened issue/PR #XXX to track the change.
