### PR TITLE
feat: data connection administration UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.env
 /.env.local
+/.worktrees
 
 # Created by https://www.toptal.com/developers/gitignore/api/osx,windows,linux,nextjs,react,node
 # Edit at https://www.toptal.com/developers/gitignore?templates=osx,windows,linux,nextjs,react,node

--- a/src/app/(app)/admin/data-connections/[data_connection_id]/page.tsx
+++ b/src/app/(app)/admin/data-connections/[data_connection_id]/page.tsx
@@ -1,0 +1,32 @@
+import { Flex, Heading } from "@radix-ui/themes";
+import { dataConnectionsTable } from "@/lib/clients";
+import { notFound } from "next/navigation";
+import { DataConnectionForm } from "@/components/features/data-connections";
+import { DeleteDataConnectionButton } from "@/components/features/data-connections";
+
+interface EditDataConnectionPageProps {
+  params: Promise<{ data_connection_id: string }>;
+}
+
+export default async function EditDataConnectionPage({
+  params,
+}: EditDataConnectionPageProps) {
+  const { data_connection_id } = await params;
+  const dataConnection = await dataConnectionsTable.fetchById(data_connection_id);
+
+  if (!dataConnection) {
+    notFound();
+  }
+
+  return (
+    <Flex direction="column" gap="4">
+      <Flex justify="between" align="center">
+        <Heading size="4">Edit Data Connection</Heading>
+        <DeleteDataConnectionButton
+          dataConnectionId={dataConnection.data_connection_id}
+        />
+      </Flex>
+      <DataConnectionForm mode="edit" dataConnection={dataConnection} />
+    </Flex>
+  );
+}

--- a/src/app/(app)/admin/data-connections/create/page.tsx
+++ b/src/app/(app)/admin/data-connections/create/page.tsx
@@ -1,0 +1,11 @@
+import { Flex, Heading } from "@radix-ui/themes";
+import { DataConnectionForm } from "@/components/features/data-connections";
+
+export default function CreateDataConnectionPage() {
+  return (
+    <Flex direction="column" gap="4">
+      <Heading size="4">Create Data Connection</Heading>
+      <DataConnectionForm mode="create" />
+    </Flex>
+  );
+}

--- a/src/app/(app)/admin/data-connections/layout.tsx
+++ b/src/app/(app)/admin/data-connections/layout.tsx
@@ -1,0 +1,35 @@
+import { ReactNode } from "react";
+import { Link1Icon } from "@radix-ui/react-icons";
+import {
+  SettingsLayout,
+  SettingsHeader,
+} from "@/components/features/settings";
+import { Heading } from "@radix-ui/themes";
+import { adminDataConnectionsUrl } from "@/lib/urls";
+
+interface DataConnectionsLayoutProps {
+  children: ReactNode;
+}
+
+export default function DataConnectionsLayout({
+  children,
+}: DataConnectionsLayoutProps) {
+  const menuItems = [
+    {
+      id: "data-connections",
+      label: "Data Connections",
+      href: adminDataConnectionsUrl(),
+      icon: <Link1Icon width="16" height="16" />,
+      condition: true,
+    },
+  ];
+
+  return (
+    <>
+      <SettingsHeader>
+        <Heading size="5">Admin</Heading>
+      </SettingsHeader>
+      <SettingsLayout menuItems={menuItems}>{children}</SettingsLayout>
+    </>
+  );
+}

