### PR TITLE
Add CSV preview

### DIFF
--- a/src/components/features/products/object-browser/ObjectPreview.tsx
+++ b/src/components/features/products/object-browser/ObjectPreview.tsx
@@ -21,6 +21,12 @@ const getIframeAttributes = (
         src: `https://source-cooperative.github.io/parquet-table/?iframe=true&url=${sourceUrl}`,
         style: { border: "1px solid var(--gray-5)" },
       };
+    case "csv":
+    case "tsv":
+      return {
+        src: `https://source-cooperative.github.io/csv-table/?iframe=true&url=${sourceUrl}`,
+        style: { border: "1px solid var(--gray-5)" },
+      };
     default:
       return null;
   }


### PR DESCRIPTION
## What I'm changing

Add an iframe to preview CSV/TSV files

## How I did it

When the file extension is csv or tsv, set the iframe source to https://source-cooperative.github.io/csv-table/.

## How you can test it

https://source-cooperative-git-preview-csv-radiantearth.vercel.app/jrc-lucas/jrc-lucas-ml/ml_data/classes_dataset.csv

https://source-cooperative-git-preview-csv-radiantearth.vercel.app/jrc-lucas/jrc-lucas-ml/ml_data/lucas_ml_data.csv

To test on bigger files (not hosted in source.coop):

https://source-cooperative.github.io/csv-table/?url=https://huggingface.co/datasets/Codatta/MM-Food-100K/resolve/main/MM-Food-100K.csv

https://source-cooperative.github.io/csv-table/?url=https://huggingface.co/datasets/Mosab-Rezaei/19th-century-novelists/resolve/main/Dataset%20-%20Five%20Authors%20.csv

http://source-cooperative.github.io/csv-table/?url=https://huggingface.co/datasets/starmpcc/Asclepius-Synthetic-Clinical-Notes/resolve/main/synthetic.csv

---

The viewer is here https://source-cooperative.github.io/csv-table/

(code: https://github.com/source-cooperative/csv-table, based on https://github.com/severo/csv-range/)