### PR TITLE
Only show org members on Organization Profile

### DIFF
--- a/src/components/features/profiles/OrganizationProfilePage.tsx
+++ b/src/components/features/profiles/OrganizationProfilePage.tsx
@@ -30,10 +30,11 @@ export async function OrganizationProfilePage({
     productsTable.listByAccount(account.account_id),
   ]);
 
-  // Only consider active memberships
-  memberships = memberships.filter(
-    (membership) => membership.state === MembershipState.Member
-  );
+  memberships = memberships
+    // Only consider active memberships
+    .filter((membership) => membership.state === MembershipState.Member)
+    // Only consider memberships that are not product-specific
+    .filter((membership) => membership.repository_id === undefined);
 
   const relatedUserAccounts = new Map(
     (


### PR DESCRIPTION
## What I'm changing

When viewing an organization profile, only memberships that relate to the organization itself (as opposed to the organization's products) are visible.

Closes #142 

## How I did it

Filter memberships to only consider memberships where the `repository_id` is not set.

<!--
  Lower-level details of the steps taken to achieve goal.

  Include:
    - considerations made when deciding how to implement feature
    - any changes to API that could impact the Data Proxy
-->

## How you can test it

Issue #142 is apparent in the project's test fixtures.

See http://localhost:3000/organization

### Before

<img width="1161" height="1076" alt="Screenshot 2025-09-17 at 8 41 07 PM" src="https://github.com/user-attachments/assets/1ff57a8f-ccbe-4638-be77-6bbf27ed2ce2" />


### After
<img width="1155" height="1024" alt="Screenshot 2025-09-17 at 8 40 57 PM" src="https://github.com/user-attachments/assets/0c8f7cf2-3347-4160-ab45-b2ea3e0e97a0" />


<!--
  Instructions on how a reviewer can verify these changes.

  Consider including screenshots or video demonstrating feature.
-->
