### PR TITLE
Parquet border

### DIFF
--- a/src/components/features/products/object-browser/ObjectPreview.tsx
+++ b/src/components/features/products/object-browser/ObjectPreview.tsx
@@ -18,7 +18,7 @@ const getIframeAttributes = (
       };
     case "parquet":
       return {
-        src: `https://source-cooperative.github.io/parquet-table/?iframe&url=${sourceUrl}`,
+        src: `https://source-cooperative.github.io/parquet-table/?iframe=true&url=${sourceUrl}`,
         style: { border: "1px solid var(--gray-5)" },
       };
     default:

--- a/src/components/features/products/object-browser/ObjectPreview.tsx
+++ b/src/components/features/products/object-browser/ObjectPreview.tsx
@@ -19,6 +19,7 @@ const getIframeAttributes = (
     case "parquet":
       return {
         src: `https://source-cooperative.github.io/parquet-table/?iframe&url=${sourceUrl}`,
+        style: { border: "1px solid var(--gray-5)" },
       };
     default:
       return null;


### PR DESCRIPTION
## What I'm changing

Adding a `1px solid var(--gray-5)` border to Parquet iframes that matches other borders used throughout the application. Also setting the iframe parameter to `iframe=true` in the URLs used to load parquet files into the iframe. This removes the redundant display of the parquet object's URL in the iframe.