### PR TITLE
Revert "Display error when we fail to list S3 object"

### DIFF
--- a/src/app/[account_id]/[product_id]/[[...path]]/page.tsx
+++ b/src/app/[account_id]/[product_id]/[[...path]]/page.tsx
@@ -8,60 +8,6 @@ import { dataConnectionsTable, productsTable } from "@/lib/clients/database";
 import { storage } from "@/lib/clients/storage";
 import { DataConnection, ProductMirror } from "@/types";
 import { LOGGER } from "@/lib";
-import { MonoText } from "@/components/core";
-
-function StorageErrorDisplay({ error }: { error: Error }) {
-  const getErrorMessage = (error: Error) => {
-    if (!error) return "Unknown error";
-
-    // Handle AWS SDK errors
-    if (error.name === "NoSuchBucket") {
-      return "The storage bucket does not exist.";
-    }
-    if (error.name === "AccessDenied") {
-      return "Access denied to the storage bucket.";
-    }
-    if (error.name === "InvalidBucketName") {
-      return "Invalid bucket name.";
-    }
-    if (error.name === "NetworkingError") {
-      return "Network error connecting to storage.";
-    }
-
-    // For deserialization errors, try to extract more info
-    if (error.message?.includes("Deserialization error")) {
-      return "Storage service returned an unexpected response format.";
-    }
-
-    // Fallback to the error message if it's reasonable
-    if (
-      error.message &&
-      !error.message.includes("#text") &&
-      !error.message.includes("Deserialization error")
-    ) {
-      return `Error: ${error.message}`;
-    }
-
-    return "Storage service is currently unavailable.";
-  };
-
-  return (
-    <Box>
-      <MonoText color="red">
-        Unable to load directory contents. This may be due to:
-        <br />
-        • The bucket or product not existing
-        <br />
-        • Network connectivity issues
-        <br />
-        • Insufficient permissions
-        <br />
-        <br />
-        {getErrorMessage(error)}
-      </MonoText>
-    </Box>
-  );
-}
 
 export async function generateMetadata({ params }: PageProps) {
   const { account_id, product_id, path } = await params;
@@ -138,7 +84,8 @@ export default async function ProductPathPage({ params }: PageProps) {
               : object_path,
           delimiter: "/",
         })
-        .then((result) => result.objects || []),
+        .then((result) => result.objects || [])
+        .catch(() => []),
     ]);
 
   // Handle product fetch failure
@@ -152,6 +99,8 @@ export default async function ProductPathPage({ params }: PageProps) {
 
   const readme =
     readmeContent.status === "fulfilled" ? readmeContent.value : "";
+
+  const objects = objectsList.status === "fulfilled" ? objectsList.value : [];
 
   let connectionDetails:
     | {
@@ -186,17 +135,13 @@ export default async function ProductPathPage({ params }: PageProps) {
   return (
     <Container>
       <Box mt="4">
-        {objectsList.status === "fulfilled" ? (
-          <ObjectBrowser
-            product={product.value}
-            initialPath={object_path}
-            selectedObject={selectedObject || undefined}
-            objects={objectsList.value}
-            connectionDetails={connectionDetails}
-          />
-        ) : (
-          <StorageErrorDisplay error={objectsList.reason} />
-        )}
+        <ObjectBrowser
+          product={product.value}
+          initialPath={object_path}
+          selectedObject={selectedObject || undefined}
+          objects={objects}
+          connectionDetails={connectionDetails}
+        />
       </Box>
 
       {/* Display README if available and we're at the root */}

--- a/src/components/features/products/ObjectBrowser.tsx
+++ b/src/components/features/products/ObjectBrowser.tsx
@@ -6,7 +6,9 @@ import { DataConnection, Product, ProductMirror } from "@/types";
 import { Card, Box } from "@radix-ui/themes";
 import { SectionHeader } from "@/components/core";
 import { BreadcrumbNav } from "@/components/display";
+import { storage } from "@/lib/clients/storage";
 import { buildDirectoryTree } from "./object-browser/utils";
+import { LOGGER } from "@/lib";
 
 export interface ObjectBrowserProps {
   product: Product;
@@ -16,7 +18,7 @@ export interface ObjectBrowserProps {
     primaryMirror: ProductMirror;
     dataConnection: DataConnection;
   };
-  objects: ProductObject[]; // Allow parent to pass objects to avoid duplicate calls
+  objects?: ProductObject[]; // Allow parent to pass objects to avoid duplicate calls
 }
 
 export async function ObjectBrowser({
@@ -24,9 +26,42 @@ export async function ObjectBrowser({
   initialPath = "",
   selectedObject,
   connectionDetails,
-  objects,
+  objects: providedObjects,
 }: ObjectBrowserProps) {
   const currentPath = initialPath ? initialPath.split("/").filter(Boolean) : [];
+  const pathString = currentPath.join("/");
+
+  // Use provided objects or fetch them if needed
+  let objects: ProductObject[] = [];
+  if (providedObjects) {
+    objects = providedObjects;
+  } else if (!selectedObject || selectedObject.type === "directory") {
+    // Only fetch objects if we don't have them and we're not showing a file
+    try {
+      const prefix =
+        pathString && !pathString.endsWith("/") ? `${pathString}/` : pathString;
+      const result = await storage.listObjects({
+        account_id: product.account_id,
+        product_id: product.product_id,
+        object_path: pathString,
+        prefix,
+        delimiter: "/",
+      });
+      objects = result.objects || [];
+    } catch (error) {
+      LOGGER.error("Error fetching objects", {
+        operation: "ObjectBrowser",
+        context: "object fetching",
+        error: error,
+        metadata: {
+          account_id: product.account_id,
+          product_id: product.product_id,
+          path: pathString,
+        },
+      });
+      objects = [];
+    }
+  }
 
   // Build directory tree
   const root = buildDirectoryTree(objects, currentPath);
@@ -82,6 +117,7 @@ export async function ObjectBrowser({
           />
         </Box>
       </SectionHeader>
+
       <DirectoryList
         items={items}
         currentPath={currentPath}


### PR DESCRIPTION
Reverts source-cooperative/source.coop#123

While it initially seemed to make to render errors on lookup failures, this is now seeming to be a not-good idea. Namely, for the reason that when a Product is first created, it is an empty "bucket" (ie path prefix in the Source S3 bucket). As such, it appears to be non-existent and the error is rendered.  However, this is a totally normal state simply representing an empty product/bucket-prefix and should not be rendered as an error.