--- a/src/app/(app)/admin/data-connections/page.tsx
+++ b/src/app/(app)/admin/data-connections/page.tsx
@@ -1,0 +1,95 @@
+import { dataConnectionsTable } from "@/lib/clients";
+import { Text, Table, Flex, Badge, Button, Heading } from "@radix-ui/themes";
+import { Link1Icon } from "@radix-ui/react-icons";
+import Link from "next/link";
+import {
+  adminDataConnectionCreateUrl,
+  adminDataConnectionEditUrl,
+} from "@/lib/urls";
+
+export default async function DataConnectionsPage() {
+  const connections = await dataConnectionsTable.listAll();
+
+  return (
+    <Flex direction="column" gap="4">
+      <Flex justify="between" align="center">
+        <Heading size="4">Data Connections</Heading>
+        <Button asChild size="2">
+          <Link href={adminDataConnectionCreateUrl()}>New Connection</Link>
+        </Button>
+      </Flex>
+
+      {connections.length === 0 ? (
+        <Flex
+          direction="column"
+          align="center"
+          gap="2"
+          py="8"
+          style={{ userSelect: "none" }}
+        >
+          <Link1Icon width="48" height="48" color="var(--gray-8)" />
+          <Text size="4" weight="medium" color="gray">
+            No data connections
+          </Text>
+          <Text size="2" color="gray">
+            Create a data connection to get started.
+          </Text>
+        </Flex>
+      ) : (
+        <Table.Root>
+          <Table.Header>
+            <Table.Row>
+              <Table.ColumnHeaderCell>Name</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>ID</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Provider</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Region</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Read Only</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Data Modes</Table.ColumnHeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {connections.map((conn) => (
+              <Table.Row key={conn.data_connection_id}>
+                <Table.Cell>
+                  <Link
+                    href={adminDataConnectionEditUrl(conn.data_connection_id)}
+                    style={{ color: "var(--accent-11)" }}
+                  >
+                    {conn.name}
+                  </Link>
+                </Table.Cell>
+                <Table.Cell>
+                  <Text size="2" style={{ fontFamily: "var(--code-font-family)" }}>
+                    {conn.data_connection_id}
+                  </Text>
+                </Table.Cell>
+                <Table.Cell>
+                  <Badge color={conn.details.provider === "s3" ? "orange" : "blue"}>
+                    {conn.details.provider === "s3" ? "S3" : "Azure"}
+                  </Badge>
+                </Table.Cell>
+                <Table.Cell>
+                  <Text size="2">{conn.details.region}</Text>
+                </Table.Cell>
+                <Table.Cell>
+                  <Badge color={conn.read_only ? "red" : "green"}>
+                    {conn.read_only ? "Yes" : "No"}
+                  </Badge>
+                </Table.Cell>
+                <Table.Cell>
+                  <Flex gap="1" wrap="wrap">
+                    {conn.allowed_data_modes.map((mode) => (
+                      <Badge key={mode} variant="soft" size="1">
+                        {mode}
+                      </Badge>
+                    ))}
+                  </Flex>
+                </Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table.Root>
+      )}
+    </Flex>
+  );
+}

--- a/src/app/(app)/admin/layout.tsx
+++ b/src/app/(app)/admin/layout.tsx
@@ -1,0 +1,24 @@
+import { ReactNode } from "react";
+import { getPageSession } from "@/lib/api/utils";
+import { isAdmin } from "@/lib/api/authz";
+import { notFound } from "next/navigation";
+import { CONFIG } from "@/lib/config";
+import { redirect } from "next/navigation";
+
+interface AdminLayoutProps {
+  children: ReactNode;
+}
+
+export default async function AdminLayout({ children }: AdminLayoutProps) {
+  const session = await getPageSession();
+
+  if (!session?.account) {
+    redirect(CONFIG.auth.routes.login);
+  }
+
+  if (!isAdmin(session)) {
+    notFound();
+  }
+
+  return <>{children}</>;
+}

--- a/src/app/(app)/edit/product/[account_id]/[product_id]/data-connections/page.tsx
+++ b/src/app/(app)/edit/product/[account_id]/[product_id]/data-connections/page.tsx
@@ -1,0 +1,36 @@
+import { getPageSession } from "@/lib/api/utils";
+import { isAdmin } from "@/lib/api/authz";
+import { productsTable, dataConnectionsTable } from "@/lib/clients";
+import { notFound } from "next/navigation";
+import { ProductMirrorsManager } from "@/components/features/data-connections";
+
+interface ProductDataConnectionsPageProps {
+  params: Promise<{ account_id: string; product_id: string }>;
+}
+
+export default async function ProductDataConnectionsPage({
+  params,
+}: ProductDataConnectionsPageProps) {
+  const { account_id, product_id } = await params;
+
+  const session = await getPageSession();
+  const product = await productsTable.fetchById(account_id, product_id);
+
+  if (!product) {
+    notFound();
+  }
+
+  const userIsAdmin = isAdmin(session);
+
+  const availableConnections = userIsAdmin
+    ? await dataConnectionsTable.listAll()
+    : [];
+
+  return (
+    <ProductMirrorsManager
+      product={product}
+      availableConnections={availableConnections}
+      isAdmin={userIsAdmin}
+    />
+  );
+}

--- a/src/app/(app)/edit/product/[account_id]/[product_id]/layout.tsx
+++ b/src/app/(app)/edit/product/[account_id]/[product_id]/layout.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from "react";
-import { Pencil1Icon, PersonIcon } from "@radix-ui/react-icons";
+import { Pencil1Icon, PersonIcon, Link1Icon } from "@radix-ui/react-icons";
 import { Flex } from "@radix-ui/themes";
 import {
   SettingsLayout,
@@ -8,7 +8,7 @@ import {
   AccountSelector,
 } from "@/components/features/settings";
 import { getPageSession } from "@/lib/api/utils";
-import { isAuthorized } from "@/lib/api/authz";
+import { isAuthorized, isAdmin } from "@/lib/api/authz";
 import { Actions } from "@/types";
 import { productsTable } from "@/lib/clients/database";
 import { notFound, redirect } from "next/navigation";
@@ -18,6 +18,7 @@ import {
   productUrl,
   editProductDetailsUrl,
   editProductMembershipsUrl,
+  editProductDataConnectionsUrl,
 } from "@/lib/urls";
 import { getManageableAccounts } from "@/lib/clients/lookups";
 
@@ -80,6 +81,13 @@ export default async function ProductLayout({
       href: editProductMembershipsUrl(account_id, product_id),
       icon: <PersonIcon width="16" height="16" />,
       condition: canReadMembership,
+    },
+    {
+      id: "data-connections",
+      label: "Data Connections",
+      href: editProductDataConnectionsUrl(account_id, product_id),
+      icon: <Link1Icon width="16" height="16" />,
+      condition: canEditProduct || isAdmin(session),
     },
   ];
 

--- a/src/components/features/data-connections/DataConnectionForm.tsx
+++ b/src/components/features/data-connections/DataConnectionForm.tsx
@@ -141,7 +141,7 @@ export function DataConnectionForm({
             defaultValue={
               (state.data.get("prefix_template") as string) ||
               dataConnection?.prefix_template ||
-              "{account_id}/{repository_id}/"
+              "{{repository.account_id}}/{{repository.repository_id}}/"
             }
             style={fieldStyle}
           />

--- a/src/components/features/data-connections/DataConnectionForm.tsx
+++ b/src/components/features/data-connections/DataConnectionForm.tsx
@@ -1,0 +1,569 @@
+"use client";
+
+import React, { useState, useActionState } from "react";
+import { Button, Text, Flex, Checkbox } from "@radix-ui/themes";
+import Form from "next/form";
+import {
+  DataConnection,
+  DataProvider,
+  DataConnectionAuthenticationType,
+  S3Regions,
+  AzureRegions,
+  RepositoryDataMode,
+  AccountFlags,
+} from "@/types";
+import {
+  createDataConnection,
+  updateDataConnection,
+} from "@/lib/actions/data-connections";
+
+interface DataConnectionFormProps {
+  dataConnection?: DataConnection;
+  mode: "create" | "edit";
+}
+
+const fieldStyle: React.CSSProperties = {
+  fontFamily: "var(--code-font-family)",
+  width: "100%",
+  padding: "8px 12px",
+  borderRadius: "0",
+  border: "1px solid var(--gray-6)",
+  fontSize: "16px",
+  lineHeight: "1.5",
+  boxSizing: "border-box",
+};
+
+const s3AuthTypes = [
+  DataConnectionAuthenticationType.S3ECSTaskRole,
+  DataConnectionAuthenticationType.S3AccessKey,
+  DataConnectionAuthenticationType.S3IAMRole,
+  DataConnectionAuthenticationType.S3Local,
+];
+
+const azureAuthTypes = [DataConnectionAuthenticationType.AzureSasToken];
+
+export function DataConnectionForm({
+  dataConnection,
+  mode,
+}: DataConnectionFormProps) {
+  const action = mode === "create" ? createDataConnection : updateDataConnection;
+
+  const [state, formAction, pending] = useActionState(action, {
+    message: "",
+    data: new FormData(),
+    fieldErrors: {},
+    success: false,
+  });
+
+  const [provider, setProvider] = useState<string>(
+    dataConnection?.details.provider || DataProvider.S3
+  );
+
+  const [authType, setAuthType] = useState<string>(
+    dataConnection?.authentication?.type || ""
+  );
+
+  // Reset auth type when provider changes
+  const handleProviderChange = (value: string) => {
+    setProvider(value);
+    setAuthType("");
+  };
+
+  const authOptions =
+    provider === DataProvider.S3 ? s3AuthTypes : azureAuthTypes;
+
+  return (
+    <Form action={formAction}>
+      <Flex direction="column" gap="4">
+        {/* Connection ID */}
+        <Flex direction="column" gap="1">
+          <Text size="3" weight="medium">
+            Connection ID
+          </Text>
+          <input
+            type="text"
+            name="data_connection_id"
+            required
+            placeholder="my-data-connection"
+            readOnly={mode === "edit"}
+            defaultValue={
+              (state.data.get("data_connection_id") as string) ||
+              dataConnection?.data_connection_id ||
+              ""
+            }
+            style={{
+              ...fieldStyle,
+              ...(mode === "edit"
+                ? { backgroundColor: "var(--gray-3)", cursor: "not-allowed" }
+                : {}),
+            }}
+          />
+          {state.fieldErrors?.data_connection_id?.map(
+            (error: string, index: number) => (
+              <Text size="1" color="red" key={`data_connection_id-${index}`}>
+                {error}
+              </Text>
+            )
+          )}
+        </Flex>
+
+        {/* Name */}
+        <Flex direction="column" gap="1">
+          <Text size="3" weight="medium">
+            Name
+          </Text>
+          <input
+            type="text"
+            name="name"
+            required
+            defaultValue={
+              (state.data.get("name") as string) ||
+              dataConnection?.name ||
+              ""
+            }
+            style={fieldStyle}
+          />
+          {state.fieldErrors?.name?.map((error: string, index: number) => (
+            <Text size="1" color="red" key={`name-${index}`}>
+              {error}
+            </Text>
+          ))}
+        </Flex>
+
+        {/* Prefix Template */}
+        <Flex direction="column" gap="1">
+          <Text size="3" weight="medium">
+            Prefix Template
+          </Text>
+          <input
+            type="text"
+            name="prefix_template"
+            defaultValue={
+              (state.data.get("prefix_template") as string) ||
+              dataConnection?.prefix_template ||
+              "{account_id}/{repository_id}/"
+            }
+            style={fieldStyle}
+          />
+          {state.fieldErrors?.prefix_template?.map(
+            (error: string, index: number) => (
+              <Text size="1" color="red" key={`prefix_template-${index}`}>
+                {error}
+              </Text>
+            )
+          )}
+        </Flex>
+
+        {/* Read Only */}
+        <Flex direction="column" gap="1">
+          <Text size="3" weight="medium">
+            Read Only
+          </Text>
+          <Flex align="center" gap="2">
+            <Checkbox
+              name="read_only"
+              defaultChecked={dataConnection?.read_only || false}
+            />
+            <Text size="2">Connection is read-only</Text>
+          </Flex>
+        </Flex>
+
+        {/* Allowed Data Modes */}
+        <Flex direction="column" gap="1">
+          <Text size="3" weight="medium">
+            Allowed Data Modes
+          </Text>
+          <Flex direction="column" gap="2">
+            {Object.values(RepositoryDataMode).map((modeValue) => (
+              <Flex align="center" gap="2" key={modeValue}>
+                <Checkbox
+                  name={`mode_${modeValue}`}
+                  defaultChecked={
+                    dataConnection?.allowed_data_modes?.includes(modeValue) ||
+                    false
+                  }
+                />
+                <Text size="2">{modeValue}</Text>
+              </Flex>
+            ))}
+          </Flex>
+          {state.fieldErrors?.allowed_data_modes?.map(
+            (error: string, index: number) => (
+              <Text size="1" color="red" key={`allowed_data_modes-${index}`}>
+                {error}
+              </Text>
+            )
+          )}
+        </Flex>
+
+        {/* Required Flag */}
+        <Flex direction="column" gap="1">
+          <Text size="3" weight="medium">
+            Required Flag
+          </Text>
+          <select
+            name="required_flag"
+            defaultValue={
+              (state.data.get("required_flag") as string) ||
+              dataConnection?.required_flag ||
+              ""
+            }
+            style={fieldStyle}
+          >
+            <option value="">None</option>
+            {Object.values(AccountFlags).map((flag) => (
+              <option key={flag} value={flag}>
+                {flag}
+              </option>
+            ))}
+          </select>
+          {state.fieldErrors?.required_flag?.map(
+            (error: string, index: number) => (
+              <Text size="1" color="red" key={`required_flag-${index}`}>
+                {error}
+              </Text>
+            )
+          )}
+        </Flex>
+
+        {/* Provider */}
+        <Flex direction="column" gap="1">
+          <Text size="3" weight="medium">
+            Provider
+          </Text>
+          <select
+            name="provider"
+            value={provider}
+            onChange={(e) => handleProviderChange(e.target.value)}
+            style={fieldStyle}
+          >
+            {Object.values(DataProvider).map((p) => (
+              <option key={p} value={p}>
+                {p === DataProvider.S3
+                  ? "S3"
+                  : p === DataProvider.Azure
+                    ? "Azure"
+                    : p}
+              </option>
+            ))}
+          </select>
+          {state.fieldErrors?.provider?.map(
+            (error: string, index: number) => (
+              <Text size="1" color="red" key={`provider-${index}`}>
+                {error}
+              </Text>
+            )
+          )}
+        </Flex>
+
+        {/* Provider-specific fields */}
+        {provider === DataProvider.S3 && (
+          <>
+            <Flex direction="column" gap="1">
+              <Text size="3" weight="medium">
+                Bucket
+              </Text>
+              <input
+                type="text"
+                name="bucket"
+                defaultValue={
+                  (state.data.get("bucket") as string) ||
+                  (dataConnection?.details.provider === "s3"
+                    ? dataConnection.details.bucket
+                    : "")
+                }
+                style={fieldStyle}
+              />
+              {state.fieldErrors?.bucket?.map(
+                (error: string, index: number) => (
+                  <Text size="1" color="red" key={`bucket-${index}`}>
+                    {error}
+                  </Text>
+                )
+              )}
+            </Flex>
+
+            <Flex direction="column" gap="1">
+              <Text size="3" weight="medium">
+                Base Prefix
+              </Text>
+              <input
+                type="text"
+                name="base_prefix"
+                defaultValue={
+                  (state.data.get("base_prefix") as string) ||
+                  (dataConnection?.details.provider === "s3"
+                    ? dataConnection.details.base_prefix
+                    : "")
+                }
+                style={fieldStyle}
+              />
+              {state.fieldErrors?.base_prefix?.map(
+                (error: string, index: number) => (
+                  <Text size="1" color="red" key={`base_prefix-${index}`}>
+                    {error}
+                  </Text>
+                )
+              )}
+            </Flex>
+
+            <Flex direction="column" gap="1">
+              <Text size="3" weight="medium">
+                Region
+              </Text>
+              <select
+                name="region"
+                defaultValue={
+                  (state.data.get("region") as string) ||
+                  (dataConnection?.details.provider === "s3"
+                    ? dataConnection.details.region
+                    : "")
+                }
+                style={fieldStyle}
+              >
+                <option value="" disabled>
+                  Select a region
+                </option>
+                {Object.values(S3Regions).map((region) => (
+                  <option key={region} value={region}>
+                    {region}
+                  </option>
+                ))}
+              </select>
+              {state.fieldErrors?.region?.map(
+                (error: string, index: number) => (
+                  <Text size="1" color="red" key={`region-${index}`}>
+                    {error}
+                  </Text>
+                )
+              )}
+            </Flex>
+          </>
+        )}
+
+        {provider === DataProvider.Azure && (
+          <>
+            <Flex direction="column" gap="1">
+              <Text size="3" weight="medium">
+                Account Name
+              </Text>
+              <input
+                type="text"
+                name="account_name"
+                defaultValue={
+                  (state.data.get("account_name") as string) ||
+                  (dataConnection?.details.provider === "az"
+                    ? dataConnection.details.account_name
+                    : "")
+                }
+                style={fieldStyle}
+              />
+              {state.fieldErrors?.account_name?.map(
+                (error: string, index: number) => (
+                  <Text size="1" color="red" key={`account_name-${index}`}>
+                    {error}
+                  </Text>
+                )
+              )}
+            </Flex>
+
+            <Flex direction="column" gap="1">
+              <Text size="3" weight="medium">
+                Container Name
+              </Text>
+              <input
+                type="text"
+                name="container_name"
+                defaultValue={
+                  (state.data.get("container_name") as string) ||
+                  (dataConnection?.details.provider === "az"
+                    ? dataConnection.details.container_name
+                    : "")
+                }
+                style={fieldStyle}
+              />
+              {state.fieldErrors?.container_name?.map(
+                (error: string, index: number) => (
+                  <Text size="1" color="red" key={`container_name-${index}`}>
+                    {error}
+                  </Text>
+                )
+              )}
+            </Flex>
+
+            <Flex direction="column" gap="1">
+              <Text size="3" weight="medium">
+                Base Prefix
+              </Text>
+              <input
+                type="text"
+                name="base_prefix"
+                defaultValue={
+                  (state.data.get("base_prefix") as string) ||
+                  (dataConnection?.details.provider === "az"
+                    ? dataConnection.details.base_prefix
+                    : "")
+                }
+                style={fieldStyle}
+              />
+              {state.fieldErrors?.base_prefix?.map(
+                (error: string, index: number) => (
+                  <Text size="1" color="red" key={`base_prefix-${index}`}>
+                    {error}
+                  </Text>
+                )
+              )}
+            </Flex>
+
+            <Flex direction="column" gap="1">
+              <Text size="3" weight="medium">
+                Region
+              </Text>
+              <select
+                name="region"
+                defaultValue={
+                  (state.data.get("region") as string) ||
+                  (dataConnection?.details.provider === "az"
+                    ? dataConnection.details.region
+                    : "")
+                }
+                style={fieldStyle}
+              >
+                <option value="" disabled>
+                  Select a region
+                </option>
+                {Object.values(AzureRegions).map((region) => (
+                  <option key={region} value={region}>
+                    {region}
+                  </option>
+                ))}
+              </select>
+              {state.fieldErrors?.region?.map(
+                (error: string, index: number) => (
+                  <Text size="1" color="red" key={`region-${index}`}>
+                    {error}
+                  </Text>
+                )
+              )}
+            </Flex>
+          </>
+        )}
+
+        {/* Authentication Type */}
+        <Flex direction="column" gap="1">
+          <Text size="3" weight="medium">
+            Authentication Type
+          </Text>
+          <select
+            name="auth_type"
+            value={authType}
+            onChange={(e) => setAuthType(e.target.value)}
+            style={fieldStyle}
+          >
+            <option value="" disabled>
+              Select authentication type
+            </option>
+            {authOptions.map((type) => (
+              <option key={type} value={type}>
+                {type}
+              </option>
+            ))}
+          </select>
+          {state.fieldErrors?.auth_type?.map(
+            (error: string, index: number) => (
+              <Text size="1" color="red" key={`auth_type-${index}`}>
+                {error}
+              </Text>
+            )
+          )}
+        </Flex>
+
+        {/* Auth-specific fields */}
+        {authType === DataConnectionAuthenticationType.S3AccessKey && (
+          <>
+            <Flex direction="column" gap="1">
+              <Text size="3" weight="medium">
+                Access Key ID
+              </Text>
+              <input
+                type="text"
+                name="access_key_id"
+                defaultValue={
+                  (state.data.get("access_key_id") as string) || ""
+                }
+                style={fieldStyle}
+              />
+              {state.fieldErrors?.access_key_id?.map(
+                (error: string, index: number) => (
+                  <Text size="1" color="red" key={`access_key_id-${index}`}>
+                    {error}
+                  </Text>
+                )
+              )}
+            </Flex>
+
+            <Flex direction="column" gap="1">
+              <Text size="3" weight="medium">
+                Secret Access Key
+              </Text>
+              <input
+                type="password"
+                name="secret_access_key"
+                defaultValue={
+                  (state.data.get("secret_access_key") as string) || ""
+                }
+                style={fieldStyle}
+              />
+              {state.fieldErrors?.secret_access_key?.map(
+                (error: string, index: number) => (
+                  <Text
+                    size="1"
+                    color="red"
+                    key={`secret_access_key-${index}`}
+                  >
+                    {error}
+                  </Text>
+                )
+              )}
+            </Flex>
+          </>
+        )}
+
+        {authType === DataConnectionAuthenticationType.AzureSasToken && (
+          <Flex direction="column" gap="1">
+            <Text size="3" weight="medium">
+              SAS Token
+            </Text>
+            <input
+              type="password"
+              name="sas_token"
+              defaultValue={(state.data.get("sas_token") as string) || ""}
+              style={fieldStyle}
+            />
+            {state.fieldErrors?.sas_token?.map(
+              (error: string, index: number) => (
+                <Text size="1" color="red" key={`sas_token-${index}`}>
+                  {error}
+                </Text>
+              )
+            )}
+          </Flex>
+        )}
+
+        {/* Submit */}
+        <Flex mt="4" justify="end">
+          <Flex direction="column" gap="2">
+            <Button size="3" type="submit" disabled={pending} loading={pending}>
+              {mode === "create" ? "Create Connection" : "Update Connection"}
+            </Button>
+            {state?.message && (
+              <Text size="1" color={state.success ? "green" : "red"}>
+                {state.message}
+              </Text>
+            )}
+          </Flex>
+        </Flex>
+      </Flex>
+    </Form>
+  );
+}

--- a/src/components/features/data-connections/DeleteDataConnectionButton.tsx
+++ b/src/components/features/data-connections/DeleteDataConnectionButton.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useActionState } from "react";
+import { Button, Text, Flex, AlertDialog } from "@radix-ui/themes";
+import Form from "next/form";
+import { deleteDataConnection } from "@/lib/actions/data-connections";
+
+interface DeleteDataConnectionButtonProps {
+  dataConnectionId: string;
+}
+
+export function DeleteDataConnectionButton({
+  dataConnectionId,
+}: DeleteDataConnectionButtonProps) {
+  const [state, formAction, pending] = useActionState(deleteDataConnection, {
+    message: "",
+    data: new FormData(),
+    fieldErrors: {},
+    success: false,
+  });
+
+  return (
+    <AlertDialog.Root>
+      <AlertDialog.Trigger>
+        <Button size="2" color="red" variant="soft">
+          Delete
+        </Button>
+      </AlertDialog.Trigger>
+      <AlertDialog.Content maxWidth="450px">
+        <AlertDialog.Title>Delete Data Connection</AlertDialog.Title>
+        <AlertDialog.Description>
+          Are you sure you want to delete this data connection? This action
+          cannot be undone. Products using this connection may be affected.
+        </AlertDialog.Description>
+        <Flex gap="3" mt="4" justify="end">
+          <AlertDialog.Cancel>
+            <Button variant="soft" color="gray">
+              Cancel
+            </Button>
+          </AlertDialog.Cancel>
+          <AlertDialog.Action>
+            <Form action={formAction}>
+              <input
+                type="hidden"
+                name="data_connection_id"
+                value={dataConnectionId}
+              />
+              <Button
+                type="submit"
+                color="red"
+                disabled={pending}
+                loading={pending}
+              >
+                Delete
+              </Button>
+            </Form>
+          </AlertDialog.Action>
+        </Flex>
+        {state.message && !state.success && (
+          <Text size="1" color="red" mt="2">
+            {state.message}
+          </Text>
+        )}
+      </AlertDialog.Content>
+    </AlertDialog.Root>
+  );
+}

--- a/src/components/features/data-connections/ProductMirrorsManager.tsx
+++ b/src/components/features/data-connections/ProductMirrorsManager.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useActionState } from "react";
+import {
+  Text,
+  Table,
+  Flex,
+  Badge,
+  Button,
+  Heading,
+} from "@radix-ui/themes";
+import { Link1Icon } from "@radix-ui/react-icons";
+import Form from "next/form";
+import { DataConnection, Product } from "@/types";
+import {
+  addProductMirror,
+  removeProductMirror,
+  setPrimaryMirror,
+} from "@/lib/actions/product-mirrors";
+
+interface ProductMirrorsManagerProps {
+  product: Product;
+  availableConnections: DataConnection[];
+  isAdmin: boolean;
+}
+
+export function ProductMirrorsManager({
+  product,
+  availableConnections,
+  isAdmin,
+}: ProductMirrorsManagerProps) {
+  const [addState, addAction, addPending] = useActionState(addProductMirror, {
+    message: "",
+    data: new FormData(),
+    fieldErrors: {},
+    success: false,
+  });
+
+  const [removeState, removeAction, removePending] = useActionState(
+    removeProductMirror,
+    { message: "", data: new FormData(), fieldErrors: {}, success: false }
+  );
+
+  const [primaryState, primaryAction, primaryPending] = useActionState(
+    setPrimaryMirror,
+    { message: "", data: new FormData(), fieldErrors: {}, success: false }
+  );
+
+  const mirrors = Object.entries(product.metadata.mirrors);
+
+  const usedConnectionIds = new Set(
+    mirrors.map(([_, mirror]) => mirror.connection_id)
+  );
+  const unusedConnections = availableConnections.filter(
+    (conn) => !usedConnectionIds.has(conn.data_connection_id)
+  );
+
+  return (
+    <Flex direction="column" gap="4">
+      <Heading size="4">Data Connections</Heading>
+
+      {mirrors.length === 0 ? (
+        <Flex
+          direction="column"
+          align="center"
+          gap="2"
+          py="8"
+          style={{ userSelect: "none" }}
+        >
+          <Link1Icon width="48" height="48" color="var(--gray-8)" />
+          <Text size="4" weight="medium" color="gray">
+            No data connections
+          </Text>
+          <Text size="2" color="gray">
+            {isAdmin
+              ? "Add a data connection to this product."
+              : "No data connections have been configured for this product."}
+          </Text>
+        </Flex>
+      ) : (
+        <Table.Root>
+          <Table.Header>
+            <Table.Row>
+              <Table.ColumnHeaderCell>Connection</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Provider</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Region</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Primary</Table.ColumnHeaderCell>
+              {isAdmin && (
+                <Table.ColumnHeaderCell>Actions</Table.ColumnHeaderCell>
+              )}
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {mirrors.map(([key, mirror]) => (
+              <Table.Row key={key}>
+                <Table.Cell>
+                  <Text size="2" style={{ fontFamily: "var(--code-font-family)" }}>
+                    {key}
+                  </Text>
+                </Table.Cell>
+                <Table.Cell>
+                  <Badge color={mirror.storage_type === "s3" ? "orange" : "blue"}>
+                    {mirror.storage_type === "s3" ? "S3" : "Azure"}
+                  </Badge>
+                </Table.Cell>
+                <Table.Cell>
+                  <Text size="2">{mirror.config.region || "-"}</Text>
+                </Table.Cell>
+                <Table.Cell>
+                  {mirror.is_primary ? (
+                    <Badge color="green">Primary</Badge>
+                  ) : isAdmin ? (
+                    <Form action={primaryAction} style={{ display: "inline" }}>
+                      <input type="hidden" name="account_id" value={product.account_id} />
+                      <input type="hidden" name="product_id" value={product.product_id} />
+                      <input type="hidden" name="mirror_key" value={key} />
+                      <Button type="submit" size="1" variant="soft" disabled={primaryPending} loading={primaryPending}>
+                        Set Primary
+                      </Button>
+                    </Form>
+                  ) : (
+                    <Text size="2" color="gray">-</Text>
+                  )}
+                </Table.Cell>
+                {isAdmin && (
+                  <Table.Cell>
+                    <Form action={removeAction} style={{ display: "inline" }}>
+                      <input type="hidden" name="account_id" value={product.account_id} />
+                      <input type="hidden" name="product_id" value={product.product_id} />
+                      <input type="hidden" name="mirror_key" value={key} />
+                      <Button type="submit" size="1" variant="soft" color="red" disabled={removePending} loading={removePending}>
+                        Remove
+                      </Button>
+                    </Form>
+                  </Table.Cell>
+                )}
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table.Root>
+      )}
+
+      {removeState.message && (
+        <Text size="2" color={removeState.success ? "green" : "red"}>{removeState.message}</Text>
+      )}
+      {primaryState.message && (
+        <Text size="2" color={primaryState.success ? "green" : "red"}>{primaryState.message}</Text>
+      )}
+
+      {isAdmin && unusedConnections.length > 0 && (
+        <Flex direction="column" gap="2">
+          <Text size="3" weight="medium">Add Data Connection</Text>
+          <Form action={addAction}>
+            <input type="hidden" name="account_id" value={product.account_id} />
+            <input type="hidden" name="product_id" value={product.product_id} />
+            <Flex gap="2" align="end">
+              <select
+                name="connection_id"
+                required
+                style={{
+                  fontFamily: "var(--code-font-family)",
+                  padding: "8px 12px",
+                  border: "1px solid var(--gray-6)",
+                  fontSize: "16px",
+                  lineHeight: "1.5",
+                  flex: 1,
+                }}
+              >
+                <option value="" disabled>Select a data connection...</option>
+                {unusedConnections.map((conn) => (
+                  <option key={conn.data_connection_id} value={conn.data_connection_id}>
+                    {conn.name} ({conn.details.provider} - {conn.details.region})
+                  </option>
+                ))}
+              </select>
+              <Button type="submit" size="2" disabled={addPending} loading={addPending}>
+                Add
+              </Button>
+            </Flex>
+          </Form>
+          {addState.message && (
+            <Text size="2" color={addState.success ? "green" : "red"}>{addState.message}</Text>
+          )}
+        </Flex>
+      )}
+    </Flex>
+  );
+}

--- a/src/components/features/data-connections/index.ts
+++ b/src/components/features/data-connections/index.ts
@@ -1,0 +1,3 @@
+export { DataConnectionForm } from "./DataConnectionForm";
+export { DeleteDataConnectionButton } from "./DeleteDataConnectionButton";
+export { ProductMirrorsManager } from "./ProductMirrorsManager";

--- a/src/components/layout/AccountDropdown.tsx
+++ b/src/components/layout/AccountDropdown.tsx
@@ -10,9 +10,10 @@ import {
   editAccountProfileUrl,
   newOrganizationUrl,
   newProductUrl,
+  adminDataConnectionsUrl,
 } from "@/lib";
 import { DropdownSection } from "./DropdownSection";
-import { isAuthorized } from "@/lib/api/authz";
+import { isAuthorized, isAdmin } from "@/lib/api/authz";
 import { Actions, UserSession } from "@/types";
 import { ProfileAvatar } from "@/components/features/profiles/ProfileAvatar";
 import { UploadBadge } from "@/components/features/uploader/UploadBadge";
@@ -99,6 +100,16 @@ export function AccountDropdown({ session }: { session: UserSession }) {
               href: newProductUrl(),
               children: "Create Product",
               condition: isAuthorized(session, "*", Actions.CreateRepository),
+            },
+          ]}
+        />
+        <DropdownSection
+          label="Admin"
+          items={[
+            {
+              href: adminDataConnectionsUrl(),
+              children: "Data Connections",
+              condition: isAdmin(session),
             },
           ]}
         />

--- a/src/lib/actions/data-connections.ts
+++ b/src/lib/actions/data-connections.ts
@@ -1,0 +1,318 @@
+"use server";
+
+import { LOGGER } from "@/lib/logging";
+import {
+  Actions,
+  DataConnectionSchema,
+  DataConnection,
+  DataProvider,
+  DataConnectionAuthenticationType,
+} from "@/types";
+import { isAuthorized } from "../api/authz";
+import { getPageSession } from "../api/utils";
+import { dataConnectionsTable } from "../clients";
+import { FormState } from "@/components/core/DynamicForm";
+import { redirect } from "next/navigation";
+import { revalidatePath } from "next/cache";
+import { adminDataConnectionsUrl, adminDataConnectionEditUrl } from "@/lib/urls";
+
+export async function createDataConnection(
+  initialState: any,
+  formData: FormData
+): Promise<FormState<DataConnection>> {
+  const session = await getPageSession();
+
+  if (!session?.identity_id) {
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Unauthenticated",
+      success: false,
+    };
+  }
+
+  try {
+    const dataConnection = buildDataConnectionFromForm(formData);
+
+    const validated = DataConnectionSchema.safeParse(dataConnection);
+    if (!validated.success) {
+      return {
+        fieldErrors: validated.error.flatten().fieldErrors,
+        data: formData,
+        message: "Invalid form data",
+        success: false,
+      };
+    }
+
+    if (
+      !isAuthorized(session, validated.data, Actions.CreateDataConnection)
+    ) {
+      return {
+        fieldErrors: {},
+        data: formData,
+        message: "Unauthorized to create data connections",
+        success: false,
+      };
+    }
+
+    const existing = await dataConnectionsTable.fetchById(
+      validated.data.data_connection_id
+    );
+    if (existing) {
+      return {
+        fieldErrors: {
+          data_connection_id: ["A data connection with this ID already exists"],
+        },
+        data: formData,
+        message: "Data connection ID already exists",
+        success: false,
+      };
+    }
+
+    await dataConnectionsTable.create(validated.data);
+
+    LOGGER.info("Successfully created data connection", {
+      operation: "createDataConnection",
+      metadata: {
+        data_connection_id: validated.data.data_connection_id,
+      },
+    });
+
+    revalidatePath(adminDataConnectionsUrl());
+  } catch (error) {
+    LOGGER.error("Error creating data connection", {
+      operation: "createDataConnection",
+      error,
+    });
+
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Failed to create data connection. Please try again.",
+      success: false,
+    };
+  }
+
+  redirect(adminDataConnectionsUrl());
+}
+
+export async function updateDataConnection(
+  initialState: any,
+  formData: FormData
+): Promise<FormState<DataConnection>> {
+  const session = await getPageSession();
+
+  if (!session?.identity_id) {
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Unauthenticated",
+      success: false,
+    };
+  }
+
+  const dataConnectionId = formData.get("data_connection_id") as string;
+  if (!dataConnectionId) {
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Data connection ID is required",
+      success: false,
+    };
+  }
+
+  try {
+    const existing = await dataConnectionsTable.fetchById(dataConnectionId);
+    if (!existing) {
+      return {
+        fieldErrors: {},
+        data: formData,
+        message: "Data connection not found",
+        success: false,
+      };
+    }
+
+    if (!isAuthorized(session, existing, Actions.PutDataConnection)) {
+      return {
+        fieldErrors: {},
+        data: formData,
+        message: "Unauthorized to update data connections",
+        success: false,
+      };
+    }
+
+    const dataConnection = buildDataConnectionFromForm(formData);
+    const validated = DataConnectionSchema.safeParse(dataConnection);
+    if (!validated.success) {
+      return {
+        fieldErrors: validated.error.flatten().fieldErrors,
+        data: formData,
+        message: "Invalid form data",
+        success: false,
+      };
+    }
+
+    await dataConnectionsTable.update(validated.data);
+
+    LOGGER.info("Successfully updated data connection", {
+      operation: "updateDataConnection",
+      metadata: { data_connection_id: dataConnectionId },
+    });
+
+    revalidatePath(adminDataConnectionsUrl());
+    revalidatePath(adminDataConnectionEditUrl(dataConnectionId));
+
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Data connection updated successfully!",
+      success: true,
+    };
+  } catch (error) {
+    LOGGER.error("Error updating data connection", {
+      operation: "updateDataConnection",
+      error,
+    });
+
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Failed to update data connection. Please try again.",
+      success: false,
+    };
+  }
+}
+
+export async function deleteDataConnection(
+  initialState: any,
+  formData: FormData
+): Promise<FormState<any>> {
+  const session = await getPageSession();
+
+  if (!session?.identity_id) {
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Unauthenticated",
+      success: false,
+    };
+  }
+
+  const dataConnectionId = formData.get("data_connection_id") as string;
+  if (!dataConnectionId) {
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Data connection ID is required",
+      success: false,
+    };
+  }
+
+  try {
+    const existing = await dataConnectionsTable.fetchById(dataConnectionId);
+    if (!existing) {
+      return {
+        fieldErrors: {},
+        data: formData,
+        message: "Data connection not found",
+        success: false,
+      };
+    }
+
+    if (!isAuthorized(session, existing, Actions.DeleteDataConnection)) {
+      return {
+        fieldErrors: {},
+        data: formData,
+        message: "Unauthorized to delete data connections",
+        success: false,
+      };
+    }
+
+    await dataConnectionsTable.delete(dataConnectionId);
+
+    LOGGER.info("Successfully deleted data connection", {
+      operation: "deleteDataConnection",
+      metadata: { data_connection_id: dataConnectionId },
+    });
+
+    revalidatePath(adminDataConnectionsUrl());
+  } catch (error) {
+    LOGGER.error("Error deleting data connection", {
+      operation: "deleteDataConnection",
+      error,
+    });
+
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Failed to delete data connection. Please try again.",
+      success: false,
+    };
+  }
+
+  redirect(adminDataConnectionsUrl());
+}
+
+function buildDataConnectionFromForm(formData: FormData): Record<string, any> {
+  const provider = formData.get("provider") as string;
+  const authType = formData.get("auth_type") as string;
+
+  const allowedDataModes: string[] = [];
+  if (formData.get("mode_open") === "on") allowedDataModes.push("open");
+  if (formData.get("mode_private") === "on") allowedDataModes.push("private");
+  if (formData.get("mode_subscription") === "on")
+    allowedDataModes.push("subscription");
+
+  let details: Record<string, any>;
+  if (provider === DataProvider.S3) {
+    details = {
+      provider: DataProvider.S3,
+      bucket: formData.get("bucket") as string,
+      base_prefix: (formData.get("base_prefix") as string) || "",
+      region: formData.get("region") as string,
+    };
+  } else {
+    details = {
+      provider: DataProvider.Azure,
+      account_name: formData.get("account_name") as string,
+      container_name: formData.get("container_name") as string,
+      base_prefix: (formData.get("base_prefix") as string) || "",
+      region: formData.get("region") as string,
+    };
+  }
+
+  let authentication: Record<string, any> | undefined;
+  if (authType === DataConnectionAuthenticationType.S3AccessKey) {
+    authentication = {
+      type: DataConnectionAuthenticationType.S3AccessKey,
+      access_key_id: formData.get("access_key_id") as string,
+      secret_access_key: formData.get("secret_access_key") as string,
+    };
+  } else if (authType === DataConnectionAuthenticationType.AzureSasToken) {
+    authentication = {
+      type: DataConnectionAuthenticationType.AzureSasToken,
+      sas_token: formData.get("sas_token") as string,
+    };
+  } else if (authType === DataConnectionAuthenticationType.S3ECSTaskRole) {
+    authentication = {
+      type: DataConnectionAuthenticationType.S3ECSTaskRole,
+    };
+  } else if (authType === DataConnectionAuthenticationType.S3Local) {
+    authentication = {
+      type: DataConnectionAuthenticationType.S3Local,
+    };
+  }
+
+  const requiredFlag = formData.get("required_flag") as string;
+
+  return {
+    data_connection_id: formData.get("data_connection_id") as string,
+    name: formData.get("name") as string,
+    prefix_template: (formData.get("prefix_template") as string) || undefined,
+    read_only: formData.get("read_only") === "on",
+    allowed_data_modes: allowedDataModes,
+    required_flag: requiredFlag || undefined,
+    details,
+    authentication,
+  };
+}

