### PR TITLE
fix: make username lookups case-insensitive

### DIFF
--- a/src/app/(app)/[account_id]/page.tsx
+++ b/src/app/(app)/[account_id]/page.tsx
@@ -11,7 +11,7 @@
  */
 
 import { Metadata } from "next";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { OrganizationProfilePage } from "@/app/(app)/[account_id]/OrganizationProfilePage";
 import { accountsTable, isOrganizationalAccount } from "@/lib/clients/database";
 import { IndividualProfilePage } from "./IndividualProfilePage";
@@ -39,6 +39,10 @@ export async function generateMetadata({
 export default async function AccountPage({ params, searchParams }: PageProps) {
   const { account_id } = await params;
   const showWelcome = Object.hasOwn(await searchParams, "welcome");
+
+  if (account_id !== account_id.toLowerCase()) {
+    redirect(`/${account_id.toLowerCase()}`);
+  }
 
   const account = await accountsTable.fetchById(account_id);
   if (!account) {

--- a/src/lib/clients/database/accounts.ts
+++ b/src/lib/clients/database/accounts.ts
@@ -20,6 +20,7 @@ class AccountsTable extends BaseTable {
   model = "accounts";
 
   async fetchById(account_id: string): Promise<Account | null> {
+    account_id = account_id.toLowerCase();
     try {
       LOGGER.debug(`Trying to fetch account for ID`, {
         operation: "AccountsTable.fetchById",
@@ -60,8 +61,8 @@ class AccountsTable extends BaseTable {
   ): Promise<Account[]> {
     const accountBatches: Account[] = [];
 
-    // Remove duplicates
-    account_ids = [...new Set(account_ids)];
+    // Remove duplicates and normalize to lowercase
+    account_ids = [...new Set(account_ids.map((id) => id.toLowerCase()))];
 
     for (let i = 0; i < account_ids.length; i += batchSize) {
       const batch = account_ids.slice(i, i + batchSize);

--- a/src/lib/clients/database/products.ts
+++ b/src/lib/clients/database/products.ts
@@ -68,6 +68,7 @@ export class ProductsTable extends BaseTable {
     products: Product[];
     lastEvaluatedKey: any;
   }> {
+    account_id = account_id.toLowerCase();
     const result = await this.client.send(
       new QueryCommand({
         TableName: this.table,
@@ -170,6 +171,8 @@ export class ProductsTable extends BaseTable {
     account_id: string,
     product_id: string
   ): Promise<Product | null> {
+    account_id = account_id.toLowerCase();
+    product_id = product_id.toLowerCase();
     try {
       const [result, account] = await Promise.all([
         this.client.send(


### PR DESCRIPTION
Normalize account_id and product_id to lowercase before DynamoDB queries so that URLs like /ALukach resolve correctly to the /alukach account. Also redirects mixed-case account page URLs to their canonical lowercase form.

Closes #299

Generated with [Claude Code](https://claude.ai/code)