### PR TITLE
feat: Add custom COG viewer

### DIFF
--- a/src/components/features/products/object-browser/ObjectPreviewExternal.tsx
+++ b/src/components/features/products/object-browser/ObjectPreviewExternal.tsx
@@ -68,9 +68,12 @@ const getIframeAttributes = async (
         src: `https://source-cooperative.github.io/csv-table/?iframe=true&url=${url}`,
         style: { border: "1px solid var(--gray-5)" },
       };
-    // TIFF is disabled until https://github.com/source-cooperative/source.coop/issues/221 is fixed.
-    // case "tif":
-    // case "tiff":
+    case "tif":
+    case "tiff":
+      return {
+        src: `https://source-cooperative.github.io/cog-viewer/?url=${url}`,
+        style: { border: "1px solid var(--gray-5)" },
+      };
     case "avif":
     case "bmp":
     case "gif":


### PR DESCRIPTION
## What I'm changing

Based on @kylebarron's comment (https://github.com/source-cooperative/source.coop/pull/169#issuecomment-4375304561), I thought I'd give a vibe-coded COG viewer a try based on deck.gl-raster.

<!--
  High-level summary of what is achieved by these changes.

  Optional: reference related issues.
-->

## How I did it

Viewer here: https://github.com/source-cooperative/cog-viewer

Viewer renders COGs client-side. Written via vibe coding. Attempts to implement some sensible defaults:

* If < 3 bands, use single band viewer
* If >= 3 bands, use multiband viewer
* Render band selection tooling with dropdowns of known bands
* Avoid refetching data when rerendering

<!--
  Lower-level details of the steps taken to achieve goal.

  Include:
    - considerations made when deciding how to implement feature
    - any changes to API that could impact the Data Proxy
-->

## How you can test it

Compare to results mentioned in https://github.com/source-cooperative/source.coop/pull/169#issuecomment-4382686967:


* No Zoom, Fails to render (possibly due to projection issues near pole?): 
  * Before: https://source-cooperative-f97gdakvo-radiantearth.vercel.app/ausantarctic/ghrsst-mur-v2/2002/07/02/20020702090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1_sea_ice_fraction.tif
  * After: https://source-cooperative-git-feat-alt-cog-viewer-radiantearth.vercel.app/ausantarctic/ghrsst-mur-v2/2002/07/02/20020702090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1_sea_ice_fraction.tif
* Zooms to location, Fails to render: 
  * Before: https://source-cooperative-f97gdakvo-radiantearth.vercel.app/nasa/floods/florence_20180919t231350/florence_img_s1a_iw_rt30_20180919t231350_g_gpn_vh.tif
  * After: https://source-cooperative-git-feat-alt-cog-viewer-radiantearth.vercel.app/nasa/floods/florence_20180919t231350/florence_img_s1a_iw_rt30_20180919t231350_g_gpn_vh.tif
* Strange blockiness in TIF: 
  * Before: https://source-cooperative-f97gdakvo-radiantearth.vercel.app/cboettig/mobi/range-size-rarity-all/RSR_All.tif
  * After: https://source-cooperative-git-feat-alt-cog-viewer-radiantearth.vercel.app/cboettig/mobi/range-size-rarity-all/RSR_All.tif
* Stream networks are beautiful 
  * Before: https://source-cooperative-f97gdakvo-radiantearth.vercel.app/fika/waternet/raster/21_28.tif
  * After: https://source-cooperative-git-feat-alt-cog-viewer-radiantearth.vercel.app/fika/waternet/raster/21_28.tif


<!--
  Instructions on how a reviewer can verify these changes.

  Consider including screenshots or video demonstrating feature.
-->

closes #169 