### PR TITLE
fix!: require auth for restricted products

### DIFF
--- a/fixtures/data-connections.json
+++ b/fixtures/data-connections.json
@@ -4,7 +4,7 @@
     "name": "Staging Bucket",
     "prefix_template": "{account_id}/{repository_id}/",
     "read_only": false,
-    "allowed_data_modes": ["open", "private", "subscription"],
+    "allowed_data_modes": ["public", "unlisted"],
     "details": {
       "provider": "s3",
       "bucket": "dev.us-west-2.opendata.source.coop",
@@ -20,7 +20,7 @@
     "name": "Primary Data Connection",
     "prefix_template": "{account_id}/{repository_id}/",
     "read_only": false,
-    "allowed_data_modes": ["open", "private", "subscription"],
+    "allowed_data_modes": ["public", "unlisted", "restricted"],
     "details": {
       "provider": "s3",
       "bucket": "source-coop-data",
@@ -36,7 +36,7 @@
     "name": "Read-Only Data Connection",
     "prefix_template": "{account_id}/{repository_id}/",
     "read_only": true,
-    "allowed_data_modes": ["open"],
+    "allowed_data_modes": ["public", "unlisted"],
     "details": {
       "provider": "s3",
       "bucket": "source-coop-readonly",
@@ -54,7 +54,7 @@
     "name": "Azure Data Connection",
     "prefix_template": "{account_id}/{repository_id}/",
     "read_only": false,
-    "allowed_data_modes": ["open", "private"],
+    "allowed_data_modes": ["public", "unlisted", "restricted"],
     "details": {
       "provider": "az",
       "account_name": "sourcecoopstorage",
@@ -72,7 +72,7 @@
     "name": "Subscription Data Connection",
     "prefix_template": "{account_id}/{repository_id}/",
     "read_only": false,
-    "allowed_data_modes": ["subscription"],
+    "allowed_data_modes": ["restricted"],
     "required_flag": "admin",
     "details": {
       "provider": "s3",

--- a/fixtures/data-connections.json
+++ b/fixtures/data-connections.json
@@ -4,7 +4,7 @@
     "name": "Staging Bucket",
     "prefix_template": "{account_id}/{repository_id}/",
     "read_only": false,
-    "allowed_data_modes": ["public", "unlisted"],
+    "allowed_visibilities": ["public", "unlisted"],
     "details": {
       "provider": "s3",
       "bucket": "dev.us-west-2.opendata.source.coop",
@@ -20,7 +20,7 @@
     "name": "Primary Data Connection",
     "prefix_template": "{account_id}/{repository_id}/",
     "read_only": false,
-    "allowed_data_modes": ["public", "unlisted", "restricted"],
+    "allowed_visibilities": ["public", "unlisted", "restricted"],
     "details": {
       "provider": "s3",
       "bucket": "source-coop-data",
@@ -36,7 +36,7 @@
     "name": "Read-Only Data Connection",
     "prefix_template": "{account_id}/{repository_id}/",
     "read_only": true,
-    "allowed_data_modes": ["public", "unlisted"],
+    "allowed_visibilities": ["public", "unlisted"],
     "details": {
       "provider": "s3",
       "bucket": "source-coop-readonly",
@@ -54,7 +54,7 @@
     "name": "Azure Data Connection",
     "prefix_template": "{account_id}/{repository_id}/",
     "read_only": false,
-    "allowed_data_modes": ["public", "unlisted", "restricted"],
+    "allowed_visibilities": ["public", "unlisted", "restricted"],
     "details": {
       "provider": "az",
       "account_name": "sourcecoopstorage",
@@ -72,7 +72,7 @@
     "name": "Subscription Data Connection",
     "prefix_template": "{account_id}/{repository_id}/",
     "read_only": false,
-    "allowed_data_modes": ["restricted"],
+    "allowed_visibilities": ["restricted"],
     "required_flag": "admin",
     "details": {
       "provider": "s3",

--- a/fixtures/products.json
+++ b/fixtures/products.json
@@ -174,35 +174,6 @@
     "featured": 0
   },
   {
-    "product_id": "subscription-org-repo-id",
-    "account_id": "organization",
-    "title": "Subscription Repo",
-    "description": "Subscription Organization's product",
-    "created_at": "2020-01-01T00:00:00Z",
-    "updated_at": "2020-01-01T00:00:00Z",
-    "visibility": "restricted",
-    "metadata": {
-      "mirrors": {
-        "primary-data-connection": {
-          "storage_type": "s3",
-          "connection_id": "primary-data-connection",
-          "prefix": "organization/subscription-org-repo-id/",
-          "config": {
-            "region": "us-east-1",
-            "bucket": "source-coop-data"
-          },
-          "is_primary": true
-        }
-      },
-      "primary_mirror": "primary-data-connection",
-      "tags": ["mock", "subscription"],
-      "roles": {}
-    },
-    "disabled": false,
-
-    "featured": 0
-  },
-  {
     "product_id": "overture",
     "account_id": "cholmes",
     "title": "Overture Open Buildings",

--- a/fixtures/products.json
+++ b/fixtures/products.json
@@ -25,7 +25,6 @@
       "roles": {}
     },
     "disabled": false,
-
     "featured": 0
   },
   {
@@ -54,7 +53,6 @@
       "roles": {}
     },
     "disabled": false,
-
     "featured": 0
   },
   {
@@ -83,7 +81,6 @@
       "roles": {}
     },
     "disabled": true,
-
     "featured": 0
   },
   {
@@ -112,7 +109,6 @@
       "roles": {}
     },
     "disabled": false,
-
     "featured": 0
   },
   {
@@ -141,7 +137,6 @@
       "roles": {}
     },
     "disabled": false,
-
     "featured": 1
   },
   {
@@ -170,7 +165,6 @@
       "roles": {}
     },
     "disabled": false,
-
     "featured": 0
   },
   {
@@ -199,7 +193,6 @@
       "roles": {}
     },
     "disabled": false,
-
     "featured": 10
   }
 ]

--- a/fixtures/products.json
+++ b/fixtures/products.json
@@ -25,7 +25,7 @@
       "roles": {}
     },
     "disabled": false,
