### PR TITLE
feature: Add zip file viewer

### DIFF
--- a/src/components/features/products/object-browser/ObjectPreview.tsx
+++ b/src/components/features/products/object-browser/ObjectPreview.tsx
@@ -48,6 +48,11 @@ const getIframeAttributes = (
         src: `https://source-cooperative.github.io/model-viewer/?url=${sourceUrl}`,
         style: { border: "1px solid var(--gray-5)" },
       };
+    case "zip":
+      return {
+        src: `https://source-cooperative.github.io/zip-viewer/?url=${sourceUrl}`,
+        style: { border: "1px solid var(--gray-5)" },
+      };
     default:
       return null;
   }


### PR DESCRIPTION
## What I'm changing

This adds a viewer for `.zip` archive files to the ObjectPreview mappings. Users can browse the zip file's contents, including nested directories, using an interface similar to Source's default file navigator.

## How I did it

The app uses [zip.js](https://gildas-lormeau.github.io/zip.js) to scan and list the file's directory contents, and then displays the files in a hierarchy much like the main Source interface. There are some sanity checks to prevent the interface from blowing up (maximum 200 MB file; maximum 100 directories and files listed per view; maximum 10 directory levels deep).

Ideally, we could also use zip.js's support for HTTP range requests to prevent having the load the whole zip file. Any chance there are plans to add range request support to the proxy?

## How you can test it

The app is live on GitHub Pages here: <https://source-cooperative.github.io/zip-viewer>

Test it by passing a remote `.zip` file URL via the `url` param, like for example these BagIt archive files:

* <https://source-cooperative.github.io/zip-viewer/?url=https://data.source.coop/harvard-lil/gov-data/collections/data_gov/baffin-bay-region-narwhal-research-version-1/v1.zip>
* <https://source-cooperative.github.io/zip-viewer/?url=https://data.source.coop/harvard-lil/gov-data/collections/data_gov/seattle-pet-licenses-f092d/v1.zip>