### PR TITLE
ci: add merge-readiness verdict and verify suggestion blocks in PR review

### DIFF
--- a/.github/workflows/pr-review-comprehensive.yml
+++ b/.github/workflows/pr-review-comprehensive.yml
@@ -2,6 +2,11 @@ name: Claude Auto Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
+    # Skip when a PR touches workflow files: the action can't validate/run
+    # against modified workflows and fails with "401 Unauthorized - Workflow
+    # validation failed".
+    paths-ignore:
+      - '.github/workflows/**'
 
 jobs:
   review:

--- a/.github/workflows/pr-review-comprehensive.yml
+++ b/.github/workflows/pr-review-comprehensive.yml
@@ -50,8 +50,13 @@ jobs:
             Requirements for that JSON:
             - "event": "REQUEST_CHANGES" if there are blocking issues, otherwise "COMMENT".
               Never use "APPROVE" (bot approvals are restricted and not meaningful here).
-            - "body": a short verdict followed by a brief bullet list. No checklists,
-              no progress logs.
+            - "body": begin with a single bold verdict line that starts with a clear
+              status emoji — `✅` when nothing is blocking (safe to merge) or `❌` when
+              changes are requested — e.g. `**✅ No blocking issues — safe to merge.**`
+              or `**❌ Changes requested — see findings below.**`. The emoji must match
+              the "event": ✅ pairs with "COMMENT", ❌ pairs with "REQUEST_CHANGES".
+              Follow the verdict line with a brief bullet list. No checklists, no
+              progress logs.
             - "comments": one entry per finding, each { "path", "line" (and "start_line"
               for multi-line), "body" }. Anchor each to the exact changed line(s).
 
@@ -68,5 +73,12 @@ jobs:
             several small, targeted suggestions over one large comment — they are far
             easier for the author to apply individually. Reserve plain prose comments
             for issues that have no mechanical fix.
+
+            Before posting any suggestion block, re-read it and verify it is
+            syntactically complete — balanced brackets, parens, and braces — and that
+            it would compile if committed verbatim. The author applies it with one
+            click, so a malformed suggestion breaks their build. If you are not
+            confident the replacement is exactly correct, describe the fix in prose
+            instead.
           claude_args: |
             --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*)"


### PR DESCRIPTION
## What

Two refinements to the Claude auto-review workflow (`pr-review-comprehensive.yml`):

1. **Explicit merge-readiness verdict.** Each formal review body now leads with a bold verdict line prefixed by a status emoji — `✅` when nothing is blocking (safe to merge) or `❌` when changes are requested. The emoji is pinned to the review event (✅↔COMMENT, ❌↔REQUEST_CHANGES), so the comment states an explicit, at-a-glance merge call instead of just an implicit "no blocking issues."

2. **Suggestion-block self-check.** Before posting a `suggestion` block, the reviewer must re-read it and confirm balanced brackets/parens/braces and that it would compile if committed verbatim — and fall back to prose when unsure.

## Why

- The review never emits a formal GitHub `APPROVE`, so authors had no clear at-a-glance signal of merge-readiness from the comment body. The emoji verdict fixes that.
- Motivated by a malformed suggestion in #320 ([discussion](https://github.com/source-cooperative/source.coop/pull/320#discussion_r3328146787)): the suggested code had an unbalanced bracket and would have broken the build if applied via the one-click "Commit suggestion" button. The new workflow leans heavily on suggestion blocks, so a self-check guards against that failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)