--- a/src/lib/actions/index.ts
+++ b/src/lib/actions/index.ts
@@ -2,3 +2,4 @@ export * from "./account";
 export * from "./credentials";
 export * from "./memberships";
 export * from "./products";
+export * from "./data-connections";

--- a/src/lib/actions/product-mirrors.ts
+++ b/src/lib/actions/product-mirrors.ts
@@ -47,8 +47,8 @@ export async function addProductMirror(
 
     const prefix = connection.prefix_template
       ? connection.prefix_template
-          .replace("{account_id}", accountId)
-          .replace("{repository_id}", productId)
+          .replace("{{repository.account_id}}", accountId)
+          .replace("{{repository.repository_id}}", productId)
       : `${accountId}/${productId}/`;
 
     const config: Record<string, string> = {};

--- a/src/lib/actions/product-mirrors.ts
+++ b/src/lib/actions/product-mirrors.ts
@@ -1,0 +1,220 @@
+"use server";
+
+import { LOGGER } from "@/lib/logging";
+import { isAdmin } from "../api/authz";
+import { getPageSession } from "../api/utils";
+import { productsTable, dataConnectionsTable } from "../clients";
+import { FormState } from "@/components/core/DynamicForm";
+import { revalidatePath } from "next/cache";
+import { editProductDataConnectionsUrl } from "@/lib/urls";
+
+export async function addProductMirror(
+  initialState: any,
+  formData: FormData
+): Promise<FormState<any>> {
+  const session = await getPageSession();
+
+  if (!session?.identity_id) {
+    return { fieldErrors: {}, data: formData, message: "Unauthenticated", success: false };
+  }
+
+  if (!isAdmin(session)) {
+    return { fieldErrors: {}, data: formData, message: "Only admins can manage product mirrors", success: false };
+  }
+
+  const accountId = formData.get("account_id") as string;
+  const productId = formData.get("product_id") as string;
+  const connectionId = formData.get("connection_id") as string;
+
+  if (!accountId || !productId || !connectionId) {
+    return { fieldErrors: {}, data: formData, message: "Missing required fields", success: false };
+  }
+
+  try {
+    const product = await productsTable.fetchById(accountId, productId);
+    if (!product) {
+      return { fieldErrors: {}, data: formData, message: "Product not found", success: false };
+    }
+
+    const connection = await dataConnectionsTable.fetchById(connectionId);
+    if (!connection) {
+      return { fieldErrors: {}, data: formData, message: "Data connection not found", success: false };
+    }
+
+    if (product.metadata.mirrors[connectionId]) {
+      return { fieldErrors: {}, data: formData, message: "This data connection is already associated with this product", success: false };
+    }
+
+    const prefix = connection.prefix_template
+      ? connection.prefix_template
+          .replace("{account_id}", accountId)
+          .replace("{repository_id}", productId)
+      : `${accountId}/${productId}/`;
+
+    const config: Record<string, string> = {};
+    if (connection.details.provider === "s3") {
+      config.region = connection.details.region;
+      config.bucket = connection.details.bucket;
+    } else {
+      config.region = connection.details.region;
+      config.container = connection.details.container_name;
+    }
+
+    const isFirst = Object.keys(product.metadata.mirrors).length === 0;
+
+    const mirror = {
+      storage_type: connection.details.provider === "s3" ? "s3" as const : "azure" as const,
+      connection_id: connectionId,
+      prefix,
+      config,
+      is_primary: isFirst,
+    };
+
+    const updatedMirrors = { ...product.metadata.mirrors, [connectionId]: mirror };
+
+    const updatedProduct = {
+      ...product,
+      metadata: {
+        ...product.metadata,
+        mirrors: updatedMirrors,
+        primary_mirror: isFirst ? connectionId : product.metadata.primary_mirror,
+      },
+    };
+
+    await productsTable.update(updatedProduct);
+
+    LOGGER.info("Successfully added product mirror", {
+      operation: "addProductMirror",
+      metadata: { accountId, productId, connectionId },
+    });
+
+    revalidatePath(editProductDataConnectionsUrl(accountId, productId));
+
+    return { fieldErrors: {}, data: formData, message: "Data connection added successfully!", success: true };
+  } catch (error) {
+    LOGGER.error("Error adding product mirror", { operation: "addProductMirror", error });
+    return { fieldErrors: {}, data: formData, message: "Failed to add data connection. Please try again.", success: false };
+  }
+}
+
+export async function removeProductMirror(
+  initialState: any,
+  formData: FormData
+): Promise<FormState<any>> {
+  const session = await getPageSession();
+
+  if (!session?.identity_id) {
+    return { fieldErrors: {}, data: formData, message: "Unauthenticated", success: false };
+  }
+
+  if (!isAdmin(session)) {
+    return { fieldErrors: {}, data: formData, message: "Only admins can manage product mirrors", success: false };
+  }
+
+  const accountId = formData.get("account_id") as string;
+  const productId = formData.get("product_id") as string;
+  const mirrorKey = formData.get("mirror_key") as string;
+
+  if (!accountId || !productId || !mirrorKey) {
+    return { fieldErrors: {}, data: formData, message: "Missing required fields", success: false };
+  }
+
+  try {
+    const product = await productsTable.fetchById(accountId, productId);
+    if (!product) {
+      return { fieldErrors: {}, data: formData, message: "Product not found", success: false };
+    }
+
+    if (!product.metadata.mirrors[mirrorKey]) {
+      return { fieldErrors: {}, data: formData, message: "Mirror not found", success: false };
+    }
+
+    const { [mirrorKey]: removed, ...remainingMirrors } = product.metadata.mirrors;
+
+    let primaryMirror = product.metadata.primary_mirror;
+    if (primaryMirror === mirrorKey) {
+      const remainingKeys = Object.keys(remainingMirrors);
+      primaryMirror = remainingKeys.length > 0 ? remainingKeys[0] : "";
+      if (primaryMirror && remainingMirrors[primaryMirror]) {
+        remainingMirrors[primaryMirror] = { ...remainingMirrors[primaryMirror], is_primary: true };
+      }
+    }
+
+    const updatedProduct = {
+      ...product,
+      metadata: { ...product.metadata, mirrors: remainingMirrors, primary_mirror: primaryMirror },
+    };
+
+    await productsTable.update(updatedProduct);
+
+    LOGGER.info("Successfully removed product mirror", {
+      operation: "removeProductMirror",
+      metadata: { accountId, productId, mirrorKey },
+    });
+
+    revalidatePath(editProductDataConnectionsUrl(accountId, productId));
+
+    return { fieldErrors: {}, data: formData, message: "Data connection removed successfully!", success: true };
+  } catch (error) {
+    LOGGER.error("Error removing product mirror", { operation: "removeProductMirror", error });
+    return { fieldErrors: {}, data: formData, message: "Failed to remove data connection. Please try again.", success: false };
+  }
+}
+
+export async function setPrimaryMirror(
+  initialState: any,
+  formData: FormData
+): Promise<FormState<any>> {
+  const session = await getPageSession();
+
+  if (!session?.identity_id) {
+    return { fieldErrors: {}, data: formData, message: "Unauthenticated", success: false };
+  }
+
+  if (!isAdmin(session)) {
+    return { fieldErrors: {}, data: formData, message: "Only admins can manage product mirrors", success: false };
+  }
+
+  const accountId = formData.get("account_id") as string;
+  const productId = formData.get("product_id") as string;
+  const mirrorKey = formData.get("mirror_key") as string;
+
+  if (!accountId || !productId || !mirrorKey) {
+    return { fieldErrors: {}, data: formData, message: "Missing required fields", success: false };
+  }
+
+  try {
+    const product = await productsTable.fetchById(accountId, productId);
+    if (!product) {
+      return { fieldErrors: {}, data: formData, message: "Product not found", success: false };
+    }
+
+    if (!product.metadata.mirrors[mirrorKey]) {
+      return { fieldErrors: {}, data: formData, message: "Mirror not found", success: false };
+    }
+
+    const updatedMirrors = { ...product.metadata.mirrors };
+    for (const key of Object.keys(updatedMirrors)) {
+      updatedMirrors[key] = { ...updatedMirrors[key], is_primary: key === mirrorKey };
+    }
+
+    const updatedProduct = {
+      ...product,
+      metadata: { ...product.metadata, mirrors: updatedMirrors, primary_mirror: mirrorKey },
+    };
+
+    await productsTable.update(updatedProduct);
+
+    LOGGER.info("Successfully set primary mirror", {
+      operation: "setPrimaryMirror",
+      metadata: { accountId, productId, mirrorKey },
+    });
+
+    revalidatePath(editProductDataConnectionsUrl(accountId, productId));
+
+    return { fieldErrors: {}, data: formData, message: "Primary mirror updated successfully!", success: true };
+  } catch (error) {
+    LOGGER.error("Error setting primary mirror", { operation: "setPrimaryMirror", error });
+    return { fieldErrors: {}, data: formData, message: "Failed to update primary mirror. Please try again.", success: false };
+  }
+}

--- a/src/lib/clients/database/data-connections.ts
+++ b/src/lib/clients/database/data-connections.ts
@@ -8,6 +8,7 @@ import {
   ScanCommand,
   PutCommand,
   UpdateCommand,
+  DeleteCommand,
 } from "@aws-sdk/lib-dynamodb";
 import { marshall } from "@aws-sdk/util-dynamodb";
 import { BaseTable } from "./base";
@@ -131,6 +132,22 @@ export class DataConnectionsTable extends BaseTable {
       this.logError("upsert", error, {
         dataConnectionId: dataConnection.data_connection_id,
       });
+      throw error;
+    }
+  }
+
+  async delete(dataConnectionId: string): Promise<void> {
+    try {
+      await this.client.send(
+        new DeleteCommand({
+          TableName: this.table,
+          Key: {
+            data_connection_id: dataConnectionId,
+          },
+        })
+      );
+    } catch (error) {
+      this.logError("delete", error, { dataConnectionId });
       throw error;
     }
   }

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -67,3 +67,16 @@ export const fileSourceUrl = ({ account_id, product_id, object_path }: {
   object_path: string
 }) =>
   `${CONFIG.storage.endpoint}/${account_id}/${product_id}/${object_path}`;
