### PR TITLE
fix: validate product DOI format

### DIFF
--- a/fixtures/products.json
+++ b/fixtures/products.json
@@ -18,6 +18,7 @@
       },
       "primary_mirror": "primary-data-connection",
       "tags": ["mock"],
+      "doi": "10.1234/regular-user-dataset",
       "roles": {}
     },
     "disabled": false,

--- a/src/types/product.test.ts
+++ b/src/types/product.test.ts
@@ -1,0 +1,40 @@
+import { ProductMetadataSchema } from "./product";
+
+const baseMetadata = {
+  mirrors: {
+    "primary-data-connection": {
+      storage_type: "s3" as const,
+      connection_id: "primary-data-connection",
+      prefix: "account/product/",
+      is_primary: true,
+    },
+  },
+  primary_mirror: "primary-data-connection",
+};
+
+describe("ProductMetadataSchema DOI validation", () => {
+  it("accepts metadata without a DOI", () => {
+    expect(ProductMetadataSchema.safeParse(baseMetadata).success).toBe(true);
+  });
+
+  it.each([
+    "10.1234/foo.bar",
+    "10.1000/182",
+    "10.1234/abc-DEF_123;(x):y/z",
+  ])("accepts well-formed DOI %p", (doi) => {
+    const result = ProductMetadataSchema.safeParse({ ...baseMetadata, doi });
+    expect(result.success).toBe(true);
+  });
+
+  it.each([
+    "not-a-doi",
+    "10/missing-registrant",
+    "10.1234/", // empty suffix
+    "https://doi.org/10.1234/foo", // must be the bare DOI, not a URL
+    "<script>alert(1)</script>",
+    "10.12/too-short-registrant",
+  ])("rejects malformed DOI %p", (doi) => {
+    const result = ProductMetadataSchema.safeParse({ ...baseMetadata, doi });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/types/product.test.ts
+++ b/src/types/product.test.ts
@@ -17,6 +17,17 @@ describe("ProductMetadataSchema DOI validation", () => {
     expect(ProductMetadataSchema.safeParse(baseMetadata).success).toBe(true);
   });
 
+  it("trims surrounding whitespace from a DOI", () => {
+    const result = ProductMetadataSchema.safeParse({
+      ...baseMetadata,
+      doi: "  10.1234/foo.bar  ",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.doi).toBe("10.1234/foo.bar");
+    }
+  });
+
   it.each([
     "10.1234/foo.bar",
     "10.1000/182",

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -26,6 +26,7 @@ const DOI_REGEX = /^10\.\d{4,9}\/[-._;()/:A-Za-z0-9]+$/;
 
 export const DoiSchema = z
   .string()
+  .trim()
   .regex(DOI_REGEX, "Invalid DOI (expected a bare DOI such as 10.1234/foo.bar)");
 
 // Metadata for a product, including mirrors, roles, and tags

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -18,13 +18,23 @@ export const ProductMirrorSchema = z
 
 export type ProductMirror = z.infer<typeof ProductMirrorSchema>;
 
+// A Digital Object Identifier: "10.<registrant>/<suffix>" (e.g. 10.1234/foo.bar).
+// Stored bare (without the https://doi.org/ prefix), since that prefix is added
+// when rendering links and schema.org identifiers. Pattern from Crossref:
+// https://www.crossref.org/blog/dois-and-matching-regular-expressions/
+const DOI_REGEX = /^10\.\d{4,9}\/[-._;()/:A-Za-z0-9]+$/;
+
+export const DoiSchema = z
+  .string()
+  .regex(DOI_REGEX, "Invalid DOI (expected a bare DOI such as 10.1234/foo.bar)");
+
 // Metadata for a product, including mirrors, roles, and tags
 export const ProductMetadataSchema = z
   .object({
     mirrors: z.record(ProductMirrorSchema),
     primary_mirror: z.string(), // Key of the primary mirror (e.g., "aws-us-east-1")
     tags: z.array(z.string()).optional(),
-    doi: z.string().optional(), // Digital Object Identifier
+    doi: DoiSchema.optional(), // Digital Object Identifier
   })
   .openapi("ProductMetadata");
 


### PR DESCRIPTION
## Summary

`ProductMetadata.doi` was an unvalidated `z.string().optional()`. A malformed or junk value would be stored and then interpolated into:

- `https://doi.org/${doi}` links (`DataCiteSection`, `ProductSummaryCard`)
- the schema.org `identifier` on public product pages (`ProductSchemaMetadata`)

producing broken DOI links and invalid schema.org markup. (JSON-LD escaping already prevents script injection, so this is a data-quality issue, not an XSS one.)

## Changes

- Add a `DoiSchema` constraining `doi` to the [Crossref DOI pattern](https://www.crossref.org/blog/dois-and-matching-regular-expressions/) — a bare `10.<registrant>/<suffix>` (no `https://doi.org/` prefix, since that's added at render time).
- Add `src/types/product.test.ts` covering accepted and rejected DOI values.
- Add a valid DOI to a fixture product as a concrete example.

## Safety

Product reads cast DynamoDB rows to `Product` **without** calling `.parse()`, so this only tightens the write/validation path. Existing stored products — including any with malformed DOIs — are unaffected at read time.

## Testing

- `npx tsc --noEmit` — clean
- Full jest suite — 135 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)