### PR TITLE
fix: set default mirrors on newly created products

### DIFF
--- a/src/lib/actions/products.ts
+++ b/src/lib/actions/products.ts
@@ -271,10 +271,20 @@ export async function createProduct(
     featured: 0,
     data_mode: ProductDataMode.Open,
     metadata: {
-      // TODO: Add required metadata
       tags: [],
-      primary_mirror: "",
-      mirrors: {},
+      primary_mirror: "aws-opendata-us-west-2",
+      mirrors: {
+        "aws-opendata-us-west-2": {
+          storage_type: "s3",
+          connection_id: "aws-opendata-us-west-2",
+          prefix: `${validatedFields.data.account_id}/${validatedFields.data.product_id}/`,
+          config: {
+            region: "us-west-2",
+            bucket: "aws-opendata-us-west-2",
+          },
+          is_primary: true,
+        },
+      },
       roles: {},
     },
   };


### PR DESCRIPTION
## What I'm changing

When a new product was created via the form, the mirror information was not populated.

<!--
  High-level summary of what is achieved by these changes.

  Optional: reference related issues.
-->

## How I did it

<!--
  Lower-level details of the steps taken to achieve goal.

  Include:
    - considerations made when deciding how to implement feature
    - any changes to API that could impact the Data Proxy
-->

## How you can test it

<!--
  Instructions on how a reviewer can verify these changes.

  Consider including screenshots or video demonstrating feature.
-->
