### PR TITLE
feature: Add full screen support for ObjectPreview iframes

### DIFF
--- a/src/components/features/products/object-browser/ObjectPreview.tsx
+++ b/src/components/features/products/object-browser/ObjectPreview.tsx
@@ -59,7 +59,7 @@ export function ObjectPreview({ sourceUrl: cloudUri }: ObjectPreviewProps) {
     const { src, style } = iframeProps;
     return (
       <Box mt="4" pt="4" style={{ borderTop: "1px solid var(--gray-6)" }}>
-        <iframe width="100%" height="600px" style={style} src={src}>
+        <iframe width="100%" height="600px" allow="fullscreen" style={style} src={src}>
           Your browser does not support iframes.
         </iframe>
       </Box>


### PR DESCRIPTION
## What I'm changing

This change enables the ObjectPreview `iframe` element to launch full screen mode for viewers that request it, such as the image and 3D model viewers from https://github.com/source-cooperative/source.coop/pull/210.

## How I did it

I've added the permissions policy `allow="fullscreen"` to the `iframe` in ObjectPreview. This should let any current or future viewer launch full screen mode.

## How you can test it

On a preview branch where this feature is active, navigate to the following pages and click the "Toggle full screen" button within the preview `iframe`:

* https://source.coop/harvard-lil/smithsonian-open-access/media/nmnh/NMNH-00000406-000001.jpg
* https://source.coop/harvard-lil/smithsonian-open-access/3d/009463d3-6f58-4f5b-8e60-915805a876ee/USNM_91201-150k-1024-low.glb