### PR TITLE
feat: Add viewers for images and 3D models

### DIFF
--- a/src/components/features/products/object-browser/ObjectPreview.tsx
+++ b/src/components/features/products/object-browser/ObjectPreview.tsx
@@ -33,6 +33,7 @@ const getIframeAttributes = (
     case "jpg":
     case "jpeg":
     case "svg":
+    case "tif":
     case "tiff":
     case "webp":
       return {


### PR DESCRIPTION
## What I'm changing

This adds `ObjectPreview` mappings for image and 3D model files.

## How I did it

I've transferred the [image-viewer](https://github.com/source-cooperative/image-viewer) and [model-viewer](https://github.com/source-cooperative/model-viewer) repos to the Source organization. Each app is deployed as a static GitHub Pages site that accepts a `url` parameter representing the file to preview.

## How you can test it

For image-viewer, pass an image file URL via the `url` parameter. Supported formats: JPEG, PNG, GIF, SVG, WebP, TIFF, AVIF, BMP. Examples:

* <https://source-cooperative.github.io/image-viewer/?url=https://data.source.coop/harvard-lil/smithsonian-open-access/media/nmah/NMAH-2003-24476.tif>
* <https://source-cooperative.github.io/image-viewer/?url=https://upload.wikimedia.org/wikipedia/commons/a/a2/Hannah_Cohoon%2C_Tree_of_Life_or_Blazaing_Tree%2C_1845.jpg>

Likewise, for model-viewer, pass a 3D model file URL via the `url` parameter. Supported formats: GLB, GLTF, OBJ, STL. Examples:

* <https://source-cooperative.github.io/model-viewer/?url=https://data.source.coop/harvard-lil/smithsonian-open-access/3d/009463d3-6f58-4f5b-8e60-915805a876ee/USNM_91201-150k-1024-low.glb>
* <https://source-cooperative.github.io/model-viewer/?url=https://data.source.coop/harvard-lil/smithsonian-open-access/3d/4f7c25e9-abd7-458e-a7f7-0fb39d86b211/USNM270807_mt2_right_0-20k-decimated-meshlab-webmulti.obj>
