### PR TITLE
feat: add schema.org Person/Organization metadata to account pages

### DIFF
--- a/src/app/(app)/[account_id]/page.tsx
+++ b/src/app/(app)/[account_id]/page.tsx
@@ -19,6 +19,7 @@ import {
   generateNotFoundMetadata,
   generateAccountMetadata,
 } from "@/components/features/metadata";
+import { AccountSchemaMetadata } from "@/components/features/profiles/AccountSchemaMetadata";
 
 type PageProps = {
   params: Promise<{ account_id: string }>;
@@ -45,9 +46,14 @@ export default async function AccountPage({ params, searchParams }: PageProps) {
     notFound();
   }
 
-  return isOrganizationalAccount(account) ? (
-    <OrganizationProfilePage account={account} />
-  ) : (
-    <IndividualProfilePage account={account} showWelcome={showWelcome} />
+  return (
+    <>
+      <AccountSchemaMetadata account={account} />
+      {isOrganizationalAccount(account) ? (
+        <OrganizationProfilePage account={account} />
+      ) : (
+        <IndividualProfilePage account={account} showWelcome={showWelcome} />
+      )}
+    </>
   );
 }

--- a/src/components/features/profiles/AccountSchemaMetadata.tsx
+++ b/src/components/features/profiles/AccountSchemaMetadata.tsx
@@ -1,0 +1,48 @@
+import type { Account } from "@/types";
+import { accountUrl } from "@/lib/urls";
+import { getBaseUrl } from "@/lib/baseUrl";
+
+export async function AccountSchemaMetadata({ account }: { account: Account }) {
+  const baseUrl = await getBaseUrl();
+  const url = `${baseUrl}${accountUrl(account.account_id)}`;
+
+  const schemaData =
+    account.type === "organization"
+      ? {
+          "@context": "https://schema.org/",
+          "@type": "Organization",
+          name: account.name,
+          url,
+          ...(account.metadata_public?.bio && {
+            description: account.metadata_public.bio,
+          }),
+          ...(account.metadata_public?.profile_image && {
+            image: account.metadata_public.profile_image,
+          }),
+          ...(account.metadata_public?.ror_id && {
+            sameAs: `https://ror.org/${account.metadata_public.ror_id}`,
+          }),
+        }
+      : {
+          "@context": "https://schema.org/",
+          "@type": "Person",
+          name: account.name,
+          url,
+          ...(account.metadata_public?.bio && {
+            description: account.metadata_public.bio,
+          }),
+          ...(account.metadata_public?.profile_image && {
+            image: account.metadata_public.profile_image,
+          }),
+          ...(account.metadata_public?.orcid && {
+            sameAs: `https://orcid.org/${account.metadata_public.orcid}`,
+          }),
+        };
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(schemaData) }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a new `AccountSchemaMetadata` server component that emits a `<script type="application/ld+json">` tag on account profile pages
- Emits `Organization` schema for org accounts and `Person` schema for individual accounts
- Includes `name`, `url`, `description` (from bio), `image` (from profile image), and `sameAs` (ROR for orgs, ORCID for individuals) — all fields are conditional and omitted when not set

## Test plan

- [ ] Visit an organization profile page and inspect the HTML source for a `<script type="application/ld+json">` tag with `@type: "Organization"`
- [ ] Visit an individual profile page and verify `@type: "Person"`
- [ ] Verify `sameAs` appears for accounts with a ROR ID or ORCID set
- [ ] Verify `sameAs` is absent for accounts without those identifiers

🤖 Generated with [Claude Code](https://claude.ai/claude-code)