### PR TITLE
feat: add ROR ID field to organization profile edit form

### DIFF
--- a/src/components/features/profiles/EditProfileForm.tsx
+++ b/src/components/features/profiles/EditProfileForm.tsx
@@ -20,6 +20,7 @@ interface EditProfileFormData {
   email: string;
   description: string;
   orcid?: string;
+  ror_id?: string;
   websites?: string;
   bio?: string;
 }
@@ -58,6 +59,10 @@ export function EditProfileForm({
     orcid:
       (initialAccount.type === "individual" &&
         initialAccount.metadata_public?.orcid) ||
+      "",
+    ror_id:
+      (initialAccount.type === "organization" &&
+        initialAccount.metadata_public?.ror_id) ||
       "",
   };
 
@@ -105,6 +110,17 @@ export function EditProfileForm({
             type: "text" as const,
             placeholder: "0000-0002-1825-0097",
             description: "Your ORCID identifier (optional)",
+          } as const,
+        ]
+      : []),
+    ...(initialAccount.type === "organization"
+      ? [
+          {
+            label: "ROR ID",
+            name: "ror_id",
+            type: "text" as const,
+            placeholder: "03yrm5c26",
+            description: "Your Research Organization Registry identifier (optional)",
           } as const,
         ]
       : []),

--- a/src/lib/actions/account.ts
+++ b/src/lib/actions/account.ts
@@ -189,6 +189,7 @@ export async function updateAccountProfile(
     const name = formData.get("name") as string;
     const description = formData.get("description") as string;
     const orcid = formData.get("orcid") as string;
+    const ror_id = formData.get("ror_id") as string;
 
     // Extract websites from form data (handle both indexed and direct approaches)
     const websites: string[] = [];
@@ -230,6 +231,7 @@ export async function updateAccountProfile(
         ...currentAccount.metadata_public,
         bio: description || undefined,
         orcid: orcid || undefined,
+        ror_id: ror_id || undefined,
         domains: validWebsites,
       },
       updated_at: new Date().toISOString(),


### PR DESCRIPTION
## Summary

- Adds an editable ROR ID field to the organization profile form, mirroring the existing ORCID field for individual accounts
- Extracts and persists `ror_id` in `metadata_public` via the `updateAccountProfile` server action

## Test plan

- [ ] Edit an organization profile and set a ROR ID — verify it saves and displays on the profile page
- [ ] Edit an individual profile — verify the ROR ID field does not appear
- [ ] Clear a previously set ROR ID — verify it is removed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)