### PR TITLE
fix: smooth transition when loading globe

### DIFF
--- a/src/components/features/globe/LiveGlobe.module.css
+++ b/src/components/features/globe/LiveGlobe.module.css
@@ -4,6 +4,13 @@
   position: relative;
   overflow: hidden;
 }
+.loading canvas {
+  opacity: 0;
+}
+.ready canvas {
+  opacity: 1;
+  transition: opacity 0.5s ease-in;
+}
 :global(.dark) .container canvas {
   filter: invert(1);
 }

--- a/src/components/features/globe/LiveGlobe.tsx
+++ b/src/components/features/globe/LiveGlobe.tsx
@@ -64,6 +64,7 @@ export function LiveGlobe({
   const globeRef = useRef<GlobeMethods | undefined>(undefined);
   const pointsRef = useRef<LocationPoint[]>([]);
   const [globeReady, setGlobeReady] = useState(false);
+  const [sceneReady, setSceneReady] = useState(false);
   const globeReadyRef = useRef(false);
   const onErrorRef = useRef(onError);
   onErrorRef.current = onError;
@@ -387,8 +388,10 @@ export function LiveGlobe({
       document.addEventListener("click", handleDocClick);
 
       animate();
+      setSceneReady(true);
 
       return () => {
+        setSceneReady(false);
         cancelled = true;
         cancelAnimationFrame(animFrameId);
         window.removeEventListener("scroll", updateRect);
@@ -492,7 +495,7 @@ export function LiveGlobe({
     <>
       <div
         ref={wrapperRef}
-        className={styles.container}
+        className={`${styles.container} ${sceneReady ? styles.ready : styles.loading}`}
         role="img"
         aria-label="Interactive 3D globe showing live data request locations"
       >


### PR DESCRIPTION
## What I'm changing

The globe is a bit jerky on load, even having an instant flash of undithered full-color 😲.

This PR hides the globe initially and then quickly fades the globe into view once it is loaded.

## How I did it

CSS + state hooks

<!--
  Lower-level details of the steps taken to achieve goal.

  Include:
    - considerations made when deciding how to implement feature
    - any changes to API that could impact the Data Proxy
-->

## How you can test it

Compare:
* https://source.coop
* https://source-cooperative-dlknkq0h6-radiantearth.vercel.app

### Before

https://github.com/user-attachments/assets/4b336557-5ce7-458d-8d69-be8902b508f6


### After

https://github.com/user-attachments/assets/abc36868-416d-40ba-826a-72cc66fc30ac


