### PR TITLE
feat(products): choose a data connection and enforce its allowed visibilities

### DIFF
--- a/src/app/(app)/edit/product/[account_id]/[product_id]/details/page.tsx
+++ b/src/app/(app)/edit/product/[account_id]/[product_id]/details/page.tsx
@@ -1,7 +1,12 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { ProductCreationForm } from "@/components/features/products/ProductCreationForm";
-import { productsTable, accountsTable } from "@/lib/clients/database";
+import {
+  productsTable,
+  accountsTable,
+  dataConnectionsTable,
+} from "@/lib/clients/database";
+import { DataConnection, DataConnectionSchema } from "@/types";
 
 export async function generateMetadata({
   params,
@@ -29,10 +34,21 @@ export default async function DetailsPage({ params }: PageProps) {
     notFound();
   }
 
+  // Resolve the product's data connection so the visibility options stay
+  // constrained to what that connection allows. Credentials are stripped before
+  // the connection reaches the client form.
+  const connection = await dataConnectionsTable.fetchById(
+    product.metadata.primary_mirror
+  );
+  const dataConnections: DataConnection[] = connection
+    ? [DataConnectionSchema.omit({ authentication: true }).parse(connection)]
+    : [];
+
   return (
     <ProductCreationForm
       potentialOwnerAccounts={[account]}
       product={product}
+      dataConnections={dataConnections}
       mode="edit"
     />
   );

--- a/src/app/(app)/products/new/page.tsx
+++ b/src/app/(app)/products/new/page.tsx
@@ -1,7 +1,8 @@
 import { ProductCreationForm } from "@/components/features/products/ProductCreationForm";
 import { accountsTable, getPageSession, membershipsTable } from "@/lib";
 import { isAuthorized } from "@/lib/api/authz";
-import { Actions, MembershipState } from "@/types";
+import { listUsableDataConnections } from "@/lib/data-connections";
+import { Actions, DataConnectionSchema, MembershipState } from "@/types";
 import { Heading, Text } from "@radix-ui/themes";
 import { FormTitle } from "@/components/core";
 
@@ -45,6 +46,12 @@ export default async function NewProductPage() {
     )),
   ];
 
+  // Strip credentials before handing connections to the client component.
+  const dataConnections = (await listUsableDataConnections(session)).map(
+    (connection) =>
+      DataConnectionSchema.omit({ authentication: true }).parse(connection)
+  );
+
   return (
     <>
       <FormTitle
@@ -52,7 +59,10 @@ export default async function NewProductPage() {
         description="Create a new product to share with others"
       />
 
-      <ProductCreationForm potentialOwnerAccounts={potentialOwnerAccounts} />
+      <ProductCreationForm
+        potentialOwnerAccounts={potentialOwnerAccounts}
+        dataConnections={dataConnections}
+      />
     </>
   );
 }

--- a/src/components/features/products/ProductCreationForm.tsx
+++ b/src/components/features/products/ProductCreationForm.tsx
@@ -30,6 +30,11 @@ function allowedVisibilitiesFor(
     : ALL_VISIBILITIES;
 }
 
+// Region is only present on S3/Azure connections, not GCP (keyless WIF).
+function regionOf(connection: DataConnection): string | undefined {
+  return "region" in connection.details ? connection.details.region : undefined;
+}
+
 // A new product defaults to a us-west-2 connection when one is available — the
 // region we steer unsure users toward — and otherwise to the first option.
 const DEFAULT_REGION = "us-west-2";
@@ -37,8 +42,7 @@ function pickDefaultConnection(
   connections: DataConnection[]
 ): DataConnection | undefined {
   return (
-    connections.find((c) => c.details.region === DEFAULT_REGION) ??
-    connections[0]
+    connections.find((c) => regionOf(c) === DEFAULT_REGION) ?? connections[0]
   );
 }
 
