### PR TITLE
disable TIFF preview until #221 is fixed

### DIFF
--- a/src/components/features/products/object-browser/ObjectPreviewExternal.tsx
+++ b/src/components/features/products/object-browser/ObjectPreviewExternal.tsx
@@ -74,15 +74,15 @@ const getIframeAttributes = async (
         src: `https://source-cooperative.github.io/csv-table/?iframe=true&url=${url}`,
         style: { border: "1px solid var(--gray-5)" },
       };
+    // TIFF is disabled until https://github.com/source-cooperative/source.coop/issues/221 is fixed.
+    // case "tif":
+    // case "tiff":
     case "avif":
     case "bmp":
     case "gif":
     case "jpg":
     case "jpeg":
     case "svg":
-    // case "tif":
-    // case "tiff":
-    // TIFF is disabled until https://github.com/source-cooperative/source.coop/issues/221 is fixed.
     case "webp":
       return {
         src: `https://source-cooperative.github.io/image-viewer/?url=${url}`,


### PR DESCRIPTION
## What I'm changing

Disabling object preview for .tif and .tiff, due to the bug #221.

## How I did it

Commenting .tif and .tiff in the switch case

## How you can test it

https://source-cooperative-git-remove-tiff-preview-radiantearth.vercel.app/kerner-lab/fields-of-the-world/austria/s2_images/window_a/g77_00002_10.tif

<img width="2400" height="1745" alt="Screenshot From 2026-02-16 15-09-35" src="https://github.com/user-attachments/assets/04934c6a-9f18-490c-9646-7166d68ca376" />
