### PR TITLE
ci: deliver one formal, replaceable Claude PR review

### DIFF
--- a/.github/workflows/pr-review-comprehensive.yml
+++ b/.github/workflows/pr-review-comprehensive.yml
@@ -1,4 +1,4 @@
-name: Claude Auto Review with Tracking
+name: Claude Auto Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
@@ -19,32 +19,54 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          track_progress: true # ✨ Enables tracking comments
+          # No track_progress / use_sticky_comment: we deliver a single FORMAL PR
+          # review and supersede the prior one, so there are no accumulating
+          # progress/summary comments across pushes.
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            PR: ${{ github.event.pull_request.number }}
 
-            STEP 1 — Clean up prior review artifacts from previous runs of THIS workflow:
-            - List inline review comments:
-              `gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments" --paginate`
-              For each whose body starts with `<!-- claude-review-inline -->`, delete it:
-              `gh api -X DELETE "repos/${{ github.repository }}/pulls/comments/<id>"`
-            - List issue comments:
-              `gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" --paginate`
-              Find the one whose body starts with `<!-- claude-review-summary -->` (if any) and remember its id as PRIOR_SUMMARY_ID.
+            You are reviewing this pull request. Deliver exactly ONE formal GitHub
+            pull request review per run, replacing any prior review from earlier runs.
 
-            STEP 2 — Review this pull request with a focus on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Security implications
-            - Performance considerations
+            STEP 1 — Supersede prior rounds.
+            List existing reviews:
+              `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews --paginate`
+            For each review authored by the Claude app user whose state is APPROVED or
+            CHANGES_REQUESTED (i.e. still active), dismiss it so only this run's review
+            is in effect:
+              `gh api -X PUT repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews/<id>/dismissals \
+                 -f message="Superseded by a newer Claude review." -f event=DISMISS`
 
-            For each specific issue, post an inline comment whose body begins with the marker line `<!-- claude-review-inline -->` followed by your feedback.
+            STEP 2 — Review the diff (`gh pr diff`) for correctness bugs, security
+            issues, and clear best-practice problems. Skip nits and anything the
+            linter/formatter already enforces. If nothing is blocking, say so briefly —
+            do not pad the review.
 
-            STEP 3 — Post a single sticky summary comment whose body begins with the marker line `<!-- claude-review-summary -->`.
-            - If PRIOR_SUMMARY_ID exists, update it in place:
-              `gh api -X PATCH "repos/${{ github.repository }}/issues/comments/<PRIOR_SUMMARY_ID>" -f body=@<file>`
-            - Otherwise create it with `gh pr comment`.
+            STEP 3 — Submit ONE formal review in a single API call, bundling every
+            inline note in the `comments` array. Build a JSON file and post it:
+              `gh api -X POST repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews --input <file>`
 
+            Requirements for that JSON:
+            - "event": "REQUEST_CHANGES" if there are blocking issues, otherwise "COMMENT".
+              Never use "APPROVE" (bot approvals are restricted and not meaningful here).
+            - "body": a short verdict followed by a brief bullet list. No checklists,
+              no progress logs.
+            - "comments": one entry per finding, each { "path", "line" (and "start_line"
+              for multi-line), "body" }. Anchor each to the exact changed line(s).
+
+            MAKE FINDINGS ONE-CLICK APPLYABLE. Whenever a finding has a concrete code
+            fix, put a GitHub suggestion block in that inline comment's body so the
+            author can apply it with the "Commit suggestion" button:
+
+                ```suggestion
+                <the exact replacement text for the commented line(s)>
+                ```
+
+            The suggestion content must replace the full line range the comment is
+            anchored to (use start_line..line for multi-line replacements). Prefer
+            several small, targeted suggestions over one large comment — they are far
+            easier for the author to apply individually. Reserve plain prose comments
+            for issues that have no mechanical fix.
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*)"
+            --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*)"


### PR DESCRIPTION
## What I'm changing

Reworks the automated Claude PR review workflow (`pr-review-comprehensive.yml`) to deliver **one formal, self-replacing GitHub review per run** instead of a growing pile of comments.

Previously the workflow ran two overlapping comment systems:
- `track_progress: true` posted a `**Claude finished…**` checklist comment — a **new one on every push** (e.g. PR #319 accumulated three).
- The prompt separately hand-rolled a sticky `<!-- claude-review-summary -->` comment and manually deleted/re-posted inline comments.

## How I did it

- Removed `track_progress`, which was the sole source of the duplicated per-run checklist comments.
- Each run now **dismisses the prior active Claude review**, then submits **exactly one formal pull request review** via `POST /pulls/{n}/reviews` (`event: REQUEST_CHANGES` when blocking, else `COMMENT`; never `APPROVE`, since bot approvals are restricted and not meaningful). The result shows up in the **Reviews** section and supersedes the previous round.
- Findings are bundled as inline comments inside that single review, and the prompt instructs Claude to include GitHub ` ```suggestion ` blocks so the author can apply each fix with one click. It favors several small targeted suggestions over one large prose comment.

Net effect: no accumulating progress/summary comments, a real "Claude reviewed" entry, and easy-to-apply suggestions.

## How you can test it

Open a small test PR against this branch (or merge and open any PR) and confirm:
1. A single formal review appears in the **Reviews** section rather than standalone checklist/summary comments.
2. Pushing a new commit dismisses the prior review and posts a fresh one — reviews don't pile up.
3. Inline findings with a concrete fix render an **Apply / Commit suggestion** button.
