### PR TITLE
add a border to the parquet-table iframe

### DIFF
--- a/src/components/features/products/object-browser/ObjectPreview.tsx
+++ b/src/components/features/products/object-browser/ObjectPreview.tsx
@@ -28,15 +28,10 @@ const getIframeAttributes = (
 export function ObjectPreview({ sourceUrl: cloudUri }: ObjectPreviewProps) {
   const iframeProps = getIframeAttributes(cloudUri);
   if (iframeProps) {
-    const {src, style} = iframeProps;
+    const { src, style } = iframeProps;
     return (
       <Box mt="4">
-        <iframe
-          width="100%"
-          height="600px"
-          style={style}
-          src={src}
-        >
+        <iframe width="100%" height="600px" style={style} src={src}>
           Your browser does not support iframes.
         </iframe>
       </Box>

--- a/src/components/features/products/object-browser/ObjectPreview.tsx
+++ b/src/components/features/products/object-browser/ObjectPreview.tsx
@@ -1,28 +1,42 @@
 "use client";
 
 import { Box } from "@radix-ui/themes";
+import type { CSSProperties } from "react";
 
 interface ObjectPreviewProps {
   sourceUrl: string;
 }
 
-const getIframeSrc = (sourceUrl: string) => {
+const getIframeAttributes = (
+  sourceUrl: string
+): { src: string; style?: CSSProperties } | null => {
   switch (sourceUrl.split(".").pop()) {
     case "pmtiles":
-      return `https://pmtiles.io/#url=${sourceUrl}&iframe=true`;
+      return {
+        src: `https://pmtiles.io/#url=${sourceUrl}&iframe=true`,
+        style: { border: "none" },
+      };
     case "parquet":
-      return `https://source-cooperative.github.io/parquet-table/?iframe&url=${sourceUrl}`;
+      return {
+        src: `https://source-cooperative.github.io/parquet-table/?iframe&url=${sourceUrl}`,
+      };
     default:
       return null;
   }
 };
 
 export function ObjectPreview({ sourceUrl: cloudUri }: ObjectPreviewProps) {
-  const iframeSrc = getIframeSrc(cloudUri);
-  if (iframeSrc) {
+  const iframeProps = getIframeAttributes(cloudUri);
+  if (iframeProps) {
+    const {src, style} = iframeProps;
     return (
       <Box mt="4">
-        <iframe width="100%" height="600px" style={{ border: "none" }} src={iframeSrc}>
+        <iframe
+          width="100%"
+          height="600px"
+          style={style}
+          src={src}
+        >
           Your browser does not support iframes.
         </iframe>
       </Box>


### PR DESCRIPTION
## What I'm changing

Set a border to the iframe when embedding the parquet table. It does not affect the PMTiles viewer.

## How I did it

Pass a style attribute that depends on the viewer we include.

An alternative would be to set the CSS in the embedded table viewer.

## How you can test it

Try it here: https://source-cooperative-git-add-border-to-parque-871e31-radiantearth.vercel.app/vida/google-microsoft-osm-open-buildings/geoparquet/by_country/country_iso=AFG/AFG.parquet

and here (no border for pmtiles): https://source-cooperative-git-add-border-to-parque-871e31-radiantearth.vercel.app/vida/google-microsoft-osm-open-buildings/pmtiles/goog_msft_osm.pmtiles


---

Before

<img width="2433" height="1564" alt="Screenshot From 2025-09-24 14-18-26" src="https://github.com/user-attachments/assets/a980381e-0833-4937-b2de-76ba53505e92" />

<img width="2433" height="1564" alt="Screenshot From 2025-09-24 14-18-59" src="https://github.com/user-attachments/assets/d30bec63-a8ca-4a01-bb46-12270875b330" />

After

<img width="2433" height="1564" alt="Screenshot From 2025-09-24 14-17-42" src="https://github.com/user-attachments/assets/ef7be32e-d5b2-4657-aac5-d5fe553ae906" />

<img width="2433" height="1564" alt="Screenshot From 2025-09-24 14-19-30" src="https://github.com/user-attachments/assets/99a72416-8d67-40c2-8639-ee4608696033" />
