### PR TITLE
Hyparquet iframe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13382,15 +13382,6 @@
         "undici-types": "~6.19.2"
       }
     },
-    "node_modules/@types/parse-json": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
-      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@types/parse5": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
@@ -14775,24 +14766,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/babel-plugin-macros": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "cosmiconfig": "^7.0.0",
-        "resolve": "^1.19.0"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-      }
-    },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.13",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.13.tgz",
@@ -15449,25 +15422,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
-      }
-    },
-    "node_modules/cosmiconfig": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/create-jest": {
@@ -23689,18 +23643,6 @@
         "node": ">=16"
       }
     },
-    "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -28043,18 +27985,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/src/components/features/products/ObjectBrowser.tsx
+++ b/src/components/features/products/ObjectBrowser.tsx
@@ -65,7 +65,7 @@ export async function ObjectBrowser({
           cloudUri={cloudUri}
         />
 
-        {cloudUri?.endsWith(".pmtiles") && (
+        {cloudUri?.endsWith(".pmtiles") ? (
           <Card style={{ marginTop: "2rem" }}>
             <SectionHeader title="Preview" />
             <iframe
@@ -77,7 +77,19 @@ export async function ObjectBrowser({
               Your browser does not support iframes.
             </iframe>
           </Card>
-        )}
+        ) : cloudUri?.endsWith(".parquet") ? (
+          <Card style={{ marginTop: "2rem" }}>
+            <SectionHeader title="Preview" />
+            <iframe
+              frameBorder="0"
+              width="100%"
+              height="600px"
+              src={`https://hyparam.github.io/demos/hyparquet/?key=${sourceUrl}`}
+            >
+              Your browser does not support iframes.
+            </iframe>
+          </Card>
+        ) : null}
       </>
     );
   }

--- a/src/components/features/products/ObjectBrowser.tsx
+++ b/src/components/features/products/ObjectBrowser.tsx
@@ -65,26 +65,14 @@ export async function ObjectBrowser({
           cloudUri={cloudUri}
         />
 
-        {cloudUri?.endsWith(".pmtiles") ? (
+        {cloudUri?.endsWith(".parquet") ? (
           <Card style={{ marginTop: "2rem" }}>
             <SectionHeader title="Preview" />
             <iframe
               frameBorder="0"
               width="100%"
               height="600px"
-              src={`https://pmtiles.io/#url=${sourceUrl}&iframe=true`}
-            >
-              Your browser does not support iframes.
-            </iframe>
-          </Card>
-        ) : cloudUri?.endsWith(".parquet") ? (
-          <Card style={{ marginTop: "2rem" }}>
-            <SectionHeader title="Preview" />
-            <iframe
-              frameBorder="0"
-              width="100%"
-              height="600px"
-              src={`https://hyparam.github.io/demos/hyparquet/?key=${sourceUrl}`}
+              src={`https://source-cooperative.github.io/parquet-table/?iframe&url=${sourceUrl}`}
             >
               Your browser does not support iframes.
             </iframe>

--- a/src/components/features/products/ObjectBrowser.tsx
+++ b/src/components/features/products/ObjectBrowser.tsx
@@ -55,13 +55,25 @@ export async function ObjectBrowser({
           break;
       }
     }
+    const sourceUrl = `https://data.source.coop/${product.account?.account_id}/${product.product_id}/${selectedObject.path}`;
     return (
-      <ObjectDetails
-        product={product}
-        selectedObject={selectedObject}
-        selectedDataItem={null}
-        cloudUri={cloudUri}
-      />
+      <>
+        <ObjectDetails
+          product={product}
+          selectedObject={selectedObject}
+          selectedDataItem={null}
+          cloudUri={cloudUri}
+        />
+
+        { cloudUri.endsWith(".pmtiles") ?
+          <Card style={{marginTop:"2rem"}}>
+            <SectionHeader title="Preview"/>
+            <iframe frameBorder="0" width="100%" height="600px" src={`https://pmtiles.io/#url=${sourceUrl}&iframe=true`}>
+              Your browser does not support iframes.
+            </iframe>
+          </Card>
+         : null }
+      </>
     );
   }
 

--- a/src/components/features/products/ObjectBrowser.tsx
+++ b/src/components/features/products/ObjectBrowser.tsx
@@ -65,14 +65,19 @@ export async function ObjectBrowser({
           cloudUri={cloudUri}
         />
 
-        { cloudUri.endsWith(".pmtiles") ?
-          <Card style={{marginTop:"2rem"}}>
-            <SectionHeader title="Preview"/>
-            <iframe frameBorder="0" width="100%" height="600px" src={`https://pmtiles.io/#url=${sourceUrl}&iframe=true`}>
+        {cloudUri?.endsWith(".pmtiles") && (
+          <Card style={{ marginTop: "2rem" }}>
+            <SectionHeader title="Preview" />
+            <iframe
+              frameBorder="0"
+              width="100%"
+              height="600px"
+              src={`https://pmtiles.io/#url=${sourceUrl}&iframe=true`}
+            >
               Your browser does not support iframes.
             </iframe>
           </Card>
-         : null }
+        )}
       </>
     );
   }


### PR DESCRIPTION
## What I'm changing

Show a table viewer for Parquet and GeoParquet files.

## How I did it

I created an app in https://github.com/source-cooperative/parquet-table/, deployed to https://source-cooperative.github.io/parquet-table/ on each commit to main.

The app is adapted from https://hyparam.github.io/demos/hyparquet/.

The app is included in the product page using an iframe, using the same technique as https://github.com/source-cooperative/source.coop/pull/125.

## How you can test it

Open any product with a parquet or geoparquet file. Eg:

https://source.coop/vida/google-microsoft-osm-open-buildings/geoparquet/by_country/country_iso=BOL/BOL.parquet


