### PR TITLE
pass theme parameter to parquet-table iframe

### DIFF
--- a/src/components/features/products/object-browser/ObjectPreview.tsx
+++ b/src/components/features/products/object-browser/ObjectPreview.tsx
@@ -1,17 +1,22 @@
 "use client";
 
 import { Box } from "@radix-ui/themes";
+import { useTheme } from 'next-themes';
 
 interface ObjectPreviewProps {
   sourceUrl: string;
 }
 
 const getIframeSrc = (sourceUrl: string) => {
+  const { resolvedTheme } = useTheme();
+  const theme = resolvedTheme === 'dark' ? 'dark' : 'light';
+
   switch (sourceUrl.split(".").pop()) {
     case "pmtiles":
+      // TODO(SL): add support for theme param in pmtiles.io?
       return `https://pmtiles.io/#url=${sourceUrl}&iframe=true`;
     case "parquet":
-      return `https://source-cooperative.github.io/parquet-table/?iframe&url=${sourceUrl}`;
+      return `https://source-cooperative.github.io/parquet-table/?url=${sourceUrl}&iframe=true&theme=${theme}`;
     default:
       return null;
   }


### PR DESCRIPTION
## What I'm changing

Pass a `theme` query parameter to the Parquet table iframe. See https://github.com/source-cooperative/parquet-table/pull/10

## How I did it

Get the theme from the context, and pass it to the iframe, using "light" as the default.

## How you can test it

It requires https://github.com/source-cooperative/parquet-table/pull/10 to be merged first. Then: go to a product with a parquet file, go the parquet page, see the embedded table: it should use the same theme as the page. If you change the theme in source.coop, it should change in the iframe too.