-    "data_mode": "open",
+
     "featured": 0
   },
   {
@@ -54,7 +54,7 @@
       "roles": {}
     },
     "disabled": false,
-    "data_mode": "open",
+
     "featured": 0
   },
   {
@@ -83,7 +83,7 @@
       "roles": {}
     },
     "disabled": true,
-    "data_mode": "open",
+
     "featured": 0
   },
   {
@@ -112,7 +112,7 @@
       "roles": {}
     },
     "disabled": false,
-    "data_mode": "open",
+
     "featured": 0
   },
   {
@@ -141,7 +141,7 @@
       "roles": {}
     },
     "disabled": false,
-    "data_mode": "open",
+
     "featured": 1
   },
   {
@@ -170,7 +170,7 @@
       "roles": {}
     },
     "disabled": false,
-    "data_mode": "private",
+
     "featured": 0
   },
   {
@@ -199,7 +199,7 @@
       "roles": {}
     },
     "disabled": false,
-    "data_mode": "subscription",
+
     "featured": 0
   },
   {
@@ -228,7 +228,7 @@
       "roles": {}
     },
     "disabled": false,
-    "data_mode": "open",
+
     "featured": 10
   }
 ]

--- a/fixtures/products.json
+++ b/fixtures/products.json
@@ -13,10 +13,6 @@
           "storage_type": "s3",
           "connection_id": "primary-data-connection",
           "prefix": "create-repositories-user/regular-user-repo-id/",
-          "config": {
-            "region": "us-east-1",
-            "bucket": "source-coop-data"
-          },
           "is_primary": true
         }
       },
@@ -41,10 +37,6 @@
           "storage_type": "s3",
           "connection_id": "primary-data-connection",
           "prefix": "organization/org-repo-id/",
-          "config": {
-            "region": "us-east-1",
-            "bucket": "source-coop-data"
-          },
           "is_primary": true
         }
       },
@@ -69,10 +61,6 @@
           "storage_type": "s3",
           "connection_id": "primary-data-connection",
           "prefix": "organization/disabled-org-repo-id/",
-          "config": {
-            "region": "us-east-1",
-            "bucket": "source-coop-data"
-          },
           "is_primary": true
         }
       },
@@ -97,10 +85,6 @@
           "storage_type": "s3",
           "connection_id": "primary-data-connection",
           "prefix": "organization/unlisted-org-repo-id/",
-          "config": {
-            "region": "us-east-1",
-            "bucket": "source-coop-data"
-          },
           "is_primary": true
         }
       },
@@ -125,10 +109,6 @@
           "storage_type": "s3",
           "connection_id": "primary-data-connection",
           "prefix": "organization/featured-org-repo-id/",
-          "config": {
-            "region": "us-east-1",
-            "bucket": "source-coop-data"
-          },
           "is_primary": true
         }
       },
@@ -153,10 +133,6 @@
           "storage_type": "s3",
           "connection_id": "primary-data-connection",
           "prefix": "organization/private-org-repo-id/",
-          "config": {
-            "region": "us-east-1",
-            "bucket": "source-coop-data"
-          },
           "is_primary": true
         }
       },
@@ -181,10 +157,6 @@
           "storage_type": "s3",
           "connection_id": "primary-data-connection",
           "prefix": "cholmes/overture/",
-          "config": {
-            "region": "us-east-1",
-            "bucket": "source-coop-data"
-          },
           "is_primary": true
         }
       },

