### PR TITLE
feat: add account link popups

### DIFF
--- a/src/app/[account_id]/[product_id]/(product)/[[...path]]/@readme/page.tsx
+++ b/src/app/[account_id]/[product_id]/(product)/[[...path]]/@readme/page.tsx
@@ -1,5 +1,5 @@
 import { storage } from "@/lib";
-import { MarkdownViewer } from "@/components";
+import { MarkdownViewer } from "@/components/features/markdown";
 
 interface ProductPathComponentProps {
   account_id: string;

--- a/src/app/[account_id]/[product_id]/(product)/[[...path]]/layout.tsx
+++ b/src/app/[account_id]/[product_id]/(product)/[[...path]]/layout.tsx
@@ -10,6 +10,7 @@
 
 import { BreadcrumbNav, ProductHeader, SectionHeader } from "@/components";
 import { productsTable } from "@/lib/clients/database";
+import { productUrl } from "@/lib/urls";
 import { Box, Card } from "@radix-ui/themes";
 import { notFound } from "next/navigation";
 
@@ -19,7 +20,11 @@ interface ProductLayoutProps {
   params: Promise<{ account_id: string; product_id: string; path?: string[] }>;
 }
 
-export default async function ProductLayout({ params, children, readme }: ProductLayoutProps) {
+export default async function ProductLayout({
+  params,
+  children,
+  readme,
+}: ProductLayoutProps) {
   // Then check if product exists
   const { account_id, product_id, path } = await params;
   const product = await productsTable.fetchById(account_id, product_id);
@@ -41,7 +46,7 @@ export default async function ProductLayout({ params, children, readme }: Produc
           >
             <BreadcrumbNav
               path={path?.map((p) => decodeURIComponent(p)) || []}
-              baseUrl={`/${account_id}/${product_id}`}
+              baseUrl={productUrl(account_id, product_id)}
             />
           </Box>
         </SectionHeader>

--- a/src/app/[account_id]/[product_id]/(product)/[[...path]]/page.tsx
+++ b/src/app/[account_id]/[product_id]/(product)/[[...path]]/page.tsx
@@ -2,7 +2,13 @@ import { Suspense } from "react";
 import { notFound } from "next/navigation";
 
 import DirectoryListLoading from "./loading";
-import { LOGGER, storage, dataConnectionsTable, productsTable } from "@/lib";
+import {
+  LOGGER,
+  storage,
+  dataConnectionsTable,
+  productsTable,
+  CONFIG,
+} from "@/lib";
 import { DataConnection, ProductMirror } from "@/types";
 import { DirectoryList, ObjectSummary, ObjectPreview } from "@/components";
 
@@ -35,7 +41,7 @@ export default async function ProductPathPage({ params }: PageProps) {
     await fetchProduct(account_id, product_id, objectPath);
 
   if (objectInfo?.type === "file") {
-    const sourceUrl = `https://data.source.coop/${product.account?.account_id}/${product.product_id}/${objectInfo.path}`;
+    const sourceUrl = `${CONFIG.storage.endpoint}/${product.account?.account_id}/${product.product_id}/${objectInfo.path}`;
 
     return (
       <Suspense fallback={<DirectoryListLoading />}>

--- a/src/app/[account_id]/[product_id]/not-found.tsx
+++ b/src/app/[account_id]/[product_id]/not-found.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { NotFoundPage } from "@/components/core";
+import { accountUrl } from "@/lib/urls";
 import { usePathname } from "next/navigation";
 import { Text } from "@radix-ui/themes";
 
@@ -32,7 +33,7 @@ export default function NotFound() {
             </strong>
           </>
         }
-        actionHref={`/${account_id}`}
+        actionHref={accountUrl(account_id)}
       />
     );
   }

--- a/src/app/[account_id]/organization/new/page.tsx
+++ b/src/app/[account_id]/organization/new/page.tsx
@@ -3,6 +3,7 @@ import { FormTitle } from "@/components/core";
 import { getPageSession } from "@/lib/api/utils";
 import { redirect } from "next/navigation";
 import { Container, Heading, Text } from "@radix-ui/themes";
+import { newOrganizationUrl } from "@/lib/urls";
 
 interface PageProps {
   params: Promise<{
@@ -29,7 +30,7 @@ export default async function NewOrganizationPage({ params }: PageProps) {
   }
 
   if (session.account.account_id !== account_id) {
-    redirect(`/${session.account.account_id}/organization/new`);
+    redirect(newOrganizationUrl(session.account.account_id));
   }
 
   return (

--- a/src/app/email-verified/page.tsx
+++ b/src/app/email-verified/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { LOGGER } from "@/lib";
+import { onboardingUrl } from "@/lib/urls";
 
 export default async function EmailVerifiedPage() {
   LOGGER.info("Email verification page loaded", {
@@ -13,5 +14,5 @@ export default async function EmailVerifiedPage() {
     operation: "EmailVerifiedPage",
     context: "redirect",
   });
-  redirect("/onboarding?verified=true");
+  redirect(onboardingUrl("verified=true"));
 }

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import { OnboardingForm } from "@/components/features/onboarding";
 import { getPageSession } from "@/lib/api/utils";
 import { FormTitle } from "@/components/core";
+import { homeUrl, accountUrl } from "@/lib/urls";
 
 export const metadata: Metadata = {
   title: "Complete Your Profile",
@@ -14,11 +15,11 @@ export default async function OnboardingPage() {
   const identityId = session?.identity_id;
 
   if (!identityId) {
-    redirect("/");
+    redirect(homeUrl());
   }
 
   if (session?.account) {
-    redirect(`/${session.account.account_id}`);
+    redirect(accountUrl(session.account.account_id));
   }
 
   return (

--- a/src/components/core/AccountInfoHoverCard.tsx
+++ b/src/components/core/AccountInfoHoverCard.tsx
@@ -1,0 +1,61 @@
+import { Text, Flex, HoverCard } from "@radix-ui/themes";
+import { MonoText } from "./MonoText";
+import { Account } from "@/types";
+import { ProfileAvatar } from "../features/profiles";
+
+interface AccountInfoHoverCardProps {
+  account: Account;
+  children: React.ReactNode;
+  showHoverCard?: boolean;
+  isLink?: boolean;
+}
+
+export function AccountInfoHoverCard({
+  account,
+  children,
+  showHoverCard = true,
+  isLink = true,
+}: AccountInfoHoverCardProps) {
+  if (!showHoverCard) {
+    return <>{children}</>;
+  }
+
+  return (
+    <HoverCard.Root>
+      <HoverCard.Trigger>
+        <span style={isLink ? { cursor: "pointer" } : {}}>{children}</span>
+      </HoverCard.Trigger>
+      <HoverCard.Content
+        sideOffset={5}
+        style={{
+          maxWidth: "300px",
+          padding: "16px",
+          backgroundColor: "var(--gray-2)",
+          border: "1px solid var(--gray-6)",
+          borderRadius: "8px",
+          boxShadow: "0 4px 12px rgba(0, 0, 0, 0.1)",
+        }}
+      >
+        <Flex direction="column" gap="3">
+          <Flex align="center" gap="3">
+            <ProfileAvatar account={account} size="2" />
+            <Flex direction="column" gap="1">
+              <Text size="3" weight="bold">
+                {account.name}
+              </Text>
+              <MonoText size="1" color="gray">
+                @{account.account_id}
+              </MonoText>
+            </Flex>
+          </Flex>
+
+          {account.metadata_public?.bio && (
+            <Text size="2" color="gray">
+              {account.metadata_public.bio}
+            </Text>
+          )}
+        </Flex>
+      </HoverCard.Content>
+    </HoverCard.Root>
+  );
+}

--- a/src/components/core/AccountLinks.tsx
+++ b/src/components/core/AccountLinks.tsx
@@ -1,0 +1,80 @@
+import { Text, Flex, Link as RadixLink } from "@radix-ui/themes";
+import { MonoText } from "./MonoText";
+import { AccountInfoHoverCard } from "./AccountInfoHoverCard";
+import { accountUrl } from "@/lib/urls";
+import { Account } from "@/types";
+import Link from "next/link";
+import { ProfileAvatar } from "../features/profiles";
+
+interface AccountDisplayProps {
+  account: Account;
+  showHoverCard?: boolean;
+}
+
+export function AccountDisplay(props: AccountDisplayProps) {
+  return (
+    <AccountInfoHoverCard {...props}>
+      <Flex align="center" gap="3">
+        <ProfileAvatar account={props.account} size="2" />
+        <Flex direction="column" gap="1">
+          <Text size="2" weight="medium">
+            {props.account?.name || "Unknown User"}
+          </Text>
+          <Link href={accountUrl(props.account.account_id)}>
+            <MonoText size="1" color="gray">
+              @{props.account.account_id}
+            </MonoText>
+          </Link>
+        </Flex>
+      </Flex>
+    </AccountInfoHoverCard>
+  );
+}
+
+export function AvatarLinkCompact({
+  showAccountId = false,
+  link = true,
+  ...props
+}: AccountDisplayProps & {
+  showHoverCard?: boolean;
+  showAccountId?: boolean;
+  link?: boolean;
+}) {
+  const content = (
+    <>
+      <ProfileAvatar account={props.account} size="2" />
+      <Text size="2" ml="2">
+        {props.account.name}
+      </Text>
+    </>
+  );
+
+  return (
+    <Flex gap="2" align="center">
+      <AccountInfoHoverCard {...props} isLink={link}>
+        {link ? (
+          <RadixLink asChild>
+            <Link href={accountUrl(props.account.account_id)}>{content}</Link>
+          </RadixLink>
+        ) : (
+          content
+        )}
+      </AccountInfoHoverCard>
+      {showAccountId && (
+        <MonoText size="1">{props.account.account_id}</MonoText>
+      )}
+    </Flex>
+  );
+}
+
+export function DisplayNameLink(props: AccountDisplayProps) {
+  return (
+    <AccountInfoHoverCard {...props}>
+      <RadixLink asChild>
+        <Link href={accountUrl(props.account.account_id)}>
+          {props.account.name}
+        </Link>
+      </RadixLink>
+    </AccountInfoHoverCard>
+  );
+}

--- a/src/components/core/OnboardingCheck.tsx
+++ b/src/components/core/OnboardingCheck.tsx
@@ -3,6 +3,7 @@
 import { redirect, usePathname } from "next/navigation";
 import { Account } from "@/types/account";
 import { useEffect } from "react";
+import { homeUrl, onboardingUrl } from "@/lib/urls";
 
 /**
  * Simple client-side check to redirect to onboarding if the user is not on the
@@ -13,11 +14,11 @@ import { useEffect } from "react";
 export function OnboardingCheck({ account }: { account?: Account }) {
   useEffect(() => {
     if (pathname !== "/onboarding" && !account) {
-      redirect("/onboarding");
+      redirect(onboardingUrl());
     }
 
     if (pathname === "/onboarding" && account) {
-      redirect("/");
+      redirect(homeUrl());
     }
   }, []);
 

--- a/src/components/core/index.ts
+++ b/src/components/core/index.ts
@@ -8,3 +8,4 @@ export { DynamicForm } from "./DynamicForm";
 export type { FormField } from "./DynamicForm";
 export { SmallColumnContainer } from "./SmallColumnContainer";
 export { StatusPage, NotFoundPage, NotAuthorizedPage } from "./StatusPage";
+export * from "./AccountLinks";

--- a/src/components/features/products/ProductListItem.tsx
+++ b/src/components/features/products/ProductListItem.tsx
@@ -6,6 +6,7 @@ import { DateText } from "@/components/display";
 import { Box, Text, Badge, Heading } from "@radix-ui/themes";
 import { TagList } from "./TagList";
 import styles from "./ProductList.module.css";
+import { accountUrl, productUrl } from "@/lib/urls";
 
 interface ProductListItemProps {
   product: Product;
@@ -29,7 +30,7 @@ export function ProductListItem({ product, isSelected }: ProductListItemProps) {
       aria-current={isSelected ? "page" : undefined}
     >
       <article>
-        <Link href={`/${product.account_id}/${product.product_id}`}>
+        <Link href={productUrl(product.account_id, product.product_id)}>
           <Heading size="5" weight="bold" color="gray" mb="2">
             {product.title}
           </Heading>
@@ -46,7 +47,7 @@ export function ProductListItem({ product, isSelected }: ProductListItemProps) {
             <>
               <Text size="1" color="gray">
                 Provided by{" "}
-                <Link href={`/${product.account_id}`}>
+                <Link href={accountUrl(product.account_id)}>
                   {product.account.name}
                 </Link>
               </Text>

--- a/src/components/features/products/ProductListItem.tsx
+++ b/src/components/features/products/ProductListItem.tsx
@@ -6,7 +6,8 @@ import { DateText } from "@/components/display";
 import { Box, Text, Badge, Heading } from "@radix-ui/themes";
 import { TagList } from "./TagList";
 import styles from "./ProductList.module.css";
-import { accountUrl, productUrl } from "@/lib/urls";
+import { productUrl } from "@/lib/urls";
+import { DisplayNameLink } from "@/components/core";
 
 interface ProductListItemProps {
   product: Product;
@@ -46,10 +47,7 @@ export function ProductListItem({ product, isSelected }: ProductListItemProps) {
           {product.account?.name && (
             <>
               <Text size="1" color="gray">
-                Provided by{" "}
-                <Link href={accountUrl(product.account_id)}>
-                  {product.account.name}
-                </Link>
+                Provided by <DisplayNameLink account={product.account!} />
               </Text>
               {" • "}
             </>

--- a/src/components/features/products/ProductMetaContent.tsx
+++ b/src/components/features/products/ProductMetaContent.tsx
@@ -5,6 +5,7 @@ import { DateText } from "@/components/display";
 import Link from "next/link";
 import { Flex } from "@radix-ui/themes";
 import { ProfileAvatar } from "@/components/features/profiles/ProfileAvatar";
+import { accountUrl } from "@/lib/urls";
 
 interface ProductMetaContentProps {
   product: Product;
@@ -38,7 +39,7 @@ export function ProductMetaContent({ product }: ProductMetaContentProps) {
         <DataList.Label>Owner</DataList.Label>
         <DataList.Value>
           <RadixLink asChild>
-            <Link href={`/${product.account_id}`}>
+            <Link href={accountUrl(product.account_id)}>
               <Flex gap="2" align="center">
                 {product.account && (
                   <ProfileAvatar account={product.account} size="2" />

--- a/src/components/features/products/ProductMetaContent.tsx
+++ b/src/components/features/products/ProductMetaContent.tsx
@@ -1,11 +1,7 @@
 import { DataList, Badge, Link as RadixLink } from "@radix-ui/themes";
 import type { Product } from "@/types";
-import { MonoText } from "@/components/core";
+import { AvatarLinkCompact } from "@/components/core";
 import { DateText } from "@/components/display";
-import Link from "next/link";
-import { Flex } from "@radix-ui/themes";
-import { ProfileAvatar } from "@/components/features/profiles/ProfileAvatar";
-import { accountUrl } from "@/lib/urls";
 
 interface ProductMetaContentProps {
   product: Product;
@@ -38,18 +34,7 @@ export function ProductMetaContent({ product }: ProductMetaContentProps) {
       <DataList.Item style={{ alignItems: "center" }}>
         <DataList.Label>Owner</DataList.Label>
         <DataList.Value>
-          <RadixLink asChild>
-            <Link href={accountUrl(product.account_id)}>
-              <Flex gap="2" align="center">
-                {product.account && (
-                  <ProfileAvatar account={product.account} size="2" />
-                )}
-                <MonoText>
-                  {product.account?.name || product.account_id}
-                </MonoText>
-              </Flex>
-            </Link>
-          </RadixLink>
+          <AvatarLinkCompact account={product.account!} />
         </DataList.Value>
       </DataList.Item>
 

--- a/src/components/features/products/ProductMetaContent.tsx
+++ b/src/components/features/products/ProductMetaContent.tsx
@@ -1,4 +1,4 @@
-import { DataList, Badge, Link as RadixLink } from "@radix-ui/themes";
+import { DataList, Badge } from "@radix-ui/themes";
 import type { Product } from "@/types";
 import { AvatarLinkCompact } from "@/components/core";
 import { DateText } from "@/components/display";

--- a/src/components/features/products/ProductSchemaMetadata.tsx
+++ b/src/components/features/products/ProductSchemaMetadata.tsx
@@ -1,4 +1,5 @@
 import type { Product } from "@/types";
+import { productUrl } from "@/lib/urls";
 
 // For injecting schema.org metadata
 export function ProductSchemaMetadata({ product }: { product: Product }) {
@@ -9,7 +10,10 @@ export function ProductSchemaMetadata({ product }: { product: Product }) {
     name: product.title,
     description: product.description,
     url: account
-      ? `https://yourdomain.com/${account.account_id}/${product.product_id}`
+      ? `https://yourdomain.com${productUrl(
+          account.account_id,
+          product.product_id
+        )}`
       : "",
     dateModified: product.updated_at,
     dateCreated: product.created_at,

--- a/src/components/features/products/ProductSearchResult.tsx
+++ b/src/components/features/products/ProductSearchResult.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import DOMPurify from 'isomorphic-dompurify';
 import type { Product } from "@/types";
 import { DateText } from '@/components/display';
+import { productUrl } from "@/lib/urls";
 
 interface ProductSearchResultProps {
   product: Product;
@@ -20,15 +21,18 @@ export function ProductSearchResult({ product, highlight }: ProductSearchResultP
     product.description;
 
   return (
-    <Link href={`/${product.account_id}/${product.product_id}`}>
+    <Link href={productUrl(product.account_id, product.product_id)}>
       <Card>
         <Flex direction="column" gap="2">
-          <Text size="5" weight="bold" 
-            dangerouslySetInnerHTML={{ __html: sanitizedTitle }} 
+          <Text
+            size="5"
+            weight="bold"
+            dangerouslySetInnerHTML={{ __html: sanitizedTitle }}
           />
           {(highlight?.description || product.description) && (
-            <Text color="gray" 
-              dangerouslySetInnerHTML={{ __html: sanitizedDescription }} 
+            <Text
+              color="gray"
+              dangerouslySetInnerHTML={{ __html: sanitizedDescription }}
             />
           )}
           <Flex gap="3" align="center">
@@ -38,8 +42,8 @@ export function ProductSearchResult({ product, highlight }: ProductSearchResultP
             <Text size="2" color="blue">
               {product.account?.name}
             </Text>
-            <Badge color={product.visibility === 'public' ? "green" : "red"}>
-              {product.visibility === 'public' ? "Public" : "Private"}
+            <Badge color={product.visibility === "public" ? "green" : "red"}>
+              {product.visibility === "public" ? "Public" : "Private"}
             </Badge>
           </Flex>
         </Flex>

--- a/src/components/features/products/object-browser/DirectoryRow.tsx
+++ b/src/components/features/products/object-browser/DirectoryRow.tsx
@@ -7,6 +7,7 @@ import { MonoText } from "@/components/core";
 import type { FileNode } from "./utils";
 import type { Product } from "@/types";
 import { formatFileSize } from "./utils";
+import { objectUrl } from "@/lib/urls";
 import styles from "./ObjectBrowser.module.css";
 
 interface DirectoryRowProps {
@@ -35,10 +36,12 @@ export function DirectoryRow({
   virtualRow,
 }: DirectoryRowProps) {
   const href = item.isDirectory
-    ? `/${product.account_id}/${product.product_id}/${[...path, item.name].join(
-        "/"
-      )}`
-    : `/${product.account_id}/${product.product_id}/${item.path}`;
+    ? objectUrl(
+        product.account_id,
+        product.product_id,
+        [...path, item.name].join("/")
+      )
+    : objectUrl(product.account_id, product.product_id, item.path);
 
   const wrapperStyle = virtualRow
     ? {

--- a/src/components/features/profiles/IndividualProfile.tsx
+++ b/src/components/features/profiles/IndividualProfile.tsx
@@ -17,7 +17,8 @@ import { ProductsList } from "../products/ProductsList";
 import { WebsiteLink } from "./WebsiteLink";
 import { EmailVerificationStatus } from "./EmailVerificationStatus";
 import { IndividualProfileActions } from "./IndividualProfileActions";
-import { accountUrl, editAccountProfileUrl } from "@/lib/urls";
+import { editAccountProfileUrl } from "@/lib/urls";
+import { AvatarLinkCompact } from "@/components/core";
 
 interface IndividualProfileProps {
   account: IndividualAccount;
@@ -100,14 +101,7 @@ export function IndividualProfile({
           </Heading>
           <Grid columns="3" gap="4">
             {organizations.map((org) => (
-              <RadixLink asChild key={org.account_id}>
-                <Link href={accountUrl(org.account_id)}>
-                  <Flex gap="2" align="center">
-                    <ProfileAvatar account={org} size="2" />
-                    <Text>{org.name}</Text>
-                  </Flex>
-                </Link>
-              </RadixLink>
+              <AvatarLinkCompact account={org} key={org.account_id} />
             ))}
           </Grid>
         </Box>

--- a/src/components/features/profiles/IndividualProfile.tsx
+++ b/src/components/features/profiles/IndividualProfile.tsx
@@ -17,6 +17,7 @@ import { ProductsList } from "../products/ProductsList";
 import { WebsiteLink } from "./WebsiteLink";
 import { EmailVerificationStatus } from "./EmailVerificationStatus";
 import { IndividualProfileActions } from "./IndividualProfileActions";
+import { accountUrl, editAccountProfileUrl } from "@/lib/urls";
 
 interface IndividualProfileProps {
   account: IndividualAccount;
@@ -100,7 +101,7 @@ export function IndividualProfile({
           <Grid columns="3" gap="4">
             {organizations.map((org) => (
               <RadixLink asChild key={org.account_id}>
-                <Link href={`/${org.account_id}`}>
+                <Link href={accountUrl(org.account_id)}>
                   <Flex gap="2" align="center">
                     <ProfileAvatar account={org} size="2" />
                     <Text>{org.name}</Text>

--- a/src/components/features/profiles/OrganizationMembers.tsx
+++ b/src/components/features/profiles/OrganizationMembers.tsx
@@ -2,6 +2,7 @@ import { Box, Text, Link as RadixLink, Flex } from "@radix-ui/themes";
 import Link from "next/link";
 import type { IndividualAccount } from "@/types";
 import { ProfileAvatar } from "./ProfileAvatar";
+import { accountUrl } from "@/lib/urls";
 
 interface OrganizationMembersProps {
   owners: IndividualAccount[];
@@ -79,7 +80,7 @@ interface MemberLinkProps {
 function MemberLink({ member, role: _role }: MemberLinkProps) {
   return (
     <RadixLink asChild>
-      <Link href={`/${member.account_id}`}>
+      <Link href={accountUrl(member.account_id)}>
         <Flex gap="2" align="center">
           <ProfileAvatar account={member} size="2" />
           <Text size="2">{member.name}</Text>

--- a/src/components/features/profiles/OrganizationMembers.tsx
+++ b/src/components/features/profiles/OrganizationMembers.tsx
@@ -1,8 +1,6 @@
-import { Box, Text, Link as RadixLink, Flex } from "@radix-ui/themes";
-import Link from "next/link";
+import { Box, Text, Flex } from "@radix-ui/themes";
 import type { IndividualAccount } from "@/types";
-import { ProfileAvatar } from "./ProfileAvatar";
-import { accountUrl } from "@/lib/urls";
+import { AvatarLinkCompact } from "@/components";
 
 interface OrganizationMembersProps {
   owners: IndividualAccount[];
@@ -59,33 +57,11 @@ export function OrganizationMembers({
           </Text>
           <Flex direction="column" gap="1">
             {group.members.map((member) => (
-              <MemberLink
-                key={member.account_id}
-                member={member}
-                role={group.role as "owner" | "admin" | "member"}
-              />
+              <AvatarLinkCompact account={member} key={member.account_id} />
             ))}
           </Flex>
         </Box>
       ))}
     </Flex>
-  );
-}
-
-interface MemberLinkProps {
-  member: IndividualAccount;
-  role: "owner" | "admin" | "member";
-}
-
-function MemberLink({ member, role: _role }: MemberLinkProps) {
-  return (
-    <RadixLink asChild>
-      <Link href={accountUrl(member.account_id)}>
-        <Flex gap="2" align="center">
-          <ProfileAvatar account={member} size="2" />
-          <Text size="2">{member.name}</Text>
-        </Flex>
-      </Link>
-    </RadixLink>
   );
 }

--- a/src/components/features/profiles/OrganizationProfile.tsx
+++ b/src/components/features/profiles/OrganizationProfile.tsx
@@ -22,7 +22,6 @@ import { OrganizationMembers } from "./OrganizationMembers";
 import { ProfileAvatar } from "./ProfileAvatar";
 import { WebsiteLink } from "./WebsiteLink";
 import { ProfileLocation } from "./ProfileLocation";
-import { editAccountProfileUrl } from "@/lib/urls";
 
 interface OrganizationProfileProps {
   account: OrganizationalAccount;

--- a/src/components/features/profiles/OrganizationProfile.tsx
+++ b/src/components/features/profiles/OrganizationProfile.tsx
@@ -22,6 +22,7 @@ import { OrganizationMembers } from "./OrganizationMembers";
 import { ProfileAvatar } from "./ProfileAvatar";
 import { WebsiteLink } from "./WebsiteLink";
 import { ProfileLocation } from "./ProfileLocation";
+import { editAccountProfileUrl } from "@/lib/urls";
 
 interface OrganizationProfileProps {
   account: OrganizationalAccount;

--- a/src/components/features/profiles/ProfileAvatar.tsx
+++ b/src/components/features/profiles/ProfileAvatar.tsx
@@ -1,18 +1,18 @@
-'use client';
+"use client";
 
-import { Avatar } from '@radix-ui/themes';
-import md5 from 'md5';
+import { Avatar } from "@radix-ui/themes";
+import md5 from "md5";
 import type { Account } from "@/types";
 
 interface ProfileAvatarProps {
   account: Account;
-  size?: '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9';
+  size?: "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9";
 }
 
-export function ProfileAvatar({ account, size = '6' }: ProfileAvatarProps) {
+export function ProfileAvatar({ account, size = "6" }: ProfileAvatarProps) {
   // Get avatar source URL
   const getAvatarSrc = () => {
-    if (account.type === 'individual') {
+    if (account.type === "individual") {
       // Use Gravatar for individuals
       const primaryEmail = account.emails?.find(
         (email) => email.is_primary
@@ -22,9 +22,6 @@ export function ProfileAvatar({ account, size = '6' }: ProfileAvatarProps) {
         return `https://www.gravatar.com/avatar/${hash}?d=identicon&s=200`;
       }
     }
-    
-    // Use default organization icon for organizations
-    return 'https://source.coop/images/default-org.png';
   };
 
   return (
@@ -35,4 +32,4 @@ export function ProfileAvatar({ account, size = '6' }: ProfileAvatarProps) {
       radius={account.type === "individual" ? "full" : "medium"}
     />
   );
-} 
+}

--- a/src/components/features/profiles/WelcomeCallout.tsx
+++ b/src/components/features/profiles/WelcomeCallout.tsx
@@ -1,8 +1,9 @@
-'use client';
+"use client";
 
-import { Callout } from '@radix-ui/themes';
-import Link from 'next/link';
-import { InfoCircledIcon } from '@radix-ui/react-icons';
+import { Callout } from "@radix-ui/themes";
+import Link from "next/link";
+import { InfoCircledIcon } from "@radix-ui/react-icons";
+import { editAccountProfileUrl } from "@/lib/urls";
 
 interface WelcomeCalloutProps {
   show: boolean;
@@ -18,11 +19,15 @@ export function WelcomeCallout({ show, accountId }: WelcomeCalloutProps) {
         <InfoCircledIcon />
       </Callout.Icon>
       <Callout.Text>
-        Welcome to Source Cooperative. This is your profile page.{' '}
-        <Link href={`/${accountId}/edit`} style={{ textDecoration: 'underline' }}>
+        Welcome to Source Cooperative. This is your profile page.{" "}
+        <Link
+          href={editAccountProfileUrl(accountId)}
+          style={{ textDecoration: "underline" }}
+        >
           Edit it to add more details
-        </Link>.
+        </Link>
+        .
       </Callout.Text>
     </Callout.Root>
   );
-} 
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,8 +4,10 @@ export * from "./display";
 export * from "./layout";
 
 // Feature components
-export * from "./features/markdown";
-export * from "./features/metadata";
+// export * from './features/markdown';  // Avoid problematic import of ./features/markdown/codeConfig
+export * from './features/metadata';
+export * from './features/profiles';
+export * from './features/products';
 export * from "./features/profiles";
 export * from "./features/products";
 export * from "./features/profiles";

--- a/src/components/layout/AccountDropdown.tsx
+++ b/src/components/layout/AccountDropdown.tsx
@@ -11,6 +11,12 @@ import { LOGGER } from "@/lib";
 import { DropdownSection } from "./DropdownSection";
 import { isAuthorized } from "@/lib/api/authz";
 import { Actions } from "@/types";
+import {
+  accountUrl,
+  editAccountProfileUrl,
+  newOrganizationUrl,
+  newProductUrl,
+} from "@/lib/urls";
 
 export function AccountDropdownSkeleton() {
   return (
@@ -61,11 +67,11 @@ export function AccountDropdown({ session }: { session: UserSession }) {
           label="Account"
           items={[
             {
-              href: `/${session.account!.account_id}`,
+              href: accountUrl(session.account!.account_id),
               children: "View Profile",
             },
             {
-              href: `/${session.account!.account_id}/edit`,
+              href: editAccountProfileUrl(session.account!.account_id),
               children: "Edit Profile",
             },
           ]}
@@ -74,7 +80,7 @@ export function AccountDropdown({ session }: { session: UserSession }) {
           label="Organizations"
           items={[
             {
-              href: `/${session.account!.account_id}/organization/new`,
+              href: newOrganizationUrl(session.account!.account_id),
               children: "Create Organization",
               condition: isAuthorized(session, "*", Actions.CreateAccount),
             },
@@ -84,7 +90,7 @@ export function AccountDropdown({ session }: { session: UserSession }) {
           label="Products"
           items={[
             {
-              href: `/products/new`,
+              href: newProductUrl(),
               children: "Create Product",
               condition: isAuthorized(session, "*", Actions.CreateRepository),
             },

--- a/src/components/layout/AuthButtons.tsx
+++ b/src/components/layout/AuthButtons.tsx
@@ -3,6 +3,7 @@ import { getPageSession } from "@/lib/api/utils";
 import { Button, Callout, Link } from "@radix-ui/themes";
 import { CONFIG } from "@/lib/config";
 import { ExclamationTriangleIcon } from "@radix-ui/react-icons";
+import { onboardingUrl } from "@/lib/urls";
 
 export async function AuthButtons() {
   const session = await getPageSession();
@@ -19,7 +20,7 @@ export async function AuthButtons() {
         </Callout.Icon>
         <Callout.Text>
           You do not yet have a profile. Please click{" "}
-          <Link href="/onboarding">here</Link> to complete your profile.
+          <Link href={onboardingUrl()}>here</Link> to complete your profile.
         </Callout.Text>
       </Callout.Root>
     );

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -4,6 +4,7 @@ import { Container, Box, Link as RadixLink } from "@radix-ui/themes";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { MonoText } from "@/components/core";
+import { homeUrl, productListUrl } from "@/lib/urls";
 
 export function Footer() {
   const pathname = usePathname();
@@ -16,7 +17,7 @@ export function Footer() {
             {pathname !== "/" && (
               <Box mb="2">
                 <RadixLink color="gray" underline="always" asChild>
-                  <Link href="/">
+                  <Link href={homeUrl()}>
                     <MonoText size="2">Home</MonoText>
                   </Link>
                 </RadixLink>
@@ -24,7 +25,7 @@ export function Footer() {
             )}
             <Box mb="2">
               <RadixLink color="gray" underline="always" asChild>
-                <Link href="/products">
+                <Link href={productListUrl()}>
                   <MonoText size="2">All Products</MonoText>
                 </Link>
               </RadixLink>

--- a/src/components/layout/LogoLink.tsx
+++ b/src/components/layout/LogoLink.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import styles from './Navigation.module.css';
+import { homeUrl } from "@/lib/urls";
 
 interface LogoLinkProps {
   children: React.ReactNode;
@@ -12,9 +13,11 @@ export function LogoLink({ children }: LogoLinkProps) {
   const pathname = usePathname();
   
   // Only wrap in Link if not on home page
-  return pathname === '/' ? (
+  return pathname === "/" ? (
     <div className={styles.logo}>{children}</div>
   ) : (
-    <Link href="/" className={styles.logo}>{children}</Link>
+    <Link href={homeUrl()} className={styles.logo}>
+      {children}
+    </Link>
   );
 } 

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
+import { homeUrl, accountUrl, objectUrl } from "@/lib/urls";
 
 interface UseKeyboardShortcutsProps {
   onShowHelp?: () => void;
@@ -46,15 +47,17 @@ export function useKeyboardShortcuts({ onShowHelp }: UseKeyboardShortcutsProps =
         if (segments.length === 0) {
           // At root - do nothing
           return;
-        } else if (segments.length === 1) {
+        } else         if (segments.length === 1) {
           // On profile page - go to root
-          router.push('/');
+          router.push(homeUrl());
         } else if (segments.length === 2) {
           // On repository page - go to profile
-          router.push(`/${segments[0]}`);
+          router.push(accountUrl(segments[0]));
         } else {
           // In object browser - go up one level
-          router.push(`/${segments[0]}/${segments[1]}/${segments.slice(2, -1).join('/')}`);
+          router.push(
+            objectUrl(segments[0], segments[1], segments.slice(2, -1).join("/"))
+          );
         }
         return;
       }

--- a/src/hooks/useObjectBrowserKeyboardShortcuts.ts
+++ b/src/hooks/useObjectBrowserKeyboardShortcuts.ts
@@ -2,6 +2,7 @@ import { useEffect, useState, useRef } from 'react';
 import type { Product } from "@/types";
 import type { ProductObject } from '@/types/product_object';
 import { useKeyboardShortcuts } from './useKeyboardShortcuts';
+import { objectUrl } from "@/lib/urls";
 
 interface FileNode {
   name: string;
@@ -143,7 +144,13 @@ export function useObjectBrowserKeyboardShortcuts({
             e.preventDefault();
             // Copy permanent link
             if (selectedObject) {
-              const url = window.location.origin + `/${product.account_id}/${product.product_id}/${selectedObject.path}`;
+              const url =
+                window.location.origin +
+                objectUrl(
+                  product.account_id,
+                  product.product_id,
+                  selectedObject.path
+                );
               navigator.clipboard.writeText(url);
             }
             break;

--- a/src/hooks/useProductListKeyboardShortcuts.ts
+++ b/src/hooks/useProductListKeyboardShortcuts.ts
@@ -1,6 +1,7 @@
 import { useEffect, useCallback, useState } from "react";
 import { useRouter } from "next/navigation";
 import type { Product } from "@/types";
+import { productUrl } from "@/lib/urls";
 
 interface UseProductListKeyboardShortcutsOptions {
   products: Product[];
@@ -49,7 +50,7 @@ export function useProductListKeyboardShortcuts({
           event.preventDefault();
           if (products[selectedIndex]) {
             const product = products[selectedIndex];
-            router.push(`/${product.account_id}/${product.product_id}`);
+            router.push(productUrl(product.account_id, product.product_id));
           }
           break;
         case "?":

--- a/src/lib/actions/account.ts
+++ b/src/lib/actions/account.ts
@@ -4,7 +4,6 @@ import { updateOryIdentity } from "@/lib/ory";
 import { LOGGER } from "@/lib/logging";
 import {
   AccountCreationRequestSchema,
-  Account,
   Actions,
   AccountCreationRequest,
   DEFAULT_INDIVIDUAL_FLAGS,
@@ -23,6 +22,7 @@ import { accountsTable, membershipsTable } from "../clients";
 import { FormState } from "@/components/core/DynamicForm";
 import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
+import { accountUrl, editAccountProfileUrl } from "@/lib/urls";
 import { v4 as uuidv4 } from "uuid";
 
 /**
@@ -165,8 +165,8 @@ export async function createAccount(
 
   redirect(
     account.type === AccountType.INDIVIDUAL
-      ? `/${account.account_id}?welcome=true`
-      : `/${account.account_id}`
+      ? accountUrl(account.account_id, "welcome=true")
+      : accountUrl(account.account_id)
   );
 }
 
@@ -292,8 +292,8 @@ export async function updateAccountProfile(
     });
 
     // Revalidate the profile page to show updated data
-    revalidatePath(`/${accountId}`);
-    revalidatePath(`/${accountId}/edit`);
+    revalidatePath(accountUrl(accountId));
+    revalidatePath(editAccountProfileUrl(accountId));
 
     return {
       fieldErrors: {},

--- a/src/lib/actions/products.ts
+++ b/src/lib/actions/products.ts
@@ -12,6 +12,7 @@ import { getPageSession, LOGGER } from "@/lib";
 import { FormState } from "@/components/core/DynamicForm";
 import { isAuthorized } from "../api/authz";
 import { redirect } from "next/navigation";
+import { productUrl } from "@/lib/urls";
 
 export interface PaginatedProductsResult {
   products: Product[];
@@ -300,7 +301,7 @@ export async function createProduct(
 
   try {
     await productsTable.create(product);
-    redirect(`/${product.account_id}/${product.product_id}?success`);
+    redirect(productUrl(product.account_id, product.product_id, "success"));
   } catch (error) {
     LOGGER.error("Failed to create product", {
       operation: "createProduct",

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -1,0 +1,55 @@
+import { CONFIG } from "./config";
+
+// Public URLs
+export const homeUrl = () => "/";
+export const accountUrl = (account_id: string, params?: string) =>
+  `/${account_id}` + (params ? `?${params}` : "");
+export const productUrl = (
+  account_id: string,
+  product_id: string,
+  params?: string
+) => `/${account_id}/${product_id}` + (params ? `?${params}` : "");
+export const productListUrl = () => "/products";
+export const newProductUrl = () => "/products/new";
+
+// Auth URLs
+export const loginUrl = () => CONFIG.auth.routes.login;
+export const onboardingUrl = (params?: string) =>
+  `/onboarding` + (params ? `?${params}` : "");
+
+// Object URLs
+export const objectUrl = (
+  account_id: string,
+  product_id: string,
+  object_path: string
+) => `/${account_id}/${product_id}/${object_path}`;
+
+// Edit URLs
+export const editAccountUrl = (account_id: string) =>
+  `/edit/account/${account_id}`;
+export const editAccountProfileUrl = (account_id: string) =>
+  `/edit/account/${account_id}/profile`;
+export const editAccountSecurityUrl = (account_id: string) =>
+  `/edit/account/${account_id}/security`;
+export const editAccountMembershipsUrl = (account_id: string) =>
+  `/edit/account/${account_id}/memberships`;
+export const editAccountViewUrl = (account_id: string, view: string) =>
+  `/edit/account/${account_id}/${view}`;
+export const editProductUrl = (account_id: string, product_id: string) =>
+  `/edit/product/${account_id}/${product_id}`;
+export const editProductDetailsUrl = (account_id: string, product_id: string) =>
+  `/edit/product/${account_id}/${product_id}/details`;
+export const editProductAccessUrl = (account_id: string, product_id: string) =>
+  `/edit/product/${account_id}/${product_id}/access`;
+export const editProductVisibilityUrl = (
+  account_id: string,
+  product_id: string
+) => `/edit/product/${account_id}/${product_id}/visibility`;
+export const editProductArchiveUrl = (account_id: string, product_id: string) =>
+  `/edit/product/${account_id}/${product_id}/archive`;
+export const editProfileUrl = (account_id: string) =>
+  `/edit/profile/${account_id}`;
+
+// Organization URLs
+export const newOrganizationUrl = (account_id: string) =>
+  `/${account_id}/organization/new`;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,6 +2,7 @@ import { getServerSession } from "@ory/nextjs/app";
 import { createOryMiddleware } from "@ory/nextjs/middleware";
 import { NextRequest, NextResponse } from "next/server";
 import { getOryId, accountsTable, LOGGER } from "@/lib";
+import { productUrl } from "@/lib/urls";
 
 /**
  * Handle requests to legacy repository description paths.
@@ -25,7 +26,7 @@ const handleLegacyRedirects = (request: NextRequest): NextResponse | null => {
       // pathParts[4] = "description" or "access"
       const ownerId = pathParts[2];
       const repoId = pathParts[3];
-      const newPath = `/${ownerId}/${repoId}`;
+      const newPath = productUrl(ownerId, repoId);
       LOGGER.debug("Redirecting to new path", {
         operation: "handle_legacy_redirects",
         context: __filename,


### PR DESCRIPTION
## What I'm changing

Add a hover card to provide user with greater information about a given account when a user hovers over a link to an account.

https://github.com/user-attachments/assets/f97176fe-a8a8-4cc5-9dac-95086e8f1361


<!--
  High-level summary of what is achieved by these changes.

  Optional: reference related issues.
-->

## How I did it

* Make use of Radix' [Hover Card component](https://www.radix-ui.com/primitives/docs/components/hover-card)
* Move all URLs to a urls util file to help better manage the growing number of internal links within the app (f74b97a2c53759581369a2295dac993d61b67330)
* Avoid problematic import of bright syntax highlighter by removing it from our components `index.ts` file (it can still be explicitely imported at its full path)

<!--
  Lower-level details of the steps taken to achieve goal.

  Include:
    - considerations made when deciding how to implement feature
    - any changes to API that could impact the Data Proxy
-->

## How you can test it

Kick the tires over at https://source-cooperative-git-feat-add-account-popup-radiantearth.vercel.app



