### PR TITLE
feat: add X-Robots-Tag header for non-production deployments

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -23,6 +23,22 @@ const nextConfig = {
     },
   },
   serverExternalPackages: ["@duckdb/node-api"],
+  async headers() {
+    if (process.env.STAGE === "prod") {
+      return [];
+    }
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          {
+            key: "X-Robots-Tag",
+            value: "noindex, nofollow",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/next.config.test.ts
+++ b/next.config.test.ts
@@ -1,0 +1,41 @@
+import nextConfig from "./next.config.js";
+
+describe("next.config headers()", () => {
+  const originalStage = process.env.STAGE;
+
+  afterEach(() => {
+    if (originalStage === undefined) {
+      delete process.env.STAGE;
+    } else {
+      process.env.STAGE = originalStage;
+    }
+  });
+
+  test("non-prod stage emits noindex header on all paths", async () => {
+    process.env.STAGE = "dev";
+    const result = await nextConfig.headers!();
+    expect(result).toEqual([
+      {
+        source: "/:path*",
+        headers: [{ key: "X-Robots-Tag", value: "noindex, nofollow" }],
+      },
+    ]);
+  });
+
+  test("prod stage emits no header overrides", async () => {
+    process.env.STAGE = "prod";
+    const result = await nextConfig.headers!();
+    expect(result).toEqual([]);
+  });
+
+  test("missing STAGE defaults to noindex", async () => {
+    delete process.env.STAGE;
+    const result = await nextConfig.headers!();
+    expect(result).toEqual([
+      {
+        source: "/:path*",
+        headers: [{ key: "X-Robots-Tag", value: "noindex, nofollow" }],
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
Adds `X-Robots-Tag: noindex, nofollow` HTTP response header to all routes when `STAGE` is not `"prod"`, preventing staging and development deployments from being indexed by Google Dataset Search.

Closes #302

Generated with [Claude Code](https://claude.ai/code)