--- a/scripts/backfill-allowed-data-modes.ts
+++ b/scripts/backfill-allowed-data-modes.ts
@@ -1,0 +1,158 @@
+#!/usr/bin/env tsx
+/**
+ * Backfill script to migrate legacy `allowed_data_modes` values on
+ * data-connections records to the new ProductVisibility values.
+ *
+ * Mapping:
+ *   "open"         -> "public"
+ *   "private"      -> "restricted"
+ *   "subscription" -> "restricted"
+ *
+ * Usage:
+ *   npx tsx scripts/backfill-allowed-data-modes.ts <table-name>
+ *
+ * Examples:
+ *   npx tsx scripts/backfill-allowed-data-modes.ts sc-dev-data-connections
+ *   npx tsx scripts/backfill-allowed-data-modes.ts sc-prod-data-connections
+ *
+ * Environment variables:
+ *   AWS_REGION  - AWS region (default: us-east-1)
+ *   AWS_PROFILE - AWS profile to use (optional)
+ *   DRY_RUN     - Set (to anything) to preview changes without writing
+ */
+
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  ScanCommand,
+  UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
+
+const LEGACY_TO_NEW: Record<string, string> = {
+  open: "public",
+  private: "restricted",
+  subscription: "restricted",
+};
+
+interface DataConnectionItem {
+  data_connection_id: string;
+  allowed_data_modes?: string[];
+}
+
+function migrate(modes: string[]): string[] {
+  const mapped = modes.map((m) => LEGACY_TO_NEW[m] ?? m);
+  return Array.from(new Set(mapped));
+}
+
+function arraysEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((v, i) => v === b[i]);
+}
+
+async function backfill(tableName: string, dryRun: boolean) {
+  const region = process.env.AWS_REGION || "us-east-1";
+
+  console.log(`Backfill allowed_data_modes for table: ${tableName}`);
+  console.log(`Region: ${region}`);
+  console.log(`Dry run: ${dryRun}`);
+  console.log("");
+
+  const dbClient = new DynamoDBClient({ region });
+  const client = DynamoDBDocumentClient.from(dbClient, {
+    marshallOptions: { removeUndefinedValues: true },
+  });
+
+  let lastEvaluatedKey: Record<string, unknown> | undefined;
+  let scanned = 0;
+  let updated = 0;
+  let skipped = 0;
+  let errors = 0;
+
+  do {
+    const result = await client.send(
+      new ScanCommand({
+        TableName: tableName,
+        ProjectionExpression: "data_connection_id, allowed_data_modes",
+        ExclusiveStartKey: lastEvaluatedKey,
+      })
+    );
+    const items = (result.Items || []) as DataConnectionItem[];
+    lastEvaluatedKey = result.LastEvaluatedKey;
+    scanned += items.length;
+
+    for (const item of items) {
+      const current = item.allowed_data_modes ?? [];
+      const next = migrate(current);
+
+      if (arraysEqual(current, next)) {
+        skipped++;
+        continue;
+      }
+
+      if (dryRun) {
+        console.log(
+          `[DRY RUN] Would update ${item.data_connection_id}: ${JSON.stringify(current)} -> ${JSON.stringify(next)}`
+        );
+        updated++;
+        continue;
+      }
+
+      try {
+        await client.send(
+          new UpdateCommand({
+            TableName: tableName,
+            Key: { data_connection_id: item.data_connection_id },
+            UpdateExpression: "SET allowed_data_modes = :allowed_data_modes",
+            ExpressionAttributeValues: { ":allowed_data_modes": next },
+          })
+        );
+        updated++;
+      } catch (err) {
+        errors++;
+        console.error(`Error updating ${item.data_connection_id}:`, err);
+      }
+    }
+
+    console.log(
+      `Progress: scanned=${scanned}, updated=${updated}, skipped=${skipped}, errors=${errors}`
+    );
+  } while (lastEvaluatedKey);
+
+  console.log("");
+  console.log("Backfill complete.");
+  console.log(`  Total scanned: ${scanned}`);
+  console.log(`  Updated:       ${updated}`);
+  console.log(`  Skipped:       ${skipped} (already migrated)`);
+  console.log(`  Errors:        ${errors}`);
+}
+
+const tableName = process.argv[2];
+
+if (!tableName) {
+  console.error(
+    "Usage: npx tsx scripts/backfill-allowed-data-modes.ts <table-name>"
+  );
+  console.error("");
+  console.error("Examples:");
+  console.error(
+    "  npx tsx scripts/backfill-allowed-data-modes.ts sc-dev-data-connections"
+  );
+  console.error(
+    "  npx tsx scripts/backfill-allowed-data-modes.ts sc-prod-data-connections"
+  );
+  console.error("");
+  console.error("Environment variables:");
+  console.error("  AWS_REGION  - AWS region (default: us-east-1)");
+  console.error("  AWS_PROFILE - AWS profile to use (optional)");
+  console.error(
+    "  DRY_RUN     - Set (to anything) to preview changes without writing"
+  );
+  process.exit(1);
+}
+
+const dryRun = process.env.DRY_RUN !== undefined;
+
+backfill(tableName, dryRun).catch((err) => {
+  console.error("Backfill failed:", err);
+  process.exit(1);
+});

