### PR TITLE
feat(data-connection): federated backend authentication (AWS web identity + GCP/Azure scaffold)

### DIFF
--- a/src/types/data-connection.test.ts
+++ b/src/types/data-connection.test.ts
@@ -1,0 +1,62 @@
+/** @jest-environment node */
+import {
+  DataConnectionAuthenticationSchema,
+  DataConnectionAuthenticationType,
+  DataConnectionSchema,
+} from "./data-connection";
+
+describe("DataConnectionAuthentication (V2 web-identity role)", () => {
+  test("parses the s3_web_identity_role variant", () => {
+    const auth = DataConnectionAuthenticationSchema.parse({
+      type: "s3_web_identity_role",
+      role_arn: "arn:aws:iam::123456789012:role/source-coop",
+    });
+    expect(auth.type).toBe(DataConnectionAuthenticationType.S3WebIdentityRole);
+    expect(auth).toMatchObject({
+      role_arn: "arn:aws:iam::123456789012:role/source-coop",
+    });
+  });
+
+  test("rejects s3_web_identity_role without a role_arn", () => {
+    expect(() =>
+      DataConnectionAuthenticationSchema.parse({ type: "s3_web_identity_role" })
+    ).toThrow();
+  });
+
+  test("parses the scaffolded gcp_workload_identity variant", () => {
+    const auth = DataConnectionAuthenticationSchema.parse({
+      type: "gcp_workload_identity",
+      workload_identity_provider:
+        "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/p/providers/pr",
+      service_account: "sa@project.iam.gserviceaccount.com",
+    });
+    expect(auth.type).toBe(DataConnectionAuthenticationType.GcpWorkloadIdentity);
+  });
+
+  test("parses the scaffolded azure_workload_identity variant", () => {
+    const auth = DataConnectionAuthenticationSchema.parse({
+      type: "azure_workload_identity",
+      tenant_id: "00000000-0000-0000-0000-000000000000",
+      client_id: "11111111-1111-1111-1111-111111111111",
+    });
+    expect(auth.type).toBe(
+      DataConnectionAuthenticationType.AzureWorkloadIdentity
+    );
+  });
+
+  test("authentication is optional on a data connection (omitted = unsigned)", () => {
+    const dc = DataConnectionSchema.parse({
+      data_connection_id: "conn-1",
+      name: "Conn",
+      read_only: false,
+      allowed_visibilities: [],
+      details: {
+        provider: "s3",
+        bucket: "example-bucket",
+        base_prefix: "",
+        region: "us-west-2",
+      },
+    });
+    expect(dc.authentication).toBeUndefined();
+  });
+});

--- a/src/types/data-connection.test.ts
+++ b/src/types/data-connection.test.ts
@@ -53,7 +53,35 @@ describe("DataConnectionAuthentication (V2 web-identity role)", () => {
     ).toThrow();
   });
 
