### PR TITLE
fix: adjust grid column min-width to be responsive

### DIFF
--- a/src/components/features/products/ProductList.module.css
+++ b/src/components/features/products/ProductList.module.css
@@ -13,7 +13,7 @@
   padding: 0;
   width: 100%;
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(28rem, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(28rem, 100%), 1fr));
   gap: var(--space-4);
   position: relative;
   contain: content;


### PR DESCRIPTION
## What I'm changing

Rework CSS so that min width of grid list is at least 100% of container

## How I did it

Claude

## How you can test it

### Before

<img width="422" height="926" alt="image" src="https://github.com/user-attachments/assets/cdfa4809-1dc9-4ee2-8a28-6b247e77ce97" />

### After

<img width="421" height="925" alt="image" src="https://github.com/user-attachments/assets/c5e0b22b-9522-490c-9e19-61b5bfb92d28" />