--- a/scripts/backfill-allowed-visibilities.ts
+++ b/scripts/backfill-allowed-visibilities.ts
@@ -1,19 +1,27 @@
 #!/usr/bin/env tsx
 /**
- * Backfill script to migrate legacy `allowed_data_modes` values on
- * data-connections records to the new ProductVisibility values.
+ * Backfill script to migrate the legacy `allowed_data_modes` field to
+ * `allowed_visibilities` on data-connections records, mapping legacy
+ * values to ProductVisibility values along the way.
  *
- * Mapping:
+ * Value mapping:
  *   "open"         -> "public"
  *   "private"      -> "restricted"
  *   "subscription" -> "restricted"
+ * Values already conforming to ProductVisibility are passed through.
+ *
+ * For each record:
+ *   - if it has `allowed_data_modes`, the values are mapped, deduped,
+ *     written to `allowed_visibilities`, and `allowed_data_modes` is
+ *     removed.
+ *   - if it has only `allowed_visibilities`, it is skipped.
  *
  * Usage:
- *   npx tsx scripts/backfill-allowed-data-modes.ts <table-name>
+ *   npx tsx scripts/backfill-allowed-visibilities.ts <table-name>
  *
  * Examples:
- *   npx tsx scripts/backfill-allowed-data-modes.ts sc-dev-data-connections
- *   npx tsx scripts/backfill-allowed-data-modes.ts sc-prod-data-connections
+ *   npx tsx scripts/backfill-allowed-visibilities.ts sc-dev-data-connections
+ *   npx tsx scripts/backfill-allowed-visibilities.ts sc-prod-data-connections
  *
  * Environment variables:
  *   AWS_REGION  - AWS region (default: us-east-1)
@@ -37,22 +45,18 @@ const LEGACY_TO_NEW: Record<string, string> = {
 interface DataConnectionItem {
   data_connection_id: string;
   allowed_data_modes?: string[];
+  allowed_visibilities?: string[];
 }
 
-function migrate(modes: string[]): string[] {
+function mapValues(modes: string[]): string[] {
   const mapped = modes.map((m) => LEGACY_TO_NEW[m] ?? m);
   return Array.from(new Set(mapped));
-}
-
-function arraysEqual(a: string[], b: string[]): boolean {
-  if (a.length !== b.length) return false;
-  return a.every((v, i) => v === b[i]);
 }
 
 async function backfill(tableName: string, dryRun: boolean) {
   const region = process.env.AWS_REGION || "us-east-1";
 
-  console.log(`Backfill allowed_data_modes for table: ${tableName}`);
+  console.log(`Backfill allowed_visibilities for table: ${tableName}`);
   console.log(`Region: ${region}`);
   console.log(`Dry run: ${dryRun}`);
   console.log("");
@@ -72,7 +76,8 @@ async function backfill(tableName: string, dryRun: boolean) {
     const result = await client.send(
       new ScanCommand({
         TableName: tableName,
-        ProjectionExpression: "data_connection_id, allowed_data_modes",
+        ProjectionExpression:
+          "data_connection_id, allowed_data_modes, allowed_visibilities",
         ExclusiveStartKey: lastEvaluatedKey,
       })
     );
@@ -81,17 +86,16 @@ async function backfill(tableName: string, dryRun: boolean) {
     scanned += items.length;
 
     for (const item of items) {
-      const current = item.allowed_data_modes ?? [];
-      const next = migrate(current);
-
-      if (arraysEqual(current, next)) {
+      if (item.allowed_data_modes === undefined) {
         skipped++;
         continue;
       }
 
+      const next = mapValues(item.allowed_data_modes);
+
       if (dryRun) {
         console.log(
-          `[DRY RUN] Would update ${item.data_connection_id}: ${JSON.stringify(current)} -> ${JSON.stringify(next)}`
+          `[DRY RUN] Would update ${item.data_connection_id}: allowed_data_modes=${JSON.stringify(item.allowed_data_modes)} -> allowed_visibilities=${JSON.stringify(next)}`
         );
         updated++;
         continue;
@@ -102,8 +106,9 @@ async function backfill(tableName: string, dryRun: boolean) {
           new UpdateCommand({
             TableName: tableName,
             Key: { data_connection_id: item.data_connection_id },
-            UpdateExpression: "SET allowed_data_modes = :allowed_data_modes",
-            ExpressionAttributeValues: { ":allowed_data_modes": next },
+            UpdateExpression:
+              "SET allowed_visibilities = :allowed_visibilities REMOVE allowed_data_modes",
+            ExpressionAttributeValues: { ":allowed_visibilities": next },
           })
         );
         updated++;
@@ -130,15 +135,15 @@ const tableName = process.argv[2];
 
 if (!tableName) {
   console.error(
-    "Usage: npx tsx scripts/backfill-allowed-data-modes.ts <table-name>"
+    "Usage: npx tsx scripts/backfill-allowed-visibilities.ts <table-name>"
   );
   console.error("");
   console.error("Examples:");
   console.error(
-    "  npx tsx scripts/backfill-allowed-data-modes.ts sc-dev-data-connections"
+    "  npx tsx scripts/backfill-allowed-visibilities.ts sc-dev-data-connections"
   );
   console.error(
-    "  npx tsx scripts/backfill-allowed-data-modes.ts sc-prod-data-connections"
+    "  npx tsx scripts/backfill-allowed-visibilities.ts sc-prod-data-connections"
   );
   console.error("");
   console.error("Environment variables:");

--- a/src/app/(app)/[account_id]/[product_id]/(product)/[[...path]]/layout.tsx
+++ b/src/app/(app)/[account_id]/[product_id]/(product)/[[...path]]/layout.tsx
@@ -41,6 +41,9 @@ export default async function ProductLayout({
   if (!product) {
     notFound();
   }
+  if (!isAuthorized(session, product, Actions.GetRepository)) {
+    notFound();
+  }
   const prefix = path ? path.join("/") : "";
 
   // Check for pending invitation

--- a/src/app/api/v1/products/[account_id]/[repository_id]/route.test.ts
+++ b/src/app/api/v1/products/[account_id]/[repository_id]/route.test.ts
@@ -27,7 +27,7 @@ import {
 } from "@/lib/clients/database";
 import { getServerSession } from "@ory/nextjs/app";
 import { getOryId } from "@/lib/ory";
-import { AccountType, ProductDataMode } from "@/types";
+import { AccountType } from "@/types";
 
 // Mock database dependencies for testing real authentication
 jest.mock("@/lib/clients/database/products", () => ({
@@ -69,7 +69,7 @@ describe("/api/v1/products/[account_id]/[repository_id]", () => {
     created_at: "2024-01-01T00:00:00Z",
     updated_at: "2024-01-01T00:00:00Z",
     disabled: false,
-    data_mode: ProductDataMode.Private, // Set to private mode to test authorization
+    visibility: "restricted", // Set to restricted to test authorization
   };
 
   // Test SOURCE_KEY value (set at module level)

--- a/src/app/api/v1/products/[account_id]/route.ts
+++ b/src/app/api/v1/products/[account_id]/route.ts
@@ -144,7 +144,7 @@ export async function POST(
   //     );
   //   }
   //   if (
-  //     !dataConnection.allowed_data_modes.includes(
+  //     !dataConnection.allowed_visibilities.includes(
   //       repositoryCreateRequest.data_mode
   //     )
   //   ) {

--- a/src/lib/actions/products.ts
+++ b/src/lib/actions/products.ts
@@ -6,7 +6,7 @@ import {
   ProductCreationRequestSchema,
   type Product,
   type ProductCreationRequest,
-  ProductDataMode,
+
 } from "@/types";
 import { getPageSession, LOGGER } from "@/lib";
 import { FormState } from "@/components/core/DynamicForm";
@@ -128,7 +128,7 @@ export async function createProduct(
     updated_at: new Date().toISOString(),
     disabled: false,
     featured: 0,
-    data_mode: ProductDataMode.Open,
+
     metadata: {
       tags: [],
       primary_mirror: "aws-opendata-us-west-2",

--- a/src/lib/actions/products.ts
+++ b/src/lib/actions/products.ts
@@ -130,7 +130,6 @@ export async function createProduct(
     updated_at: new Date().toISOString(),
     disabled: false,
     featured: 0,
-
     metadata: {
       tags: [],
       primary_mirror: "aws-opendata-us-west-2",

--- a/src/lib/actions/products.ts
+++ b/src/lib/actions/products.ts
@@ -6,7 +6,7 @@ import {
   ProductCreationRequestSchema,
   type Product,
   type ProductCreationRequest,
-
+  type ProductVisibility,
 } from "@/types";
 import { getPageSession, LOGGER } from "@/lib";
 import { FormState } from "@/components/core/DynamicForm";
@@ -25,7 +25,9 @@ export interface PaginatedProductsResult {
 
 export async function getFeaturedProducts(limit = 10): Promise<Product[]> {
   try {
-    const result = await productsTable.listPublic(limit, undefined, { featuredOnly: true });
+    const result = await productsTable.listPublic(limit, undefined, {
+      featuredOnly: true,
+    });
     return productsTable.attachAccounts(result.products);
   } catch (error) {
     LOGGER.error("Failed to fetch featured products", {
@@ -218,10 +220,7 @@ export async function updateProduct(
     // Extract form data
     const title = formData.get("title") as string;
     const description = formData.get("description") as string;
-    const visibility = formData.get("visibility") as
-      | "public"
-      | "unlisted"
-      | "restricted";
+    const visibility = formData.get("visibility") as ProductVisibility;
 
     // Build update data
     const updateData = {

--- a/src/lib/actions/products.ts
+++ b/src/lib/actions/products.ts
@@ -137,10 +137,6 @@ export async function createProduct(
           storage_type: "s3",
           connection_id: "aws-opendata-us-west-2",
           prefix: `${validatedFields.data.account_id}/${validatedFields.data.product_id}/`,
-          config: {
-            region: "us-west-2",
-            bucket: "aws-opendata-us-west-2",
-          },
           is_primary: true,
         },
       },

--- a/src/lib/api/authz.test.ts
+++ b/src/lib/api/authz.test.ts
@@ -11,7 +11,7 @@ import {
   DataConnection,
   S3Regions,
   DataProvider,
-  RepositoryDataMode,
+  ProductVisibility,
 } from "@/types";
 import { AccountType } from "@/types/account";
 import { Account } from "@/types/account";
@@ -3026,7 +3026,7 @@ describe("Authorization Tests", () => {
       data_connection_id: "test-connection",
       name: "Test Connection",
       read_only: false,
-      allowed_data_modes: [RepositoryDataMode.Open],
+      allowed_data_modes: [ProductVisibility.Public],
       details: {
         provider: DataProvider.S3,
         bucket: "test-bucket",
@@ -3099,7 +3099,7 @@ describe("Authorization Tests", () => {
       data_connection_id: "test-connection",
       name: "Test Connection",
       read_only: false,
-      allowed_data_modes: [RepositoryDataMode.Open],
+      allowed_data_modes: [ProductVisibility.Public],
       details: {
         provider: DataProvider.S3,
         bucket: "test-bucket",
@@ -3172,7 +3172,7 @@ describe("Authorization Tests", () => {
       data_connection_id: "test-connection",
       name: "Test Connection",
       read_only: false,
-      allowed_data_modes: [RepositoryDataMode.Open],
+      allowed_data_modes: [ProductVisibility.Public],
       details: {
         provider: DataProvider.S3,
         bucket: "test-bucket",
@@ -3245,7 +3245,7 @@ describe("Authorization Tests", () => {
       data_connection_id: "test-connection",
       name: "Test Connection",
       read_only: false,
-      allowed_data_modes: [RepositoryDataMode.Open],
+      allowed_data_modes: [ProductVisibility.Public],
       details: {
         provider: DataProvider.S3,
         bucket: "test-bucket",
@@ -3342,7 +3342,7 @@ describe("Authorization Tests", () => {
       data_connection_id: "test-connection",
       name: "Test Connection",
       read_only: false,
-      allowed_data_modes: [RepositoryDataMode.Open],
+      allowed_data_modes: [ProductVisibility.Public],
       details: {
         provider: DataProvider.S3,
         bucket: "test-bucket",
@@ -3415,7 +3415,7 @@ describe("Authorization Tests", () => {
       data_connection_id: "test-connection",
       name: "Test Connection",
       read_only: false,
-      allowed_data_modes: [RepositoryDataMode.Open],
+      allowed_data_modes: [ProductVisibility.Public],
       details: {
         provider: DataProvider.S3,
         bucket: "test-bucket",

--- a/src/lib/api/authz.test.ts
+++ b/src/lib/api/authz.test.ts
@@ -3026,7 +3026,7 @@ describe("Authorization Tests", () => {
       data_connection_id: "test-connection",
       name: "Test Connection",
       read_only: false,
-      allowed_data_modes: [ProductVisibility.Public],
+      allowed_visibilities: [ProductVisibility.Public],
       details: {
         provider: DataProvider.S3,
         bucket: "test-bucket",
@@ -3099,7 +3099,7 @@ describe("Authorization Tests", () => {
       data_connection_id: "test-connection",
       name: "Test Connection",
       read_only: false,
-      allowed_data_modes: [ProductVisibility.Public],
+      allowed_visibilities: [ProductVisibility.Public],
       details: {
         provider: DataProvider.S3,
         bucket: "test-bucket",
@@ -3172,7 +3172,7 @@ describe("Authorization Tests", () => {
       data_connection_id: "test-connection",
       name: "Test Connection",
       read_only: false,
-      allowed_data_modes: [ProductVisibility.Public],
+      allowed_visibilities: [ProductVisibility.Public],
       details: {
         provider: DataProvider.S3,
         bucket: "test-bucket",
@@ -3245,7 +3245,7 @@ describe("Authorization Tests", () => {
       data_connection_id: "test-connection",
       name: "Test Connection",
       read_only: false,
-      allowed_data_modes: [ProductVisibility.Public],
+      allowed_visibilities: [ProductVisibility.Public],
       details: {
         provider: DataProvider.S3,
         bucket: "test-bucket",
@@ -3342,7 +3342,7 @@ describe("Authorization Tests", () => {
       data_connection_id: "test-connection",
       name: "Test Connection",
       read_only: false,
-      allowed_data_modes: [ProductVisibility.Public],
+      allowed_visibilities: [ProductVisibility.Public],
       details: {
         provider: DataProvider.S3,
         bucket: "test-bucket",
@@ -3415,7 +3415,7 @@ describe("Authorization Tests", () => {
       data_connection_id: "test-connection",
       name: "Test Connection",
       read_only: false,
-      allowed_data_modes: [ProductVisibility.Public],
+      allowed_visibilities: [ProductVisibility.Public],
       details: {
         provider: DataProvider.S3,
         bucket: "test-bucket",

--- a/src/lib/api/authz.ts
+++ b/src/lib/api/authz.ts
@@ -43,7 +43,7 @@ import {
   MembershipRole,
   MembershipState,
   Product,
-  ProductDataMode,
+
   UserSession,
 } from "@/types";
 import { match } from "ts-pattern";
@@ -680,8 +680,8 @@ function readRepositoryData(
     return false;
   }
 
-  // If the repository is open, everyone is authorized
-  if (product.data_mode === ProductDataMode.Open) {
+  // If the repository is public or unlisted, everyone is authorized
+  if (product.visibility === "public" || product.visibility === "unlisted") {
     return true;
   }
 
@@ -723,9 +723,8 @@ function getRepository(
     return false;
   }
 
-  // If the repository is open, everyone is authorized
-  // TODO: Right now we are treating unset data_mode as open
-  if (!product.data_mode || product.data_mode === ProductDataMode.Open) {
+  // If the repository is public or unlisted, everyone is authorized
+  if (product.visibility === "public" || product.visibility === "unlisted") {
     return true;
   }
 
@@ -767,12 +766,8 @@ function listRepository(
     return false;
   }
 
-  // If the repository is listed , everyone is authorized
-  if (
-    // product.state === RepositoryState.Listed &&
-    // product.data_mode === RepositoryDataMode.Open
-    product.visibility === "public"
-  ) {
+  // If the repository is public, everyone is authorized
+  if (product.visibility === "public") {
     return true;
   }
 

--- a/src/lib/api/authz.ts
+++ b/src/lib/api/authz.ts
@@ -43,7 +43,6 @@ import {
   MembershipRole,
   MembershipState,
   Product,
-
   UserSession,
 } from "@/types";
 import { match } from "ts-pattern";

--- a/src/lib/clients/database/data-connections.ts
+++ b/src/lib/clients/database/data-connections.ts
@@ -83,12 +83,12 @@ export class DataConnectionsTable extends BaseTable {
             data_connection_id: dataConnection.data_connection_id,
           },
           UpdateExpression:
-            "SET name = :name, prefix_template = :prefix_template, read_only = :read_only, allowed_data_modes = :allowed_data_modes, required_flag = :required_flag, details = :details, authentication = :authentication",
+            "SET name = :name, prefix_template = :prefix_template, read_only = :read_only, allowed_visibilities = :allowed_visibilities, required_flag = :required_flag, details = :details, authentication = :authentication",
           ExpressionAttributeValues: {
             ":name": dataConnection.name,
             ":prefix_template": dataConnection.prefix_template,
             ":read_only": dataConnection.read_only,
-            ":allowed_data_modes": dataConnection.allowed_data_modes,
+            ":allowed_visibilities": dataConnection.allowed_visibilities,
             ":required_flag": dataConnection.required_flag,
             ":details": dataConnection.details,
             ":authentication": dataConnection.authentication,

--- a/src/types/data-connection.ts
+++ b/src/types/data-connection.ts
@@ -161,6 +161,7 @@ export const DataConnectionSchema = z
     name: z.string(),
     prefix_template: z.optional(z.string()),
     read_only: z.boolean(),
+    // NOTE: allowed_data_modes is currently unenforced
     allowed_data_modes: z.array(z.nativeEnum(RepositoryDataMode)),
     required_flag: z.optional(z.nativeEnum(AccountFlags)),
     details: DataConnnectionDetailsSchema,

--- a/src/types/data-connection.ts
+++ b/src/types/data-connection.ts
@@ -156,8 +156,8 @@ export const DataConnectionSchema = z
     name: z.string(),
     prefix_template: z.optional(z.string()),
     read_only: z.boolean(),
-    // NOTE: allowed_data_modes is currently unenforced
-    allowed_data_modes: z.array(z.nativeEnum(ProductVisibility)),
+    // NOTE: allowed_visibilities is currently unenforced
+    allowed_visibilities: z.array(z.nativeEnum(ProductVisibility)),
     required_flag: z.optional(z.nativeEnum(AccountFlags)),
     details: DataConnnectionDetailsSchema,
     authentication: z.optional(DataConnectionAuthenticationSchema),

--- a/src/types/data-connection.ts
+++ b/src/types/data-connection.ts
@@ -11,13 +11,8 @@
 
 import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
 import { z } from "zod";
-import {
-  MIN_ID_LENGTH,
-  MAX_ID_LENGTH,
-  ID_REGEX,
-  RepositoryDataMode,
-  AccountFlags,
-} from "./shared";
+import { MIN_ID_LENGTH, MAX_ID_LENGTH, ID_REGEX, AccountFlags } from "./shared";
+import { ProductVisibility } from "./product";
 
 extendZodWithOpenApi(z);
 
@@ -162,7 +157,7 @@ export const DataConnectionSchema = z
     prefix_template: z.optional(z.string()),
     read_only: z.boolean(),
     // NOTE: allowed_data_modes is currently unenforced
-    allowed_data_modes: z.array(z.nativeEnum(RepositoryDataMode)),
+    allowed_data_modes: z.array(z.nativeEnum(ProductVisibility)),
     required_flag: z.optional(z.nativeEnum(AccountFlags)),
     details: DataConnnectionDetailsSchema,
     authentication: z.optional(DataConnectionAuthenticationSchema),

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -11,12 +11,6 @@ export const ProductMirrorSchema = z
     storage_type: z.enum(["s3", "azure", "gcs", "minio", "ceph"]),
     connection_id: z.string(), // Reference to storage connection config
     prefix: z.string(), // Format: "{account_id}/{product_id}/"
-    config: z.object({
-      region: z.string().optional(), // For S3/GCS
-      bucket: z.string().optional(), // For S3/GCS
-      container: z.string().optional(), // For Azure
-      endpoint: z.string().optional(), // For MinIO/Ceph
-    }),
     // Mirror-specific settings
     is_primary: z.boolean(), // Is this the primary mirror?
   })

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -36,17 +36,6 @@ export const ProductMetadataSchema = z
 
 export type ProductMetadata = z.infer<typeof ProductMetadataSchema>;
 
-export enum ProductDataMode {
-  Open = "open",
-  Subscription = "subscription",
-  Private = "private",
-}
-export const ProductDataModeSchema = z
-  .nativeEnum(ProductDataMode, {
-    errorMap: () => ({ message: "Invalid product data mode" }),
-  })
-  .openapi("ProductDataMode");
-
 // Main product interface matching new schema
 // Product is the main product entity, including metadata and optional account
 export const ProductSchema = z
@@ -62,7 +51,7 @@ export const ProductSchema = z
     account: AccountSchema.optional(),
     disabled: z.boolean(),
     featured: z.number(),
-    data_mode: ProductDataModeSchema,
+
     search_text: z.string().optional(),
   })
   .openapi("Product");
@@ -75,7 +64,7 @@ export const ProductCreationRequestSchema = ProductSchema.omit({
   account: true,
   disabled: true,
   featured: true,
-  data_mode: true,
+
   metadata: true,
 }).openapi("ProductCreationRequest");
 

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -53,7 +53,6 @@ export const ProductSchema = z
     account: AccountSchema.optional(),
     disabled: z.boolean(),
     featured: z.number(),
-
     search_text: z.string().optional(),
   })
   .openapi("Product");
@@ -66,7 +65,6 @@ export const ProductCreationRequestSchema = ProductSchema.omit({
   account: true,
   disabled: true,
   featured: true,
-
   metadata: true,
 }).openapi("ProductCreationRequest");
 

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -36,6 +36,14 @@ export const ProductMetadataSchema = z
 
 export type ProductMetadata = z.infer<typeof ProductMetadataSchema>;
 
+export enum ProductVisibility {
+  Public = "public",
+  Unlisted = "unlisted",
+  Restricted = "restricted",
+}
+
+export const ProductVisibilitySchema = z.nativeEnum(ProductVisibility);
+
 // Main product interface matching new schema
 // Product is the main product entity, including metadata and optional account
 export const ProductSchema = z
@@ -46,7 +54,7 @@ export const ProductSchema = z
     description: z.string(),
     created_at: z.string(),
     updated_at: z.string(),
-    visibility: z.enum(["public", "unlisted", "restricted"]),
+    visibility: ProductVisibilitySchema,
     metadata: ProductMetadataSchema,
     account: AccountSchema.optional(),
     disabled: z.boolean(),

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -36,7 +36,7 @@ export enum ProductVisibility {
   Restricted = "restricted",
 }
 
-export const ProductVisibilitySchema = z.nativeEnum(ProductVisibility);
+export const ProductVisibilitySchema = z.nativeEnum(ProductVisibility).openapi("ProductVisibility");
 
 // Main product interface matching new schema
 // Product is the main product entity, including metadata and optional account

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -32,12 +32,6 @@ export const DEFAULT_INDIVIDUAL_FLAGS: AccountFlags[] = [];
 
 export const DEFAULT_ORGANIZATION_FLAGS: AccountFlags[] = [];
 
-export enum RepositoryDataMode {
-  Open = "open",
-  Subscription = "subscription",
-  Private = "private",
-}
-
 // Common schemas
 export const AccountFlagsSchema = z
   .array(
@@ -46,12 +40,6 @@ export const AccountFlagsSchema = z
     })
   )
   .openapi("AccountFlags");
-
-export const RepositoryDataModeSchema = z
-  .nativeEnum(RepositoryDataMode, {
-    errorMap: () => ({ message: "Invalid repository data mode" }),
-  })
-  .openapi("RepositoryDataMode");
 
 // Common types
 export type ErrorResponse = {


### PR DESCRIPTION
## What I'm changing

Currently, our app does **not** enforce Product visibility. As such, anonymous users can view restricted products (e.g. https://staging.source.coop/alukach/alukach-experimentation).  This PR cleans up our data model by removing the legacy `data_mode` field from the Product and integrates the `visibility` into our authorization tooling. As such, we will require valid permissions for Products marked as `restricted`.

## How I did it

The Product model currently contains both a legacy `data_mode` and a modern `visibility` field. The `data_mode` should have been removed when we migrated to our new data model. During this migration, we populated the `visibility` field from the `data_mode`:

https://github.com/source-cooperative/source.coop/blob/5ad9b41ffd5395e5f75814e6e8126f0d2e2a1fde/scripts/load-dynamodb-exports.ts#L66-L72

However, the code base currently erroneously makes use of both `data_mode` and `visibility` when determining the product authorization:

https://github.com/source-cooperative/source.coop/blob/5ad9b41ffd5395e5f75814e6e8126f0d2e2a1fde/src/lib/api/authz.ts#L683-L686

https://github.com/source-cooperative/source.coop/blob/5ad9b41ffd5395e5f75814e6e8126f0d2e2a1fde/src/lib/api/authz.ts#L726-L730

https://github.com/source-cooperative/source.coop/blob/5ad9b41ffd5395e5f75814e6e8126f0d2e2a1fde/src/lib/api/authz.ts#L770-L777

Note that we don't surface `data_mode` in the Product form, only `visibility`, as the `data_mode` field is deprecated. 

This PR removes the `data_mode` field and only uses `visibility` for auth permissions. This seems inline with the documentation written during S2 development:

https://github.com/source-cooperative/source.coop/blob/5ad9b41ffd5395e5f75814e6e8126f0d2e2a1fde/docs/migration/schema-changes.md#L181-L186


## How you can test it

Compare 

* https://staging.source.coop/alukach/alukach-experimentation restricted, but publicly available
* https://source-cooperative-git-chore-rm-data-mode-radiantearth.vercel.app/alukach/alukach-experimentation restricted, not publicly available



> [!NOTE] 
> Before merging this, we need to determine what to do with the `DataConnection.allowed_data_modes` field. It's currently unenforced. https://github.com/source-cooperative/source.coop/blob/5ad9b41ffd5395e5f75814e6e8126f0d2e2a1fde/src/types/data-connection.ts#L164

---

closes #261

> [!WARNING] 
> BREAKING CHANGE: existing data-connections records must be backfilled.                                                                                                                            
> Run: npx tsx scripts/backfill-allowed-data-modes.ts <table-name>      