### PR TITLE
Add PDF viewer, PNG bindings

### DIFF
--- a/src/components/features/products/object-browser/ObjectPreviewExternal.tsx
+++ b/src/components/features/products/object-browser/ObjectPreviewExternal.tsx
@@ -86,6 +86,11 @@ const getIframeAttributes = async (
         src: `https://source-cooperative.github.io/image-viewer/?url=${url}`,
         style: { border: "1px solid var(--gray-5)" },
       };
+    case "pdf":
+      return {
+        src: `https://source-cooperative.github.io/pdf-viewer/?url=${url}`,
+        style: { border: "1px solid var(--gray-5)" },
+      };
     case "glb":
     case "gltf":
     case "obj":

--- a/src/components/features/products/object-browser/ObjectPreviewExternal.tsx
+++ b/src/components/features/products/object-browser/ObjectPreviewExternal.tsx
@@ -79,6 +79,7 @@ const getIframeAttributes = async (
     case "gif":
     case "jpg":
     case "jpeg":
+    case "png":
     case "svg":
     case "webp":
       return {


### PR DESCRIPTION
## What I'm changing

Added the capability to preview PDFs and PNGs in the browser when browsing Source data products.

## How I did it

* Added an ObjectPreviewExternal binding for `.pdf` to the PDF viewer app I just added to the Source org: [source-cooperative/pdf-viewer](https://github.com/source-cooperative/pdf-viewer).
* We had inadvertently omitted a `.png` binding to the existing image viewer, so I added that as well.

## How you can test it

Navigate to a PDF or PNG file in your dev instance of Source and confirm that the file can be previewed.