### PR TITLE
ci(tests): properly apply mock config

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -21,3 +21,26 @@ global.Response = Response;
 global.Headers = Headers;
 // @ts-ignore
 global.fetch = fetch;
+
+// Global mock for @/lib/config - can be overridden in individual test files
+jest.mock("@/lib/config", () => ({
+  CONFIG: {
+    storage: {
+      type: "S3",
+      endpoint: "http://localhost:9000",
+      region: "us-east-1",
+      credentials: {
+        accessKeyId: "test",
+        secretAccessKey: "test",
+      },
+    },
+    environment: {
+      isDevelopment: false,
+      stage: "test",
+    },
+    auth: {
+      accessToken: "test-token",
+    },
+    apiSecret: "test-source-key-123",
+  },
+}));

--- a/src/app/api/v1/data-connections/route.test.ts
+++ b/src/app/api/v1/data-connections/route.test.ts
@@ -19,26 +19,6 @@ jest.mock("@/lib/api/authz", () => ({
   isAuthorized: jest.fn(),
 }));
 
-jest.mock("@/lib/config", () => ({
-  CONFIG: {
-    storage: {
-      type: "S3",
-      endpoint: "http://localhost:9000",
-      region: "us-east-1",
-      credentials: {
-        accessKeyId: "test",
-        secretAccessKey: "test",
-      },
-    },
-    environment: {
-      isDevelopment: false,
-      stage: "test",
-    },
-    auth: {
-      accessToken: "test-token",
-    },
-  },
-}));
 
 const { GET, POST } = require("./route");
 


### PR DESCRIPTION
## What I'm changing

This PR moves the configuration mock from only one test suite and applies it to the entire project.

## How I did it


By mocking in `jest.setup.ts`, all tests will be run with mock configuration.

## How you can test it

Note actions runs, where tests were failing when I removed the mock from `src/app/api/v1/data-connections/route.test.ts` and are now passing when I applied the mock in `jest.setup.ts`

<img width="286" height="135" alt="Screenshot 2025-09-19 at 12 44 47 PM" src="https://github.com/user-attachments/assets/47f6148a-8733-4020-ab2c-b33472df9d41" />

