### PR TITLE
fix: validate bbox struct type before routing to STAC map viewer

### DIFF
--- a/src/components/features/products/object-browser/ObjectPreviewExternal.tsx
+++ b/src/components/features/products/object-browser/ObjectPreviewExternal.tsx
@@ -16,11 +16,21 @@ const isStacGeoParquet = async (sourceUrl: string): Promise<boolean> => {
     await db.run("SET home_directory='/tmp'");
     await db.run("SET extension_directory='/tmp/duckdb_extensions'");
 
+    // Check for required STAC columns and validate bbox is a struct (has xmin sub-field).
+    // Some files (e.g. Maxar) store bbox as a list/array rather than a struct, which causes
+    // the STAC map viewer to throw "Cannot extract field 'xmin' from expression 'bbox'".
     const reader = await db.runAndReadAll(
-      `SELECT count(*) > 0 FROM parquet_schema(?) WHERE name IN ('stac_version', 'geometry') GROUP BY file_name HAVING count(*) = 2`,
+      `WITH schema AS (SELECT * FROM parquet_schema(?))
+       SELECT
+         count(*) FILTER (WHERE name IN ('stac_version', 'geometry')) = 2
+           AND (count(*) FILTER (WHERE name = 'bbox') = 0
+                OR count(*) FILTER (WHERE name = 'xmin') > 0)
+         AS is_valid
+       FROM schema`,
       [sourceUrl],
     );
-    return reader.getRows().length > 0;
+    const rows = reader.getRows();
+    return rows.length > 0 && (rows[0][0] as boolean);
   } catch (error) {
     LOGGER.error(`Error checking for STAC GeoParquet: ${error}`, {
       operation: "isStacGeoParquet",


### PR DESCRIPTION
Files like maxar-opendata.parquet store the bbox column as a list/array rather than a struct with xmin/ymin/xmax/ymax fields. The STAC map viewer assumes bbox is a struct and throws a DuckDB Binder Error when it tries to access bbox.xmin on a non-struct column.

Extend the isStacGeoParquet schema check to also require that if a bbox column is present, it must have an xmin sub-field (indicating a proper struct). Files without a struct bbox fall back to the parquet-table viewer.

Closes #297

Generated with [Claude Code](https://claude.ai/code)