+
+// Admin URLs
+export const adminDataConnectionsUrl = () => "/admin/data-connections";
+export const adminDataConnectionCreateUrl = () =>
+  "/admin/data-connections/create";
+export const adminDataConnectionEditUrl = (data_connection_id: string) =>
+  `/admin/data-connections/${data_connection_id}`;
+
+// Product data connections edit URL
+export const editProductDataConnectionsUrl = (
+  account_id: string,
+  product_id: string
+) => `/edit/product/${account_id}/${product_id}/data-connections`;


### PR DESCRIPTION
## Summary
- Admin CRUD pages for system data connections at `/admin/data-connections/`
- Product settings tab for managing data connection mirrors at `/edit/product/.../data-connections`
- Admins: full create/edit/delete data connections + associate connections with products
- Product owners: read-only view of product mirrors
- Admin dropdown menu link for quick access

Closes #178

## Changes
- `src/lib/clients/database/data-connections.ts` — added `delete` method
- `src/lib/actions/data-connections.ts` — server actions for CRUD
- `src/lib/actions/product-mirrors.ts` — server actions for mirror management
- `src/components/features/data-connections/` — DataConnectionForm, DeleteDataConnectionButton, ProductMirrorsManager
- `src/app/(app)/admin/` — admin layout + data connections pages (list, create, edit)
- `src/app/(app)/edit/product/.../data-connections/` — product mirror settings page
- `src/components/layout/AccountDropdown.tsx` — admin section with link
- `src/lib/urls.ts` — new URL helpers

## Test plan
- [ ] Verify admin can list, create, edit, and delete data connections
- [ ] Verify non-admin users cannot access admin pages (redirects to 404)
- [ ] Verify admin can add/remove mirrors and set primary on product settings
- [ ] Verify product owners see read-only mirror list (no add/remove/set primary)
- [ ] Verify admin dropdown shows "Data Connections" link only for admins
- [ ] Verify provider switching (S3/Azure) shows correct fields in form
- [ ] Verify auth type switching shows correct credential fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)