### PR TITLE
feat: display organization members on product membership form

### DIFF
--- a/src/app/edit/product/[account_id]/[product_id]/memberships/page.tsx
+++ b/src/app/edit/product/[account_id]/[product_id]/memberships/page.tsx
@@ -107,7 +107,7 @@ export default async function MembershipsPage({ params }: PageProps) {
           Product Members
         </Text>
         <Text size="2" color="gray">
-          The following users have been explicitly granted access to the product
+          The following users have been explicitly granted access to this product
         </Text>
         <MembershipsTable
           memberships={activeMemberships}
@@ -123,7 +123,7 @@ export default async function MembershipsPage({ params }: PageProps) {
           Organization Members
         </Text>
         <Text size="2" color="gray">
-          The following users have implicit access to the product via their{" "}
+          The following users have implicit access to this product via their{" "}
           <Link href={editAccountMembershipsUrl(account_id)}>
             organization membership
           </Link>
@@ -134,7 +134,7 @@ export default async function MembershipsPage({ params }: PageProps) {
           userSession={userSession}
           emptyStateMessage="No organization members"
           emptyStateDescription="Organization has no members"
-          showActions={false}
+          editable={false}
         />
       </Box>
     </Box>

--- a/src/components/features/settings/MembershipsTable.tsx
+++ b/src/components/features/settings/MembershipsTable.tsx
@@ -22,7 +22,7 @@ interface MembershipsTableProps {
   userSession: UserSession;
   emptyStateMessage: string;
   emptyStateDescription: string;
-  showActions?: boolean;
+  editable?: boolean;
 }
 
 export function MembershipsTable({
@@ -31,7 +31,7 @@ export function MembershipsTable({
   userSession,
   emptyStateMessage,
   emptyStateDescription,
-  showActions = true,
+  editable = true,
 }: MembershipsTableProps) {
   // Helper function to check if user can revoke a membership
   const canRevokeMembership = (membership: Membership) =>
@@ -81,7 +81,7 @@ export function MembershipsTable({
   return (
     <>
       {/* Hidden forms outside the table */}
-      {showActions && memberships.map((membership) => {
+      {editable && memberships.map((membership) => {
         const formId = `membership-form-${membership.membership_id}`;
         return (
           <Form
@@ -104,9 +104,11 @@ export function MembershipsTable({
           <Table.Row>
             <Table.ColumnHeaderCell>Member</Table.ColumnHeaderCell>
             <Table.ColumnHeaderCell>Role</Table.ColumnHeaderCell>
-            <Table.ColumnHeaderCell>Status</Table.ColumnHeaderCell>
-            <Table.ColumnHeaderCell>Last Updated</Table.ColumnHeaderCell>
-            {showActions && <Table.ColumnHeaderCell>Actions</Table.ColumnHeaderCell>}
+            {editable && <>
+              <Table.ColumnHeaderCell>Status</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Last Updated</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Actions</Table.ColumnHeaderCell>
+            </>}
           </Table.Row>
         </Table.Header>
         <Table.Body>
@@ -141,32 +143,32 @@ export function MembershipsTable({
                     }[membership.role] || "Unknown"}
                   </Badge>
                 </Table.Cell>
-                <Table.Cell>
-                  <Text
-                    size="2"
-                    color={
-                      ({
-                        [MembershipState.Member]: "green",
-                        [MembershipState.Invited]: "blue",
-                        [MembershipState.Revoked]: "red",
-                      }[membership.state] || "gray") as React.ComponentProps<
-                        typeof Text
-                      >["color"]
-                    }
-                  >
-                    {{
-                      [MembershipState.Member]: "Member",
-                      [MembershipState.Invited]: "Invited",
-                      [MembershipState.Revoked]: "Revoked",
-                    }[membership.state] || "Unknown"}
-                  </Text>
-                </Table.Cell>
-                <Table.Cell>
-                  <Text size="2" color="gray">
-                    {new Date(membership.state_changed).toLocaleDateString()}
-                  </Text>
-                </Table.Cell>
-                {showActions && (
+                {editable && <>
+                  <Table.Cell>
+                    <Text
+                      size="2"
+                      color={
+                        ({
+                          [MembershipState.Member]: "green",
+                          [MembershipState.Invited]: "blue",
+                          [MembershipState.Revoked]: "red",
+                        }[membership.state] || "gray") as React.ComponentProps<
+                          typeof Text
+                        >["color"]
+                      }
+                    >
+                      {{
+                        [MembershipState.Member]: "Member",
+                        [MembershipState.Invited]: "Invited",
+                        [MembershipState.Revoked]: "Revoked",
+                      }[membership.state] || "Unknown"}
+                    </Text>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Text size="2" color="gray">
+                      {new Date(membership.state_changed).toLocaleDateString()}
+                    </Text>
+                  </Table.Cell>
                   <Table.Cell>
                     <Button
                       type="submit"
@@ -183,7 +185,7 @@ export function MembershipsTable({
                       Revoke
                     </Button>
                   </Table.Cell>
-                )}
+                </>}
               </Table.Row>
             );
           })}


### PR DESCRIPTION
## What I'm changing

Added a read-only table of organization members visible from the product membership admin.

<img width="1361" height="1125" alt="image" src="https://github.com/user-attachments/assets/8e52abbe-ba4c-4e60-afce-dd47b44bee32" />


<!--
  High-level summary of what is achieved by these changes.

  Optional: reference related issues.
-->

closes #195

## How I did it

<!--
  Lower-level details of the steps taken to achieve goal.

  Include:
    - considerations made when deciding how to implement feature
    - any changes to API that could impact the Data Proxy
-->

## How you can test it

<!--
  Instructions on how a reviewer can verify these changes.

  Consider including screenshots or video demonstrating feature.
-->

https://source-cooperative-git-fix-display-org-memb-57dcee-radiantearth.vercel.app/edit/product/harvard-lil/gov-data/memberships