-  test("parses the scaffolded gcp_workload_identity variant", () => {
+  test("rejects gcp_workload_identity without service_account", () => {
+    expect(() =>
+      DataConnectionAuthenticationSchema.parse({
+        type: "gcp_workload_identity",
+        workload_identity_provider:
+          "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/p/providers/pr",
+      })
+    ).toThrow();
+  });
+
+  test("rejects azure_workload_identity without tenant_id", () => {
+    expect(() =>
+      DataConnectionAuthenticationSchema.parse({
+        type: "azure_workload_identity",
+        client_id: "11111111-1111-1111-1111-111111111111",
+      })
+    ).toThrow();
+  });
+
+  test("rejects azure_workload_identity without client_id", () => {
+    expect(() =>
+      DataConnectionAuthenticationSchema.parse({
+        type: "azure_workload_identity",
+        tenant_id: "00000000-0000-0000-0000-000000000000",
+      })
+    ).toThrow();
+  });
+
+  test("authentication field is optional and absent by default", () => {
     const dc = DataConnectionSchema.parse({
       data_connection_id: "conn-1",
       name: "Conn",

--- a/src/types/data-connection.test.ts
+++ b/src/types/data-connection.test.ts
@@ -81,6 +81,50 @@ describe("DataConnectionAuthentication (V2 workload-identity variants)", () => {
     ).toThrow();
   });
 
+  test("rejects s3_web_identity_role with an empty role_arn", () => {
+    expect(() =>
+      DataConnectionAuthenticationSchema.parse({
+        type: "s3_web_identity_role",
+        role_arn: "",
+      })
+    ).toThrow();
+  });
+
+  test("rejects gcp_workload_identity with empty string fields", () => {
+    expect(() =>
+      DataConnectionAuthenticationSchema.parse({
+        type: "gcp_workload_identity",
+        workload_identity_provider: "",
+        service_account: "sa@project.iam.gserviceaccount.com",
+      })
+    ).toThrow();
+    expect(() =>
+      DataConnectionAuthenticationSchema.parse({
+        type: "gcp_workload_identity",
+        workload_identity_provider:
+          "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/p/providers/pr",
+        service_account: "",
+      })
+    ).toThrow();
+  });
+
+  test("rejects azure_workload_identity with empty string fields", () => {
+    expect(() =>
+      DataConnectionAuthenticationSchema.parse({
+        type: "azure_workload_identity",
+        tenant_id: "",
+        client_id: "11111111-1111-1111-1111-111111111111",
+      })
+    ).toThrow();
+    expect(() =>
+      DataConnectionAuthenticationSchema.parse({
+        type: "azure_workload_identity",
+        tenant_id: "00000000-0000-0000-0000-000000000000",
+        client_id: "",
+      })
+    ).toThrow();
+  });
+
   test("authentication field is optional and absent by default", () => {
     const dc = DataConnectionSchema.parse({
       data_connection_id: "conn-1",

--- a/src/types/data-connection.test.ts
+++ b/src/types/data-connection.test.ts
@@ -3,6 +3,8 @@ import {
   DataConnectionAuthenticationSchema,
   DataConnectionAuthenticationType,
   DataConnectionSchema,
+  DataConnnectionDetailsSchema,
+  DataProvider,
 } from "./data-connection";
 
 describe("DataConnectionAuthentication (V2 workload-identity variants)", () => {
@@ -202,5 +204,74 @@ describe("DataConnectionAuthentication (V2 workload-identity variants)", () => {
       },
     });
     expect(dc.authentication).toBeUndefined();
+  });
+});
+
+describe("DataConnectionDetails (S3-compatible + GCP variants)", () => {
+  test("parses an S3-compatible (R2) connection with a custom endpoint", () => {
+    const details = DataConnnectionDetailsSchema.parse({
+      provider: "s3",
+      bucket: "my-bucket",
+      base_prefix: "",
+      region: "auto",
+      endpoint: "https://abc123.r2.cloudflarestorage.com",
+    });
+    expect(details.provider).toBe(DataProvider.S3);
+    expect(details).toMatchObject({
+      region: "auto",
+      endpoint: "https://abc123.r2.cloudflarestorage.com",
+    });
+  });
+
+  test("endpoint is optional for AWS S3", () => {
+    const details = DataConnnectionDetailsSchema.parse({
+      provider: "s3",
+      bucket: "my-bucket",
+      base_prefix: "",
+      region: "us-east-1",
+    });
+    expect("endpoint" in details && details.endpoint).toBeFalsy();
+  });
+
+  test("rejects a non-URL endpoint", () => {
+    expect(() =>
+      DataConnnectionDetailsSchema.parse({
+        provider: "s3",
+        bucket: "my-bucket",
+        base_prefix: "",
+        region: "auto",
+        endpoint: "not-a-url",
+      })
+    ).toThrow();
+  });
+
+  test("parses a GCP (GCS) connection", () => {
+    const details = DataConnnectionDetailsSchema.parse({
+      provider: "gcp",
+      bucket: "my-gcs-bucket",
+      base_prefix: "data/",
+    });
+    expect(details.provider).toBe(DataProvider.GCP);
+    expect(details).toMatchObject({ bucket: "my-gcs-bucket" });
+  });
+
+  test("parses a full GCP connection with workload-identity auth", () => {
+    const dc = DataConnectionSchema.parse({
+      data_connection_id: "gcs-conn",
+      name: "GCS",
+      read_only: false,
+      allowed_visibilities: [],
+      details: { provider: "gcp", bucket: "my-gcs-bucket", base_prefix: "" },
+      authentication: {
+        type: "gcp_workload_identity",
+        workload_identity_provider:
+          "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/p/providers/pr",
+        service_account: "sa@my-project.iam.gserviceaccount.com",
+      },
+    });
+    expect(dc.details.provider).toBe(DataProvider.GCP);
+    expect(dc.authentication?.type).toBe(
+      DataConnectionAuthenticationType.GcpWorkloadIdentity
+    );
   });
 });

--- a/src/types/data-connection.test.ts
+++ b/src/types/data-connection.test.ts
@@ -44,7 +44,16 @@ describe("DataConnectionAuthentication (V2 web-identity role)", () => {
     );
   });
 
-  test("authentication is optional on a data connection (omitted = unsigned)", () => {
+  test("rejects gcp_workload_identity without workload_identity_provider", () => {
+    expect(() =>
+      DataConnectionAuthenticationSchema.parse({
+        type: "gcp_workload_identity",
+        service_account: "sa@project.iam.gserviceaccount.com",
+      })
+    ).toThrow();
+  });
+
+  test("parses the scaffolded gcp_workload_identity variant", () => {
     const dc = DataConnectionSchema.parse({
       data_connection_id: "conn-1",
       name: "Conn",

--- a/src/types/data-connection.test.ts
+++ b/src/types/data-connection.test.ts
@@ -5,7 +5,7 @@ import {
   DataConnectionSchema,
 } from "./data-connection";
 
-describe("DataConnectionAuthentication (V2 web-identity role)", () => {
+describe("DataConnectionAuthentication (V2 workload-identity variants)", () => {
   test("parses the s3_web_identity_role variant", () => {
     const auth = DataConnectionAuthenticationSchema.parse({
       type: "s3_web_identity_role",

--- a/src/types/data-connection.test.ts
+++ b/src/types/data-connection.test.ts
@@ -7,7 +7,7 @@ import {
   DataProvider,
 } from "./data-connection";
 
-describe("DataConnectionAuthentication (V2 workload-identity variants)", () => {
+describe("DataConnection V2 workload-identity variants", () => {
   test("parses the s3_web_identity_role variant", () => {
     const auth = DataConnectionAuthenticationSchema.parse({
       type: "s3_web_identity_role",

--- a/src/types/data-connection.test.ts
+++ b/src/types/data-connection.test.ts
@@ -125,6 +125,69 @@ describe("DataConnectionAuthentication (V2 workload-identity variants)", () => {
     ).toThrow();
   });
 
+  test("accepts a GovCloud role_arn (partition-tolerant)", () => {
+    const auth = DataConnectionAuthenticationSchema.parse({
+      type: "s3_web_identity_role",
+      role_arn: "arn:aws-us-gov:iam::123456789012:role/team/source-coop",
+    });
+    expect(auth.type).toBe(DataConnectionAuthenticationType.S3WebIdentityRole);
+  });
+
+  test("rejects a role_arn that is not an IAM role ARN", () => {
+    for (const role_arn of [
+      "not-an-arn",
+      "arn:aws:s3:::some-bucket",
+      "arn:aws:iam::abc:role/source-coop",
+    ]) {
+      expect(() =>
+        DataConnectionAuthenticationSchema.parse({
+          type: "s3_web_identity_role",
+          role_arn,
+        })
+      ).toThrow();
+    }
+  });
+
+  test("rejects a workload_identity_provider with the wrong prefix", () => {
+    expect(() =>
+      DataConnectionAuthenticationSchema.parse({
+        type: "gcp_workload_identity",
+        workload_identity_provider: "https://iam.googleapis.com/projects/123",
+        service_account: "sa@project.iam.gserviceaccount.com",
+      })
+    ).toThrow();
+  });
+
+  test("rejects a service_account that is not a gserviceaccount.com email", () => {
+    for (const service_account of ["not-an-email", "user@gmail.com"]) {
+      expect(() =>
+        DataConnectionAuthenticationSchema.parse({
+          type: "gcp_workload_identity",
+          workload_identity_provider:
+            "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/p/providers/pr",
+          service_account,
+        })
+      ).toThrow();
+    }
+  });
+
+  test("rejects azure_workload_identity with non-UUID ids", () => {
+    expect(() =>
+      DataConnectionAuthenticationSchema.parse({
+        type: "azure_workload_identity",
+        tenant_id: "contoso",
+        client_id: "11111111-1111-1111-1111-111111111111",
+      })
+    ).toThrow();
+    expect(() =>
+      DataConnectionAuthenticationSchema.parse({
+        type: "azure_workload_identity",
+        tenant_id: "00000000-0000-0000-0000-000000000000",
+        client_id: "not-a-uuid",
+      })
+    ).toThrow();
+  });
+
   test("authentication field is optional and absent by default", () => {
     const dc = DataConnectionSchema.parse({
       data_connection_id: "conn-1",

--- a/src/types/data-connection.ts
+++ b/src/types/data-connection.ts
@@ -124,7 +124,7 @@ export const AzureSasTokenAuthenticationSchema = z
 export const S3WebIdentityRoleAuthenticationSchema = z
   .object({
     type: z.literal(DataConnectionAuthenticationType.S3WebIdentityRole),
-    role_arn: z.string(),
+    role_arn: z.string().min(1),
   })
   .openapi("S3WebIdentityRoleAuthentication");
 
@@ -139,9 +139,9 @@ export const GcpWorkloadIdentityAuthenticationSchema = z
   .object({
     type: z.literal(DataConnectionAuthenticationType.GcpWorkloadIdentity),
     /** Full WIF provider resource: `//iam.googleapis.com/projects/.../providers/...`. */
-    workload_identity_provider: z.string(),
+    workload_identity_provider: z.string().min(1),
     /** Service account email the exchanged token impersonates for GCS. */
-    service_account: z.string(),
+    service_account: z.string().min(1),
   })
   .openapi("GcpWorkloadIdentityAuthentication");
 
@@ -156,9 +156,9 @@ export const AzureWorkloadIdentityAuthenticationSchema = z
   .object({
     type: z.literal(DataConnectionAuthenticationType.AzureWorkloadIdentity),
     /** Azure AD tenant (directory) ID. */
-    tenant_id: z.string(),
+    tenant_id: z.string().min(1),
     /** App registration (client) ID holding the federated identity credential. */
-    client_id: z.string(),
+    client_id: z.string().min(1),
   })
   .openapi("AzureWorkloadIdentityAuthentication");
 

--- a/src/types/data-connection.ts
+++ b/src/types/data-connection.ts
@@ -23,6 +23,11 @@ export enum DataProvider {
 }
 
 export enum S3Regions {
+  /**
+   * For S3-compatible backends (e.g. Cloudflare R2) that don't use an AWS
+   * region. Pair with a custom `endpoint` on the connection.
+   */
+  AUTO = "auto",
   AF_SOUTH_1 = "af-south-1",
   AP_EAST_1 = "ap-east-1",
   AP_NORTHEAST_1 = "ap-northeast-1",
@@ -193,6 +198,11 @@ export const S3DataConnectionSchema = z
     bucket: z.string(),
     base_prefix: z.string(),
     region: z.nativeEnum(S3Regions),
+    /**
+     * Custom S3-compatible endpoint for non-AWS backends (Cloudflare R2, MinIO,
+     * Ceph). Omit for AWS S3, which derives its endpoint from `region`.
+     */
+    endpoint: z.optional(z.string().url()),
   })
   .openapi("S3DataConnection");
 
@@ -206,13 +216,28 @@ export const AzureDataConnectionSchema = z
   })
   .openapi("AzureDataConnection");
 
+/**
+ * Google Cloud Storage. Access is keyless via GCP Workload Identity Federation
+ * (the `gcp_workload_identity` authentication variant), so no region/endpoint is
+ * needed to address the bucket.
+ */
+export const GcpDataConnectionSchema = z
+  .object({
+    provider: z.literal(DataProvider.GCP),
+    bucket: z.string(),
+    base_prefix: z.string(),
+  })
+  .openapi("GcpDataConnection");
+
 export type S3DataConnection = z.infer<typeof S3DataConnectionSchema>;
 export type AzureDataConnection = z.infer<typeof AzureDataConnectionSchema>;
+export type GcpDataConnection = z.infer<typeof GcpDataConnectionSchema>;
 
 export const DataConnnectionDetailsSchema = z
   .discriminatedUnion("provider", [
     S3DataConnectionSchema,
     AzureDataConnectionSchema,
+    GcpDataConnectionSchema,
   ])
   .openapi("DataConnectionDetails");
 

--- a/src/types/data-connection.ts
+++ b/src/types/data-connection.ts
@@ -117,6 +117,13 @@ export const AzureSasTokenAuthenticationSchema = z
   .openapi("AzureSasTokenAuthentication");
 
 /**
+ * IAM role ARN: `arn:{partition}:iam::{account}:role/{path}{name}`. The
+ * partition class (`aws`, `aws-us-gov`, `aws-cn`) and an optional role path are
+ * allowed so GovCloud/China and pathed roles are not rejected.
+ */
+const IAM_ROLE_ARN_REGEX = /^arn:aws[a-z-]*:iam::\d{12}:role\/.+$/;
+
+/**
  * V2 federated S3 access. `role_arn` is the customer-owned IAM role the proxy
  * assumes via `AssumeRoleWithWebIdentity`. It is *not* a secret (it's an ARN),
  * so it can be surfaced to the proxy without exposing credentials.
@@ -124,7 +131,7 @@ export const AzureSasTokenAuthenticationSchema = z
 export const S3WebIdentityRoleAuthenticationSchema = z
   .object({
     type: z.literal(DataConnectionAuthenticationType.S3WebIdentityRole),
-    role_arn: z.string().min(1),
+    role_arn: z.string().regex(IAM_ROLE_ARN_REGEX, "Invalid IAM role ARN"),
   })
   .openapi("S3WebIdentityRoleAuthentication");
 
@@ -139,9 +146,11 @@ export const GcpWorkloadIdentityAuthenticationSchema = z
   .object({
     type: z.literal(DataConnectionAuthenticationType.GcpWorkloadIdentity),
     /** Full WIF provider resource: `//iam.googleapis.com/projects/.../providers/...`. */
-    workload_identity_provider: z.string().min(1),
+    workload_identity_provider: z
+      .string()
+      .startsWith("//iam.googleapis.com/projects/"),
     /** Service account email the exchanged token impersonates for GCS. */
-    service_account: z.string().min(1),
+    service_account: z.string().email().endsWith(".gserviceaccount.com"),
   })
   .openapi("GcpWorkloadIdentityAuthentication");
 
@@ -156,9 +165,9 @@ export const AzureWorkloadIdentityAuthenticationSchema = z
   .object({
     type: z.literal(DataConnectionAuthenticationType.AzureWorkloadIdentity),
     /** Azure AD tenant (directory) ID. */
-    tenant_id: z.string().min(1),
+    tenant_id: z.string().uuid(),
     /** App registration (client) ID holding the federated identity credential. */
-    client_id: z.string().min(1),
+    client_id: z.string().uuid(),
   })
   .openapi("AzureWorkloadIdentityAuthentication");
 

--- a/src/types/data-connection.ts
+++ b/src/types/data-connection.ts
@@ -65,7 +65,25 @@ export enum AzureRegions {
 
 export enum DataConnectionAuthenticationType {
   S3AccessKey = "s3_access_key",
-  S3IAMRole = "s3_iam_role",
+  /**
+   * V2 federated backend access: the proxy presents its own OIDC identity to the
+   * data provider's AWS account and assumes `role_arn` via
+   * `AssumeRoleWithWebIdentity`, so no long-lived backend credentials are stored.
+   * (Renamed from the unused V1 `s3_iam_role` placeholder.)
+   */
+  S3WebIdentityRole = "s3_web_identity_role",
+  /**
+   * V2 federated GCS access via GCP Workload Identity Federation: the proxy's
+   * OIDC token is exchanged at GCP STS for a token that impersonates a service
+   * account. Scaffolded — not yet implemented by the proxy/multistore.
+   */
+  GcpWorkloadIdentity = "gcp_workload_identity",
+  /**
+   * V2 federated Azure Blob access via Azure Workload Identity Federation: the
+   * proxy's OIDC token is exchanged at Azure AD for a bearer token. Scaffolded —
+   * not yet implemented by the proxy/multistore.
+   */
+  AzureWorkloadIdentity = "azure_workload_identity",
   AzureSasToken = "az_sas_token",
   S3ECSTaskRole = "s3_ecs_task_role",
   S3Local = "s3_local",
@@ -98,9 +116,58 @@ export const AzureSasTokenAuthenticationSchema = z
   })
   .openapi("AzureSasTokenAuthentication");
 
+/**
+ * V2 federated S3 access. `role_arn` is the customer-owned IAM role the proxy
+ * assumes via `AssumeRoleWithWebIdentity`. It is *not* a secret (it's an ARN),
+ * so it can be surfaced to the proxy without exposing credentials.
+ */
+export const S3WebIdentityRoleAuthenticationSchema = z
+  .object({
+    type: z.literal(DataConnectionAuthenticationType.S3WebIdentityRole),
+    role_arn: z.string(),
+  })
+  .openapi("S3WebIdentityRoleAuthentication");
+
+/**
+ * V2 federated GCS access via GCP Workload Identity Federation. The proxy
+ * exchanges its OIDC assertion at GCP STS — the `workload_identity_provider`
+ * resource is itself the exchange audience — for a token that impersonates
+ * `service_account`. Neither field is a secret. Scaffolded — not yet wired in
+ * the proxy/multistore.
+ */
+export const GcpWorkloadIdentityAuthenticationSchema = z
+  .object({
+    type: z.literal(DataConnectionAuthenticationType.GcpWorkloadIdentity),
+    /** Full WIF provider resource: `//iam.googleapis.com/projects/.../providers/...`. */
+    workload_identity_provider: z.string(),
+    /** Service account email the exchanged token impersonates for GCS. */
+    service_account: z.string(),
+  })
+  .openapi("GcpWorkloadIdentityAuthentication");
+
+/**
+ * V2 federated Azure Blob access via Azure Workload Identity Federation. The
+ * proxy exchanges its OIDC assertion at Azure AD (audience
+ * `api://AzureADTokenExchange`, a constant) for a bearer token, using the app
+ * registration identified by `tenant_id` + `client_id`. Neither field is a
+ * secret. Scaffolded — not yet wired in the proxy/multistore.
+ */
+export const AzureWorkloadIdentityAuthenticationSchema = z
+  .object({
+    type: z.literal(DataConnectionAuthenticationType.AzureWorkloadIdentity),
+    /** Azure AD tenant (directory) ID. */
+    tenant_id: z.string(),
+    /** App registration (client) ID holding the federated identity credential. */
+    client_id: z.string(),
+  })
+  .openapi("AzureWorkloadIdentityAuthentication");
+
 export const DataConnectionAuthenticationSchema = z
   .discriminatedUnion("type", [
     S3AccessKeyAuthenticationSchema,
+    S3WebIdentityRoleAuthenticationSchema,
+    GcpWorkloadIdentityAuthenticationSchema,
+    AzureWorkloadIdentityAuthenticationSchema,
     AzureSasTokenAuthenticationSchema,
     S3ECSTaskRoleAuthenticationSchema,
     S3LocalAuthenticationSchema,


### PR DESCRIPTION
**Stacked on #283** (`feat/oidc-auth`). Companion to the proxy's data.source.coop#147.

Adds the per-connection backend-auth field the V2 data proxy needs to make **federated** requests to private backends, replacing the always-unsigned path.

## What

Extends the `DataConnectionAuthentication` discriminated union with the V2 keyless federation variants:

| `type` | Fields | Mechanism |
|---|---|---|
| `s3_web_identity_role` | `role_arn` | AWS `AssumeRoleWithWebIdentity` |
| `gcp_workload_identity` | `workload_identity_provider`, `service_account` | GCP Workload Identity Federation |
| `azure_workload_identity` | `tenant_id`, `client_id` | Azure Workload Identity Federation |

The AWS variant **renames the unused V1 `s3_iam_role`** enum placeholder (no schema, no references, no possible stored data).

**Audience is a per-provider constant, not connection data**, so it's deliberately not in the schema — the proxy applies it: AWS `sts.amazonaws.com`, Azure `api://AzureADTokenExchange`, GCP = the provider resource itself. Each variant carries only its distinguishing, **non-secret** config (an ARN / a provider+SA / a tenant+client) — safe to surface to the proxy without exposing credentials.

## Scope / status

- **Additive & non-breaking:** `authentication` stays optional (omitted ⇒ unsigned); the legacy V1 variants are untouched (they may still have stored data — cleanup is separate).
- **Only AWS is functional downstream today** — multistore's Azure/GCP token exchange is feature-gated stubs and its backend-auth middleware is S3-only; **Cloudflare R2 has no OIDC-federation path** (S3-compatible, but no STS role assumption) and stays on static keys. GCP/Azure here are schema scaffolding.
- **Proxy visibility is a follow-up:** `authentication` is admin-only today (`ViewDataConnectionCredentials`), so the proxy doesn't yet receive it. Surfacing the secret-less federation config to the proxy is #327 (secret-less config) + #329 (proxy service identity).

## Tests
`src/types/data-connection.test.ts` — parses each variant, rejects a role-less AWS variant, confirms `authentication` stays optional. Typecheck + jest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
