### PR TITLE
add iframe=true to COG viewer iframe URL [#169]

### DIFF
--- a/src/components/features/products/object-browser/ObjectPreview.tsx
+++ b/src/components/features/products/object-browser/ObjectPreview.tsx
@@ -13,7 +13,7 @@ const getIframeAttributes = (
   switch (sourceUrl.split(".").pop()) {
     case "pmtiles":
       return {
-        src: `https://pmtiles.io/#url=${sourceUrl}&iframe=true`,
+        src: `https://pmtiles.io/#iframe=true&url=${sourceUrl}`,
         style: { border: "none" },
       };
     case "parquet":
@@ -23,7 +23,7 @@ const getIframeAttributes = (
       };
     case "tif":
       return {
-        src: `https://cogeo.org/viewer/#url=${sourceUrl}`,
+        src: `https://cogeo.org/viewer/#iframe=true&url=${sourceUrl}`,
         style: { border: "none" },
       }
     default:


### PR DESCRIPTION
## What I'm changing

Add `#iframe=true` to COG viewer to hide parts of the UI. 

## How you can test it

The embedded COG preview should appear. In this state it should be good enough for most COGs on source that don't use zstd compression. 