@@ -47,8 +51,10 @@ function describeConnection(connection: DataConnection): string {
   const visibilities =
     connection.allowed_visibilities.map((v) => VISIBILITY_LABELS[v]).join(", ") ||
     "no visibilities";
+  const region = regionOf(connection);
+  const location = region ? ` (${region})` : "";
   const readOnly = connection.read_only ? " · Read Only" : "";
-  return `${connection.name} (${connection.details.region}) · ${visibilities}${readOnly}`;
+  return `${connection.name}${location} · ${visibilities}${readOnly}`;
 }
 
 interface ProductCreationFormProps {

--- a/src/components/features/products/ProductCreationForm.tsx
+++ b/src/components/features/products/ProductCreationForm.tsx
@@ -3,19 +3,51 @@
 import { useState } from "react";
 import { Text, Spinner, Flex } from "@radix-ui/themes";
 import { DynamicForm, FormField } from "@/components/core";
-import { Account } from "@/types";
-import { Product } from "@/types/product";
+import { Account, DataConnection } from "@/types";
+import { Product, ProductVisibility } from "@/types/product";
 import { useProductIdValidation } from "@/hooks/useIdValidation";
 import { createProduct, updateProduct } from "@/lib/actions/products";
 
+const VISIBILITY_LABELS: Record<ProductVisibility, string> = {
+  [ProductVisibility.Public]: "Public",
+  [ProductVisibility.Unlisted]: "Unlisted",
+  [ProductVisibility.Restricted]: "Restricted",
+};
+
+// Fallback when no data connection is selected (e.g. legacy products in edit
+// mode whose connection can no longer be resolved).
+const ALL_VISIBILITIES: ProductVisibility[] = [
+  ProductVisibility.Public,
+  ProductVisibility.Unlisted,
+  ProductVisibility.Restricted,
+];
+
+function allowedVisibilitiesFor(
+  connection: DataConnection | undefined
+): ProductVisibility[] {
+  return connection?.allowed_visibilities?.length
+    ? connection.allowed_visibilities
+    : ALL_VISIBILITIES;
+}
+
+// "AWS Open Data (us-west-2) · Public, Unlisted"
+function describeConnection(connection: DataConnection): string {
+  const visibilities =
+    connection.allowed_visibilities.map((v) => VISIBILITY_LABELS[v]).join(", ") ||
+    "no visibilities";
+  return `${connection.name} (${connection.details.region}) · ${visibilities}`;
+}
+
 interface ProductCreationFormProps {
   potentialOwnerAccounts: Account[];
+  dataConnections?: DataConnection[]; // Connections the user may create against
   product?: Product; // Optional product for edit mode
   mode?: "create" | "edit"; // Mode of operation
 }
 
 export function ProductCreationForm({
   potentialOwnerAccounts,
+  dataConnections = [],
   product,
   mode = "create",
 }: ProductCreationFormProps) {
@@ -28,6 +60,44 @@ export function ProductCreationForm({
     isEditMode ? product.product_id : ""
   );
   const validationState = useProductIdValidation(productId, accountId);
+
+  // Data connection selection. In edit mode the storage backend is fixed once
+  // the product exists, so we don't offer a selector — but we still resolve the
+  // product's connection to constrain the visibility options.
+  const [dataConnectionId, setDataConnectionId] = useState(
+    isEditMode
+      ? product.metadata.primary_mirror
+      : dataConnections[0]?.data_connection_id ?? ""
+  );
+
+  const selectedConnection = dataConnections.find(
+    (connection) => connection.data_connection_id === dataConnectionId
+  );
+
+  const allowedVisibilities = allowedVisibilitiesFor(selectedConnection);
+
+  const [visibility, setVisibility] = useState<ProductVisibility>(
+    isEditMode ? product.visibility : allowedVisibilities[0]
+  );
+
+  // The currently selected visibility must always be selectable, even if it
+  // falls outside the connection's allowed set (e.g. legacy data drift).
+  const visibilityOptions = allowedVisibilities.includes(visibility)
+    ? allowedVisibilities
+    : [visibility, ...allowedVisibilities];
+
+  // When the connection changes, drop a now-disallowed visibility back to a
+  // permitted one so the form can't submit an invalid combination.
+  const handleConnectionChange = (value: string) => {
+    setDataConnectionId(value);
+    const next = dataConnections.find(
+      (connection) => connection.data_connection_id === value
+    );
+    const nextAllowed = allowedVisibilitiesFor(next);
+    if (!nextAllowed.includes(visibility)) {
+      setVisibility(nextAllowed[0]);
+    }
+  };
 
   const fields: FormField<Product>[] = [
     {
@@ -94,16 +164,45 @@ export function ProductCreationForm({
       description: "A brief description of your product",
       placeholder: "Describe your product",
     },
+    // Data connection selector (create mode only). Drives the region and the
+    // visibility options available below.
+    ...(isEditMode
+      ? []
+      : ([
+          {
+            label: "Data Connection",
+            name: "data_connection_id" as keyof Product,
+            type: "select",
+            required: true,
+            description:
+              "Where this product's data is stored. Determines the available region and visibility options.",
+            options: dataConnections.map((connection) => ({
+              value: connection.data_connection_id,
+              label: describeConnection(connection),
+            })),
+            placeholder:
+              dataConnections.length === 0
+                ? "No data connections available"
+                : undefined,
+            readOnly: dataConnections.length === 0,
+            controlled: true,
+            value: dataConnectionId,
+            onValueChange: handleConnectionChange,
+          },
+        ] as FormField<Product>[])),
     {
       label: "Visibility",
       name: "visibility",
       type: "select",
+      required: true,
       description: "Your product's visibility",
-      options: [
-        { value: "public", label: "Public" },
-        { value: "unlisted", label: "Unlisted" },
-        { value: "restricted", label: "Restricted" },
-      ],
+      options: visibilityOptions.map((value) => ({
+        value,
+        label: VISIBILITY_LABELS[value],
+      })),
+      controlled: true,
+      value: visibility,
+      onValueChange: (value) => setVisibility(value as ProductVisibility),
     },
   ];
 

--- a/src/components/features/products/ProductCreationForm.tsx
+++ b/src/components/features/products/ProductCreationForm.tsx
@@ -30,12 +30,13 @@ function allowedVisibilitiesFor(
     : ALL_VISIBILITIES;
 }
 
-// "AWS Open Data (us-west-2) · Public, Unlisted"
+// "AWS Open Data (us-west-2) · Public, Unlisted · Read Only"
 function describeConnection(connection: DataConnection): string {
   const visibilities =
     connection.allowed_visibilities.map((v) => VISIBILITY_LABELS[v]).join(", ") ||
     "no visibilities";
-  return `${connection.name} (${connection.details.region}) · ${visibilities}`;
+  const readOnly = connection.read_only ? " · Read Only" : "";
+  return `${connection.name} (${connection.details.region}) · ${visibilities}${readOnly}`;
 }
 
 interface ProductCreationFormProps {

--- a/src/components/features/products/ProductCreationForm.tsx
+++ b/src/components/features/products/ProductCreationForm.tsx
@@ -61,16 +61,32 @@ export function ProductCreationForm({
   );
   const validationState = useProductIdValidation(productId, accountId);
 
+  // Connections available to the currently selected owner account: either
+  // unowned (Source-Coop-managed) or explicitly owned by that account.
+  const connectionsForAccount = (forAccountId: string) =>
+    dataConnections.filter(
+      (dc) => !dc.owner || dc.owner === forAccountId
+    );
+
   // Data connection selection. In edit mode the storage backend is fixed once
   // the product exists, so we don't offer a selector — but we still resolve the
   // product's connection to constrain the visibility options.
+  const initialAccountId = isEditMode
+    ? product.account_id
+    : potentialOwnerAccounts[0]?.account_id;
+  const initialAvailable = connectionsForAccount(initialAccountId ?? "");
+
   const [dataConnectionId, setDataConnectionId] = useState(
     isEditMode
       ? product.metadata.primary_mirror
-      : dataConnections[0]?.data_connection_id ?? ""
+      : initialAvailable[0]?.data_connection_id ?? ""
   );
 
-  const selectedConnection = dataConnections.find(
+  const [availableConnections, setAvailableConnections] = useState(
+    isEditMode ? dataConnections : initialAvailable
+  );
+
+  const selectedConnection = availableConnections.find(
     (connection) => connection.data_connection_id === dataConnectionId
   );
 
@@ -90,12 +106,32 @@ export function ProductCreationForm({
   // permitted one so the form can't submit an invalid combination.
   const handleConnectionChange = (value: string) => {
     setDataConnectionId(value);
-    const next = dataConnections.find(
+    const next = availableConnections.find(
       (connection) => connection.data_connection_id === value
     );
     const nextAllowed = allowedVisibilitiesFor(next);
     if (!nextAllowed.includes(visibility)) {
       setVisibility(nextAllowed[0]);
+    }
+  };
+
+  // When the owner account changes, recalculate which connections are available
+  // and reset the selected connection/visibility if the current choice is no
+  // longer valid for the new account.
+  const handleAccountChange = (value: string) => {
+    setAccountId(value);
+    const nextAvailable = connectionsForAccount(value);
+    setAvailableConnections(nextAvailable);
+    const stillValid = nextAvailable.find(
+      (dc) => dc.data_connection_id === dataConnectionId
+    );
+    if (!stillValid) {
+      const first = nextAvailable[0];
+      setDataConnectionId(first?.data_connection_id ?? "");
+      const nextAllowed = allowedVisibilitiesFor(first);
+      if (!nextAllowed.includes(visibility)) {
+        setVisibility(nextAllowed[0]);
+      }
     }
   };
 
@@ -124,7 +160,7 @@ export function ProductCreationForm({
             })),
             controlled: true,
             value: accountId,
-            onValueChange: setAccountId,
+            onValueChange: handleAccountChange,
           },
           {
             label: "Product ID",
@@ -176,15 +212,15 @@ export function ProductCreationForm({
             required: true,
             description:
               "Where this product's data is stored. Determines the available region and visibility options.",
-            options: dataConnections.map((connection) => ({
+            options: availableConnections.map((connection) => ({
               value: connection.data_connection_id,
               label: describeConnection(connection),
             })),
             placeholder:
-              dataConnections.length === 0
+              availableConnections.length === 0
                 ? "No data connections available"
                 : undefined,
-            readOnly: dataConnections.length === 0,
+            readOnly: availableConnections.length === 0,
             controlled: true,
             value: dataConnectionId,
             onValueChange: handleConnectionChange,

--- a/src/components/features/products/ProductCreationForm.tsx
+++ b/src/components/features/products/ProductCreationForm.tsx
@@ -30,6 +30,18 @@ function allowedVisibilitiesFor(
     : ALL_VISIBILITIES;
 }
 
+// A new product defaults to a us-west-2 connection when one is available — the
+// region we steer unsure users toward — and otherwise to the first option.
+const DEFAULT_REGION = "us-west-2";
+function pickDefaultConnection(
+  connections: DataConnection[]
+): DataConnection | undefined {
+  return (
+    connections.find((c) => c.details.region === DEFAULT_REGION) ??
+    connections[0]
+  );
+}
+
 // "AWS Open Data (us-west-2) · Public, Unlisted · Read Only"
 function describeConnection(connection: DataConnection): string {
   const visibilities =
@@ -80,7 +92,7 @@ export function ProductCreationForm({
   const [dataConnectionId, setDataConnectionId] = useState(
     isEditMode
       ? product.metadata.primary_mirror
-      : initialAvailable[0]?.data_connection_id ?? ""
+      : pickDefaultConnection(initialAvailable)?.data_connection_id ?? ""
   );
 
   const [availableConnections, setAvailableConnections] = useState(
@@ -90,6 +102,12 @@ export function ProductCreationForm({
   const selectedConnection = availableConnections.find(
     (connection) => connection.data_connection_id === dataConnectionId
   );
+
+  // In edit mode the connection is fixed and resolved server-side; if it can no
+  // longer be found (e.g. deleted), updateProduct rejects any visibility change,
+  // so the form shows visibility as read-only rather than offering options that
+  // can't be saved.
+  const connectionMissing = Boolean(isEditMode && !selectedConnection);
 
   const allowedVisibilities = allowedVisibilitiesFor(selectedConnection);
 
@@ -127,7 +145,7 @@ export function ProductCreationForm({
       (dc) => dc.data_connection_id === dataConnectionId
     );
     if (!stillValid) {
-      const first = nextAvailable[0];
+      const first = pickDefaultConnection(nextAvailable);
       setDataConnectionId(first?.data_connection_id ?? "");
       const nextAllowed = allowedVisibilitiesFor(first);
       if (!nextAllowed.includes(visibility)) {
@@ -212,7 +230,7 @@ export function ProductCreationForm({
             type: "select",
             required: true,
             description:
-              "Where this product's data is stored. Determines the available region and visibility options.",
+              "Where this product's data is stored. Determines the available region and visibility options. If you're unsure, choose a us-west-2 connection.",
             options: availableConnections.map((connection) => ({
               value: connection.data_connection_id,
               label: describeConnection(connection),
@@ -232,11 +250,14 @@ export function ProductCreationForm({
       name: "visibility",
       type: "select",
       required: true,
-      description: "Your product's visibility",
+      description: connectionMissing
+        ? "This product's data connection could not be found, so its visibility can't be changed."
+        : "Your product's visibility",
       options: visibilityOptions.map((value) => ({
         value,
         label: VISIBILITY_LABELS[value],
       })),
+      readOnly: connectionMissing,
       controlled: true,
       value: visibility,
       onValueChange: (value) => setVisibility(value as ProductVisibility),

--- a/src/components/features/products/ProductCreationForm.tsx
+++ b/src/components/features/products/ProductCreationForm.tsx
@@ -237,10 +237,16 @@ export function ProductCreationForm({
             required: true,
             description:
               "Where this product's data is stored. Determines the available region and visibility options. If you're unsure, choose a us-west-2 connection.",
-            options: availableConnections.map((connection) => ({
-              value: connection.data_connection_id,
-              label: describeConnection(connection),
-            })),
+            options: [...availableConnections]
+              .sort(
+                (a, b) =>
+                  a.details.provider.localeCompare(b.details.provider) ||
+                  a.name.localeCompare(b.name)
+              )
+              .map((connection) => ({
+                value: connection.data_connection_id,
+                label: describeConnection(connection),
+              })),
             placeholder:
               availableConnections.length === 0
                 ? "No data connections available"

--- a/src/lib/actions/products.test.ts
+++ b/src/lib/actions/products.test.ts
@@ -1,0 +1,145 @@
+/** @jest-environment node */
+import { Actions } from "@/types";
+import { productsTable, dataConnectionsTable } from "@/lib/clients/database";
+import { getPageSession } from "@/lib";
+import { isAuthorized } from "@/lib/api/authz";
+import { redirect } from "next/navigation";
+
+jest.mock("@/lib/clients/database", () => ({
+  productsTable: { create: jest.fn() },
+  dataConnectionsTable: { fetchById: jest.fn() },
+}));
+
+jest.mock("@/lib", () => ({
+  getPageSession: jest.fn(),
+  LOGGER: { error: jest.fn(), info: jest.fn() },
+}));
+
+jest.mock("@/lib/api/authz", () => ({
+  isAuthorized: jest.fn(),
+}));
+
+jest.mock("next/navigation", () => ({
+  redirect: jest.fn(),
+}));
+
+jest.mock("next/cache", () => ({
+  revalidatePath: jest.fn(),
+}));
+
+jest.mock("@/lib/urls", () => ({
+  productUrl: jest.fn(() => "/account/product"),
+  editProductDetailsUrl: jest.fn(() => "/edit"),
+}));
+
+const { createProduct } = require("./products");
+
+const SESSION = {
+  identity_id: "user-1",
+  account: { account_id: "alice", flags: [] },
+};
+
+function buildFormData(
+  overrides: Record<string, string> = {}
+): FormData {
+  const fd = new FormData();
+  fd.set("title", "My Product");
+  fd.set("account_id", "alice");
+  fd.set("product_id", "my-product");
+  fd.set("description", "A description");
+  fd.set("visibility", "public");
+  fd.set("data_connection_id", "conn-x");
+  for (const [key, value] of Object.entries(overrides)) {
+    fd.set(key, value);
+  }
+  return fd;
+}
+
+function connection(overrides: Record<string, unknown> = {}) {
+  return {
+    data_connection_id: "conn-x",
+    name: "Test Connection",
+    read_only: false,
+    allowed_visibilities: ["public", "restricted"],
+    details: { provider: "s3", bucket: "b", base_prefix: "", region: "us-west-2" },
+    ...overrides,
+  };
+}
+
+describe("createProduct", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    (getPageSession as jest.Mock).mockResolvedValue(SESSION);
+    (isAuthorized as jest.Mock).mockReturnValue(true);
+  });
+
+  test("builds mirror metadata from the selected data connection", async () => {
+    (dataConnectionsTable.fetchById as jest.Mock).mockResolvedValue(
+      connection()
+    );
+
+    await createProduct(undefined, buildFormData());
+
+    expect(productsTable.create).toHaveBeenCalledTimes(1);
+    const created = (productsTable.create as jest.Mock).mock.calls[0][0];
+    expect(created.metadata.primary_mirror).toBe("conn-x");
+    expect(created.metadata.mirrors["conn-x"]).toMatchObject({
+      storage_type: "s3",
+      connection_id: "conn-x",
+      prefix: "alice/my-product/",
+      is_primary: true,
+    });
+    expect(redirect).toHaveBeenCalled();
+  });
+
+  test("rejects a visibility not allowed by the data connection", async () => {
+    (dataConnectionsTable.fetchById as jest.Mock).mockResolvedValue(
+      connection({ allowed_visibilities: ["public"] })
+    );
+
+    const result = await createProduct(
+      undefined,
+      buildFormData({ visibility: "restricted" })
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.fieldErrors.visibility).toBeDefined();
+    expect(productsTable.create).not.toHaveBeenCalled();
+  });
+
+  test("rejects when the data connection does not exist", async () => {
+    (dataConnectionsTable.fetchById as jest.Mock).mockResolvedValue(null);
+
+    const result = await createProduct(undefined, buildFormData());
+
+    expect(result.success).toBe(false);
+    expect(result.fieldErrors.data_connection_id).toBeDefined();
+    expect(productsTable.create).not.toHaveBeenCalled();
+  });
+
+  test("rejects when the user may not use the data connection", async () => {
+    (dataConnectionsTable.fetchById as jest.Mock).mockResolvedValue(
+      connection()
+    );
+    (isAuthorized as jest.Mock).mockImplementation(
+      (_session, _resource, action) => action !== Actions.UseDataConnection
+    );
+
+    const result = await createProduct(undefined, buildFormData());
+
+    expect(result.success).toBe(false);
+    expect(productsTable.create).not.toHaveBeenCalled();
+  });
+
+  test("rejects when no data connection is selected", async () => {
+    const result = await createProduct(
+      undefined,
+      buildFormData({ data_connection_id: "" })
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.fieldErrors.data_connection_id).toBeDefined();
+    expect(dataConnectionsTable.fetchById).not.toHaveBeenCalled();
+    expect(productsTable.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/actions/products.test.ts
+++ b/src/lib/actions/products.test.ts
@@ -111,6 +111,18 @@ describe("createProduct", () => {
     expect(productsTable.create).not.toHaveBeenCalled();
   });
 
+  test("rejects unauthorized creation before any data connection lookup", async () => {
+    (isAuthorized as jest.Mock).mockImplementation(
+      (_session, _resource, action) => action !== Actions.CreateRepository
+    );
+
+    const result = await createProduct(undefined, buildFormData());
+
+    expect(result.success).toBe(false);
+    expect(dataConnectionsTable.fetchById).not.toHaveBeenCalled();
+    expect(productsTable.create).not.toHaveBeenCalled();
+  });
+
   test("rejects when the data connection does not exist", async () => {
     (dataConnectionsTable.fetchById as jest.Mock).mockResolvedValue(null);
 
@@ -250,6 +262,20 @@ describe("updateProduct", () => {
     expect(productsTable.update).toHaveBeenCalledTimes(1);
     const updated = (productsTable.update as jest.Mock).mock.calls[0][0];
     expect(updated.visibility).toBe("restricted");
+  });
+
+  test("rejects a visibility change when the data connection no longer exists", async () => {
+    (productsTable.fetchById as jest.Mock).mockResolvedValue(currentProduct());
+    (dataConnectionsTable.fetchById as jest.Mock).mockResolvedValue(null);
+
+    const result = await updateProduct(
+      undefined,
+      buildUpdateFormData({ visibility: "restricted" })
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.fieldErrors.visibility).toBeDefined();
+    expect(productsTable.update).not.toHaveBeenCalled();
   });
 
   test("does not re-validate when the visibility is unchanged", async () => {

--- a/src/lib/actions/products.test.ts
+++ b/src/lib/actions/products.test.ts
@@ -142,4 +142,41 @@ describe("createProduct", () => {
     expect(dataConnectionsTable.fetchById).not.toHaveBeenCalled();
     expect(productsTable.create).not.toHaveBeenCalled();
   });
+
+  test("rejects when the connection is owned by a different account", async () => {
+    (dataConnectionsTable.fetchById as jest.Mock).mockResolvedValue(
+      connection({ owner: "org-other" })
+    );
+
+    const result = await createProduct(
+      undefined,
+      buildFormData({ account_id: "alice" })
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.fieldErrors.data_connection_id).toBeDefined();
+    expect(productsTable.create).not.toHaveBeenCalled();
+  });
+
+  test("allows a connection owned by the same account", async () => {
+    (dataConnectionsTable.fetchById as jest.Mock).mockResolvedValue(
+      connection({ owner: "alice" })
+    );
+
+    await createProduct(undefined, buildFormData({ account_id: "alice" }));
+
+    expect(productsTable.create).toHaveBeenCalledTimes(1);
+    expect(redirect).toHaveBeenCalled();
+  });
+
+  test("allows an unowned (Source-Coop-managed) connection for any account", async () => {
+    (dataConnectionsTable.fetchById as jest.Mock).mockResolvedValue(
+      connection({ owner: undefined })
+    );
+
+    await createProduct(undefined, buildFormData({ account_id: "alice" }));
+
+    expect(productsTable.create).toHaveBeenCalledTimes(1);
+    expect(redirect).toHaveBeenCalled();
+  });
 });

--- a/src/lib/actions/products.test.ts
+++ b/src/lib/actions/products.test.ts
@@ -3,7 +3,7 @@ import { Actions } from "@/types";
 import { productsTable, dataConnectionsTable } from "@/lib/clients/database";
 import { getPageSession } from "@/lib";
 import { isAuthorized } from "@/lib/api/authz";
-import { redirect } from "next/navigation";
+import { productUrl } from "@/lib/urls";
 
 jest.mock("@/lib/clients/database", () => ({
   productsTable: {
@@ -75,6 +75,9 @@ describe("createProduct", () => {
     jest.resetAllMocks();
     (getPageSession as jest.Mock).mockResolvedValue(SESSION);
     (isAuthorized as jest.Mock).mockReturnValue(true);
+    // resetAllMocks wipes the factory implementation, so re-establish the
+    // success URL that the action returns as redirectTo.
+    (productUrl as jest.Mock).mockReturnValue("/account/product");
   });
 
   test("builds mirror metadata from the selected data connection", async () => {
@@ -82,7 +85,7 @@ describe("createProduct", () => {
       connection()
     );
 
-    await createProduct(undefined, buildFormData());
+    const result = await createProduct(undefined, buildFormData());
 
     expect(productsTable.create).toHaveBeenCalledTimes(1);
     const created = (productsTable.create as jest.Mock).mock.calls[0][0];
@@ -93,7 +96,8 @@ describe("createProduct", () => {
       prefix: "alice/my-product/",
       is_primary: true,
     });
-    expect(redirect).toHaveBeenCalled();
+    expect(result.success).toBe(true);
+    expect(result.redirectTo).toBeDefined();
   });
 
   test("rejects a visibility not allowed by the data connection", async () => {
@@ -179,10 +183,14 @@ describe("createProduct", () => {
       connection({ owner: "alice" })
     );
 
-    await createProduct(undefined, buildFormData({ account_id: "alice" }));
+    const result = await createProduct(
+      undefined,
+      buildFormData({ account_id: "alice" })
+    );
 
     expect(productsTable.create).toHaveBeenCalledTimes(1);
-    expect(redirect).toHaveBeenCalled();
+    expect(result.success).toBe(true);
+    expect(result.redirectTo).toBeDefined();
   });
 
   test("allows an unowned (Source-Coop-managed) connection for any account", async () => {
@@ -190,10 +198,14 @@ describe("createProduct", () => {
       connection({ owner: undefined })
     );
 
-    await createProduct(undefined, buildFormData({ account_id: "alice" }));
+    const result = await createProduct(
+      undefined,
+      buildFormData({ account_id: "alice" })
+    );
 
     expect(productsTable.create).toHaveBeenCalledTimes(1);
-    expect(redirect).toHaveBeenCalled();
+    expect(result.success).toBe(true);
+    expect(result.redirectTo).toBeDefined();
   });
 });
 
@@ -229,6 +241,9 @@ describe("updateProduct", () => {
     jest.resetAllMocks();
     (getPageSession as jest.Mock).mockResolvedValue(SESSION);
     (isAuthorized as jest.Mock).mockReturnValue(true);
+    // resetAllMocks wipes the factory implementation, so re-establish the
+    // success URL that the action returns as redirectTo.
+    (productUrl as jest.Mock).mockReturnValue("/account/product");
   });
 
   test("rejects a visibility not allowed by the product's data connection", async () => {

--- a/src/lib/actions/products.test.ts
+++ b/src/lib/actions/products.test.ts
@@ -6,7 +6,11 @@ import { isAuthorized } from "@/lib/api/authz";
 import { redirect } from "next/navigation";
 
 jest.mock("@/lib/clients/database", () => ({
-  productsTable: { create: jest.fn() },
+  productsTable: {
+    create: jest.fn(),
+    update: jest.fn(),
+    fetchById: jest.fn(),
+  },
   dataConnectionsTable: { fetchById: jest.fn() },
 }));
 
@@ -32,7 +36,7 @@ jest.mock("@/lib/urls", () => ({
   editProductDetailsUrl: jest.fn(() => "/edit"),
 }));
 
-const { createProduct } = require("./products");
+const { createProduct, updateProduct } = require("./products");
 
 const SESSION = {
   identity_id: "user-1",
@@ -178,5 +182,86 @@ describe("createProduct", () => {
 
     expect(productsTable.create).toHaveBeenCalledTimes(1);
     expect(redirect).toHaveBeenCalled();
+  });
+});
+
+function buildUpdateFormData(
+  overrides: Record<string, string> = {}
+): FormData {
+  const fd = new FormData();
+  fd.set("account_id", "alice");
+  fd.set("product_id", "my-product");
+  fd.set("title", "Updated Title");
+  fd.set("description", "Updated description");
+  fd.set("visibility", "restricted");
+  for (const [key, value] of Object.entries(overrides)) {
+    fd.set(key, value);
+  }
+  return fd;
+}
+
+function currentProduct(overrides: Record<string, unknown> = {}) {
+  return {
+    account_id: "alice",
+    product_id: "my-product",
+    title: "My Product",
+    description: "A description",
+    visibility: "public",
+    metadata: { primary_mirror: "conn-x", mirrors: {} },
+    ...overrides,
+  };
+}
+
+describe("updateProduct", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    (getPageSession as jest.Mock).mockResolvedValue(SESSION);
+    (isAuthorized as jest.Mock).mockReturnValue(true);
+  });
+
+  test("rejects a visibility not allowed by the product's data connection", async () => {
+    (productsTable.fetchById as jest.Mock).mockResolvedValue(currentProduct());
+    (dataConnectionsTable.fetchById as jest.Mock).mockResolvedValue(
+      connection({ allowed_visibilities: ["public"] })
+    );
+
+    const result = await updateProduct(
+      undefined,
+      buildUpdateFormData({ visibility: "restricted" })
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.fieldErrors.visibility).toBeDefined();
+    expect(productsTable.update).not.toHaveBeenCalled();
+  });
+
+  test("allows a visibility permitted by the product's data connection", async () => {
+    (productsTable.fetchById as jest.Mock).mockResolvedValue(currentProduct());
+    (dataConnectionsTable.fetchById as jest.Mock).mockResolvedValue(
+      connection({ allowed_visibilities: ["public", "restricted"] })
+    );
+
+    const result = await updateProduct(
+      undefined,
+      buildUpdateFormData({ visibility: "restricted" })
+    );
+
+    expect(result.success).toBe(true);
+    expect(productsTable.update).toHaveBeenCalledTimes(1);
+    const updated = (productsTable.update as jest.Mock).mock.calls[0][0];
+    expect(updated.visibility).toBe("restricted");
+  });
+
+  test("does not re-validate when the visibility is unchanged", async () => {
+    (productsTable.fetchById as jest.Mock).mockResolvedValue(currentProduct());
+
+    const result = await updateProduct(
+      undefined,
+      buildUpdateFormData({ visibility: "public" })
+    );
+
+    expect(result.success).toBe(true);
+    expect(dataConnectionsTable.fetchById).not.toHaveBeenCalled();
+    expect(productsTable.update).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/actions/products.ts
+++ b/src/lib/actions/products.ts
@@ -168,6 +168,24 @@ export async function createProduct(
     };
   }
 
+  // Enforce that the connection is available for the product's account. An
+  // owned connection may only be used by the account that owns it.
+  if (
+    dataConnection.owner &&
+    dataConnection.owner !== validatedFields.data.account_id
+  ) {
+    return {
+      fieldErrors: {
+        data_connection_id: [
+          "Selected data connection is not available for this account",
+        ],
+      },
+      data: formData,
+      message: "Invalid data connection for this account",
+      success: false,
+    };
+  }
+
   // Enforce the connection's allowed visibilities. Even though the form only
   // offers permitted options, the server must reject disallowed combinations.
   if (

--- a/src/lib/actions/products.ts
+++ b/src/lib/actions/products.ts
@@ -1,11 +1,13 @@
 "use server";
 
-import { productsTable } from "@/lib/clients/database";
+import { productsTable, dataConnectionsTable } from "@/lib/clients/database";
 import {
   Actions,
+  DataProvider,
   ProductCreationRequestSchema,
   type Product,
   type ProductCreationRequest,
+  type ProductMirror,
   type ProductVisibility,
 } from "@/types";
 import { getPageSession, LOGGER } from "@/lib";
@@ -13,6 +15,16 @@ import { FormState } from "@/components/core/DynamicForm";
 import { isAuthorized } from "../api/authz";
 import { revalidatePath } from "next/cache";
 import { productUrl, editProductDetailsUrl } from "@/lib/urls";
+
+// Map a data connection's storage provider to the product mirror's storage_type.
+const STORAGE_TYPE_BY_PROVIDER: Record<
+  DataProvider,
+  ProductMirror["storage_type"]
+> = {
+  [DataProvider.S3]: "s3",
+  [DataProvider.Azure]: "azure",
+  [DataProvider.GCP]: "gcs",
+};
 
 export interface PaginatedProductsResult {
   products: Product[];
@@ -123,6 +135,56 @@ export async function createProduct(
     };
   }
 
+  const dataConnectionId = formData.get("data_connection_id");
+  if (typeof dataConnectionId !== "string" || dataConnectionId.length === 0) {
+    return {
+      fieldErrors: { data_connection_id: ["A data connection is required"] },
+      data: formData,
+      message: "Invalid form data",
+      success: false,
+    };
+  }
+
+  const dataConnection = await dataConnectionsTable.fetchById(dataConnectionId);
+  if (!dataConnection) {
+    return {
+      fieldErrors: {
+        data_connection_id: ["Selected data connection was not found"],
+      },
+      data: formData,
+      message: "Invalid data connection",
+      success: false,
+    };
+  }
+
+  // Enforce that the user may create products against this connection. This
+  // covers read-only connections and connections gated behind an account flag.
+  if (!isAuthorized(session, dataConnection, Actions.UseDataConnection)) {
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "You are not permitted to use the selected data connection",
+      success: false,
+    };
+  }
+
+  // Enforce the connection's allowed visibilities. Even though the form only
+  // offers permitted options, the server must reject disallowed combinations.
+  if (
+    !dataConnection.allowed_visibilities.includes(validatedFields.data.visibility)
+  ) {
+    return {
+      fieldErrors: {
+        visibility: [
+          `The "${dataConnection.name}" data connection does not allow ${validatedFields.data.visibility} products`,
+        ],
+      },
+      data: formData,
+      message: "Invalid visibility for the selected data connection",
+      success: false,
+    };
+  }
+
   const product: Product = {
     ...validatedFields.data,
     created_at: new Date().toISOString(),
@@ -131,11 +193,12 @@ export async function createProduct(
     featured: 0,
     metadata: {
       tags: [],
-      primary_mirror: "aws-opendata-us-west-2",
+      primary_mirror: dataConnection.data_connection_id,
       mirrors: {
-        "aws-opendata-us-west-2": {
-          storage_type: "s3",
-          connection_id: "aws-opendata-us-west-2",
+        [dataConnection.data_connection_id]: {
+          storage_type:
+            STORAGE_TYPE_BY_PROVIDER[dataConnection.details.provider],
+          connection_id: dataConnection.data_connection_id,
           prefix: `${validatedFields.data.account_id}/${validatedFields.data.product_id}/`,
           is_primary: true,
         },

--- a/src/lib/actions/products.ts
+++ b/src/lib/actions/products.ts
@@ -310,6 +310,34 @@ export async function updateProduct(
     const description = formData.get("description") as string;
     const visibility = formData.get("visibility") as ProductVisibility;
 
+    // Enforce the connection's allowed visibilities when the visibility is
+    // being changed. The edit form only offers permitted options, but the
+    // server must reject disallowed combinations from tampered requests. The
+    // connection itself is fixed at creation, so we resolve it from the
+    // product's primary mirror rather than the form.
+    if (visibility && visibility !== currentProduct.visibility) {
+      const connectionId = currentProduct.metadata?.primary_mirror;
+      const dataConnection = connectionId
+        ? await dataConnectionsTable.fetchById(connectionId)
+        : undefined;
+
+      if (
+        dataConnection &&
+        !dataConnection.allowed_visibilities.includes(visibility)
+      ) {
+        return {
+          fieldErrors: {
+            visibility: [
+              `The "${dataConnection.name}" data connection does not allow ${visibility} products`,
+            ],
+          },
+          data: formData,
+          message: "Invalid visibility for the product's data connection",
+          success: false,
+        };
+      }
+    }
+
     // Build update data
     const updateData = {
       ...currentProduct,

--- a/src/lib/actions/products.ts
+++ b/src/lib/actions/products.ts
@@ -135,6 +135,28 @@ export async function createProduct(
     };
   }
 
+  // Authorize creation before any data-connection I/O. createRepository only
+  // inspects account_id/product_id, so checking here means a caller who may
+  // not create products under this account is rejected before they can probe
+  // whether a data_connection_id exists or learn its visibility policy.
+  if (
+    !isAuthorized(
+      session,
+      {
+        account_id: validatedFields.data.account_id,
+        product_id: validatedFields.data.product_id,
+      } as Product,
+      Actions.CreateRepository,
+    )
+  ) {
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Unauthorized to create product",
+      success: false,
+    };
+  }
+
   const dataConnectionId = formData.get("data_connection_id");
   if (typeof dataConnectionId !== "string" || dataConnectionId.length === 0) {
     return {
@@ -224,15 +246,6 @@ export async function createProduct(
     },
   };
 
-  if (!isAuthorized(session, product, Actions.CreateRepository)) {
-    return {
-      fieldErrors: {},
-      data: formData,
-      message: "Unauthorized to create product",
-      success: false,
-    };
-  }
-
   try {
     await productsTable.create(product);
   } catch (error) {
@@ -314,17 +327,32 @@ export async function updateProduct(
     // being changed. The edit form only offers permitted options, but the
     // server must reject disallowed combinations from tampered requests. The
     // connection itself is fixed at creation, so we resolve it from the
-    // product's primary mirror rather than the form.
+    // product's primary mirror rather than the form. This branch only runs on
+    // an actual visibility change, so unrelated edits (title, description) are
+    // never blocked by it.
     if (visibility && visibility !== currentProduct.visibility) {
       const connectionId = currentProduct.metadata?.primary_mirror;
       const dataConnection = connectionId
         ? await dataConnectionsTable.fetchById(connectionId)
-        : undefined;
+        : null;
 
-      if (
-        dataConnection &&
-        !dataConnection.allowed_visibilities.includes(visibility)
-      ) {
+      // Without a resolvable connection we cannot know the allowed set, so a
+      // missing/deleted connection is a hard rejection rather than a free pass
+      // to set any visibility. The product keeps its current visibility.
+      if (!dataConnection) {
+        return {
+          fieldErrors: {
+            visibility: [
+              "This product's data connection could not be found, so its visibility cannot be changed",
+            ],
+          },
+          data: formData,
+          message: "Data connection not found for this product",
+          success: false,
+        };
+      }
+
+      if (!dataConnection.allowed_visibilities.includes(visibility)) {
         return {
           fieldErrors: {
             visibility: [

--- a/src/lib/api/authz.test.ts
+++ b/src/lib/api/authz.test.ts
@@ -3238,6 +3238,103 @@ describe("Authorization Tests", () => {
     );
   });
 
+  test("Action: data_connection:use", () => {
+    const action = Actions.UseDataConnection;
+
+    const dataConnection: DataConnection = {
+      data_connection_id: "test-connection",
+      name: "Test Connection",
+      read_only: false,
+      allowed_visibilities: [ProductVisibility.Public],
+      details: {
+        provider: DataProvider.S3,
+        bucket: "test-bucket",
+        base_prefix: "test-prefix",
+        region: S3Regions.US_EAST_1,
+      },
+    };
+
+    expect(isAuthorized(sessions["admin"], dataConnection, action)).toBe(true);
+    expect(
+      isAuthorized(sessions["organization-owner-user"], dataConnection, action)
+    ).toBe(true);
+    expect(
+      isAuthorized(
+        sessions["organization-maintainer-user"],
+        dataConnection,
+        action
+      )
+    ).toBe(true);
+    expect(
+      isAuthorized(
+        sessions["organization-read-data-user"],
+        dataConnection,
+        action
+      )
+    ).toBe(true);
+    expect(
+      isAuthorized(
+        sessions["organization-write-data-user"],
+        dataConnection,
+        action
+      )
+    ).toBe(true);
+    expect(
+      isAuthorized(sessions["repo-member-owner"], dataConnection, action)
+    ).toBe(true);
+    expect(
+      isAuthorized(sessions["repo-member-maintainer"], dataConnection, action)
+    ).toBe(true);
+    expect(
+      isAuthorized(sessions["repo-member-read-data"], dataConnection, action)
+    ).toBe(true);
+    expect(
+      isAuthorized(sessions["repo-member-write-data"], dataConnection, action)
+    ).toBe(true);
+    expect(
+      isAuthorized(sessions["repo-member-invited"], dataConnection, action)
+    ).toBe(true);
+    expect(isAuthorized(sessions["disabled"], dataConnection, action)).toBe(
+      false
+    );
+    expect(isAuthorized(sessions["regular-user"], dataConnection, action)).toBe(
+      true
+    );
+    expect(
+      isAuthorized(sessions["create-repositories-user"], dataConnection, action)
+    ).toBe(true);
+    expect(isAuthorized(sessions["anonymous"], dataConnection, action)).toBe(
+      true
+    );
+    expect(isAuthorized(sessions["no-account"], dataConnection, action)).toBe(
+      true
+    );
+
+    // Test with read_only set to true
+    dataConnection.read_only = true;
+    expect(isAuthorized(sessions["admin"], dataConnection, action)).toBe(true);
+    expect(
+      isAuthorized(sessions["organization-owner-user"], dataConnection, action)
+    ).toBe(false);
+    expect(isAuthorized(sessions["regular-user"], dataConnection, action)).toBe(
+      false
+    );
+
+    // Test with required_flag
+    dataConnection.read_only = false;
+    dataConnection.required_flag = AccountFlags.CREATE_REPOSITORIES;
+    expect(isAuthorized(sessions["admin"], dataConnection, action)).toBe(true);
+    expect(
+      isAuthorized(sessions["organization-owner-user"], dataConnection, action)
+    ).toBe(true);
+    expect(
+      isAuthorized(sessions["create-repositories-user"], dataConnection, action)
+    ).toBe(true);
+    expect(isAuthorized(sessions["regular-user"], dataConnection, action)).toBe(
+      false
+    );
+  });
+
   test("Action: data_connection:credentials:view", () => {
     const action = Actions.ViewDataConnectionCredentials;
 

--- a/src/lib/api/authz.ts
+++ b/src/lib/api/authz.ts
@@ -451,6 +451,11 @@ function disableDataConnection(
   return false;
 }
 
+// Models what the *connection* permits, not whether the caller is
+// authenticated. A connection that is not read-only and carries no
+// required_flag is usable by anyone — including an anonymous principal — so
+// callers (e.g. createProduct, listUsableDataConnections) must apply their own
+// auth guard before relying on this result.
 function useDataConnection(
   principal: UserSession | null,
   dataConnection: DataConnection

--- a/src/lib/api/authz.ts
+++ b/src/lib/api/authz.ts
@@ -92,6 +92,7 @@ type ActionResourceMap = {
   [Actions.GetDataConnection]: DataConnection;
   [Actions.CreateDataConnection]: DataConnection;
   [Actions.DisableDataConnection]: DataConnection;
+  [Actions.UseDataConnection]: DataConnection;
   [Actions.ViewDataConnectionCredentials]: DataConnection;
   [Actions.PutDataConnection]: DataConnection;
   [Actions.DeleteDataConnection]: DataConnection;
@@ -268,6 +269,11 @@ export function isAuthorized(
 export function isAuthorized(
   principal: UserSession | null,
   resource: DataConnection,
+  action: Actions.UseDataConnection
+): boolean;
+export function isAuthorized(
+  principal: UserSession | null,
+  resource: DataConnection,
   action: Actions.ViewDataConnectionCredentials
 ): boolean;
 export function isAuthorized(
@@ -385,6 +391,9 @@ export function isAuthorized(
       .with(Actions.DisableDataConnection, () =>
         disableDataConnection(principal, resource as ResourceForAction<Actions.DisableDataConnection>)
       )
+      .with(Actions.UseDataConnection, () =>
+        useDataConnection(principal, resource as ResourceForAction<Actions.UseDataConnection>)
+      )
       .with(Actions.ViewDataConnectionCredentials, () =>
         viewDataConnectionCredentials(principal, resource as ResourceForAction<Actions.ViewDataConnectionCredentials>)
       )
@@ -440,6 +449,32 @@ function disableDataConnection(
   }
 
   return false;
+}
+
+function useDataConnection(
+  principal: UserSession | null,
+  dataConnection: DataConnection
+): boolean {
+  if (principal?.account?.disabled) {
+    return false;
+  }
+
+  if (isAdmin(principal)) {
+    return true;
+  }
+
+  if (dataConnection.read_only) {
+    return false;
+  }
+
+  if (dataConnection.required_flag) {
+    if (principal?.account?.flags?.includes(dataConnection.required_flag)) {
+      return true;
+    }
+    return false;
+  } else {
+    return true;
+  }
 }
 
 function viewDataConnectionCredentials(

--- a/src/lib/data-connections.ts
+++ b/src/lib/data-connections.ts
@@ -1,0 +1,23 @@
+import { Actions, DataConnection, UserSession } from "@/types";
+import { isAuthorized } from "@/lib/api/authz";
+import { dataConnectionsTable } from "@/lib/clients/database";
+
+/**
+ * List the data connections a user is permitted to use when creating a product.
+ *
+ * A connection is usable when the session is authorized both to read it
+ * (`GetDataConnection`) and to create products against it (`UseDataConnection`).
+ * The returned objects are unsanitized (credentials intact); callers that hand
+ * these to the client must strip `authentication` first.
+ */
+export async function listUsableDataConnections(
+  session: UserSession | null
+): Promise<DataConnection[]> {
+  const dataConnections = await dataConnectionsTable.listAll();
+
+  return dataConnections.filter(
+    (dataConnection) =>
+      isAuthorized(session, dataConnection, Actions.UseDataConnection) &&
+      isAuthorized(session, dataConnection, Actions.GetDataConnection)
+  );
+}

--- a/src/types/data-connection.ts
+++ b/src/types/data-connection.ts
@@ -156,6 +156,9 @@ export const DataConnectionSchema = z
     name: z.string(),
     prefix_template: z.optional(z.string()),
     read_only: z.boolean(),
+    // Optional account that owns this connection. Source-Coop-managed
+    // connections have no owner and are available to all accounts.
+    owner: z.optional(z.string()),
     // Visibilities a product may use on this connection; enforced at product
     // creation (see createProduct in src/lib/actions/products.ts).
     allowed_visibilities: z.array(z.nativeEnum(ProductVisibility)),

--- a/src/types/data-connection.ts
+++ b/src/types/data-connection.ts
@@ -156,7 +156,8 @@ export const DataConnectionSchema = z
     name: z.string(),
     prefix_template: z.optional(z.string()),
     read_only: z.boolean(),
-    // NOTE: allowed_visibilities is currently unenforced
+    // Visibilities a product may use on this connection; enforced at product
+    // creation (see createProduct in src/lib/actions/products.ts).
     allowed_visibilities: z.array(z.nativeEnum(ProductVisibility)),
     required_flag: z.optional(z.nativeEnum(AccountFlags)),
     details: DataConnnectionDetailsSchema,

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -90,6 +90,7 @@ export enum Actions {
   CreateDataConnection = "data_connection:create",
   DisableDataConnection = "data_connection:disable",
   DeleteDataConnection = "data_connection:delete",
+  UseDataConnection = "data_connection:use",
   ViewDataConnectionCredentials = "data_connection:credentials:view",
   PutDataConnection = "data_connection:put",
 }


### PR DESCRIPTION
## Summary

Product creation now lets users **choose which data connection** a product uses and constrains the product's **visibility to that connection's `allowed_visibilities`** — enforced on the server, not just in the form. Closes two related issues:

- **#334** — `DataConnection.allowed_visibilities` was unenforced, so `restricted` products could be created on public-only connections (e.g. AWS Open Data).
- **#335** — users couldn't choose a product's data connection, nor see each connection's region and allowed visibilities.

The selected connection determines the product's storage mirror, region, and the visibility options offered.

## Changes

**Selection & owner scoping**
- `src/lib/data-connections.ts` (new): `listUsableDataConnections(session)` — connections the session may both read (`GetDataConnection`) and create products against (`UseDataConnection`).
- **`products/new` page**: fetches the user's usable connections (credentials stripped via `DataConnectionSchema.omit({ authentication: true })`) and passes them to the form.
- **`ProductCreationForm`**: adds a **Data Connection** selector. Option labels show region, allowed visibilities, and a `· Read Only` marker (e.g. `AWS Open Data (us-west-2) · Public, Unlisted · Read Only`). Connections are filtered to those the owner account may use — unowned/Source-Coop-managed, or owned by that account. Visibility options derive from the selected connection and reset when the current choice falls outside the new connection's allowed set. New products default to a `us-west-2` connection when one is available, with help text suggesting it.

**Server-side enforcement**
- **`createProduct`**: authorizes `CreateRepository` *before* any data-connection I/O (so a caller can't probe whether a connection exists or learn its visibility policy), then validates the connection exists, that the user may use it (`UseDataConnection` — covers read-only and required-flag gating), owner scoping, and that the chosen visibility is in `allowed_visibilities`. Builds the mirror metadata from the selected connection (storage type derived from the provider; `primary_mirror`/`connection_id` set to the chosen connection) instead of the previously hardcoded `aws-opendata-us-west-2`.
- **`updateProduct`**: re-validates the visibility against the product's connection's `allowed_visibilities` on any visibility change; a missing/deleted connection is a hard rejection rather than a free pass.

**Edit mode**
- The edit page resolves the product's existing connection and passes it so visibility stays constrained. The connection is fixed post-creation, so no selector is shown. If the connection can no longer be resolved, the Visibility field renders read-only (matching the server's hard-reject) rather than offering options that can't be saved.

**Types & authz**
- Adds `Actions.UseDataConnection` and a `useDataConnection` authz check (rejects read-only connections; honors `required_flag`).
- `DataConnectionSchema`: documents that `allowed_visibilities` is now enforced and adds the optional `owner` field (Source-Coop-managed connections have no owner).

## Testing

- `npm run type-check` ✅
- `npx jest src/lib/actions/products.test.ts src/lib/api/authz.test.ts` ✅ — 55 tests, including 9 `createProduct` and 4 `updateProduct` enforcement tests (mirror construction, disallowed/unchanged visibility, missing/unknown/unauthorized/cross-owner connection) and the `UseDataConnection` authz cases.

Closes #334
Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)
