### PR TITLE
feat: add schema.org Dataset metadata to product pages

### DIFF
--- a/src/app/(app)/[account_id]/[product_id]/(product)/[[...path]]/layout.tsx
+++ b/src/app/(app)/[account_id]/[product_id]/(product)/[[...path]]/layout.tsx
@@ -22,6 +22,7 @@ import { Actions } from "@/types/shared";
 import { Box, Card, Flex } from "@radix-ui/themes";
 import { notFound } from "next/navigation";
 import { getPendingInvitation } from "@/lib/actions/memberships";
+import { ProductSchemaMetadata } from "@/components/features/products/ProductSchemaMetadata";
 
 interface ProductLayoutProps {
   children: React.ReactNode;
@@ -48,6 +49,7 @@ export default async function ProductLayout({
 
   return (
     <>
+      <ProductSchemaMetadata product={product} />
       {/* Show pending invitation banner if exists */}
       {pendingInvitation && (
         <PendingInvitationBanner

--- a/src/components/features/products/ProductSchemaMetadata.tsx
+++ b/src/components/features/products/ProductSchemaMetadata.tsx
@@ -1,33 +1,40 @@
 import type { Product } from "@/types";
-import { productUrl } from "@/lib/urls";
+import { accountUrl, productUrl } from "@/lib/urls";
+import { getBaseUrl } from "@/lib/baseUrl";
 
-// For injecting schema.org metadata
-export function ProductSchemaMetadata({ product }: { product: Product }) {
+export async function ProductSchemaMetadata({ product }: { product: Product }) {
   const account = product.account;
+  const baseUrl = await getBaseUrl();
+
+  const creator = account
+    ? {
+        "@type": account.type === "organization" ? "Organization" : "Person",
+        name: account.name,
+        url: `${baseUrl}${accountUrl(account.account_id)}`,
+        ...(account.type === "individual" && account.metadata_public?.orcid
+          ? { sameAs: `https://orcid.org/${account.metadata_public.orcid}` }
+          : {}),
+        ...(account.type === "organization" && account.metadata_public?.ror_id
+          ? { sameAs: `https://ror.org/${account.metadata_public.ror_id}` }
+          : {}),
+      }
+    : undefined;
+
   const schemaData = {
     "@context": "https://schema.org/",
     "@type": "Dataset",
     name: product.title,
     description: product.description,
     url: account
-      ? `https://yourdomain.com${productUrl(
-          account.account_id,
-          product.product_id
-        )}`
+      ? `${baseUrl}${productUrl(account.account_id, product.product_id)}`
       : "",
     dateModified: product.updated_at,
     dateCreated: product.created_at,
     isAccessibleForFree: product.visibility === "public",
-    ...(account && {
-      creator: {
-        "@type": account.type === "organization" ? "Organization" : "Person",
-        name: account.name,
-        // TODO: Implement this
-        // ...(account.metadata_public?.domains?.[0]?.domain && {
-        //   url: `https://${account.metadata_public.domains[0].domain}`, // Assuming https
-        // }),
-      },
+    ...(product.metadata?.doi && {
+      identifier: `https://doi.org/${product.metadata.doi}`,
     }),
+    ...(creator && { creator }),
   };
 
   return (


### PR DESCRIPTION
## Summary

- Fixes the existing `ProductSchemaMetadata` component (was unused and had a hardcoded `yourdomain.com` domain)
- Replaces hardcoded URL with dynamic `getBaseUrl()`, adds creator URL, DOI identifier, and `sameAs` links for ORCID/ROR
- Wires the component into the product layout so it renders on all product pages

## Test plan

- [x] Visit a product page and inspect the HTML source for a `<script type="application/ld+json">` tag
- [ ] Verify `url`, `dateCreated`, `dateModified`, and `isAccessibleForFree` are correct
- [x] Verify `creator.url` points to the account page
- [ ] On a product with a DOI, verify `identifier` is present
- [ ] On a product whose creator has an ORCID/ROR, verify `creator.sameAs` is present

🤖 Generated with [Claude Code](https://claude.ai/claude-code)