### PR TITLE
feat(data-connections): expose secret-less federated config by connection visibility (#327)

### DIFF
--- a/src/app/api/v1/data-connections/[data_connection_id]/route.ts
+++ b/src/app/api/v1/data-connections/[data_connection_id]/route.ts
@@ -30,6 +30,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { Actions, DataConnectionSchema } from "@/types";
 import { StatusCodes } from "http-status-codes";
 import { isAdmin, isAuthorized } from "@/lib/api/authz";
+import { sanitizeDataConnection } from "@/lib/api/sanitize-data-connection";
 import { getApiSession } from "@/lib/api/utils";
 import { dataConnectionsTable } from "@/lib/clients";
 
@@ -41,7 +42,7 @@ export async function GET(
     const session = await getApiSession(request);
 
     const { data_connection_id } = await params;
-    let dataConnection = await dataConnectionsTable.fetchById(
+    const dataConnection = await dataConnectionsTable.fetchById(
       data_connection_id
     );
     if (!dataConnection) {
@@ -58,20 +59,9 @@ export async function GET(
       );
     }
 
-    // Sanitize connection if user doesn't have permission to view credentials
-    if (
-      !isAuthorized(
-        session,
-        dataConnection,
-        Actions.ViewDataConnectionCredentials
-      )
-    ) {
-      dataConnection = DataConnectionSchema.omit({
-        authentication: true,
-      }).parse(dataConnection);
-    }
+    const sanitized = sanitizeDataConnection(dataConnection, session);
 
-    return NextResponse.json(dataConnection, { status: StatusCodes.OK });
+    return NextResponse.json(sanitized, { status: StatusCodes.OK });
   } catch (err: unknown) {
     const errorMessage =
       err instanceof Error ? err.message : "Internal server error";

--- a/src/app/api/v1/data-connections/[data_connection_id]/route.ts
+++ b/src/app/api/v1/data-connections/[data_connection_id]/route.ts
@@ -142,7 +142,8 @@ export async function PUT(
     const dataConnection = await dataConnectionsTable.create(
       updatedDataConnection
     );
-    return NextResponse.json(dataConnection, { status: StatusCodes.OK });
+    const sanitized = sanitizeDataConnection(dataConnection, session);
+    return NextResponse.json(sanitized, { status: StatusCodes.OK });
   } catch (err: unknown) {
     const errorMessage =
       err instanceof Error ? err.message : "Internal server error";

--- a/src/app/api/v1/data-connections/route.ts
+++ b/src/app/api/v1/data-connections/route.ts
@@ -18,9 +18,10 @@
  *         description: Internal server error
  */
 import { NextRequest, NextResponse } from "next/server";
-import { Actions, DataConnectionSchema, DataConnection } from "@/types";
+import { Actions, DataConnectionSchema } from "@/types";
 import { StatusCodes } from "http-status-codes";
 import { isAuthorized } from "@/lib/api/authz";
+import { sanitizeDataConnection } from "@/lib/api/sanitize-data-connection";
 import { getApiSession } from "@/lib/api/utils";
 import { dataConnectionsTable } from "@/lib/clients/database";
 import { LOGGER } from "@/lib";
@@ -33,17 +34,9 @@ export async function GET(request: NextRequest) {
     const filteredConnections = dataConnections.filter((dataConnection) =>
       isAuthorized(session, dataConnection, Actions.GetDataConnection)
     );
-    const sanitizedConnections = filteredConnections.map((connection) => {
-      const sanitized = DataConnectionSchema.omit({
-        authentication: true,
-      }).parse(connection);
-      if (
-        isAuthorized(session, connection, Actions.ViewDataConnectionCredentials)
-      ) {
-        return DataConnectionSchema.parse(connection);
-      }
-      return sanitized;
-    });
+    const sanitizedConnections = filteredConnections.map((connection) =>
+      sanitizeDataConnection(connection, session)
+    );
     return NextResponse.json(sanitizedConnections, { status: StatusCodes.OK });
   } catch (err: any) {
     return NextResponse.json(

--- a/src/lib/api/authz.ts
+++ b/src/lib/api/authz.ts
@@ -43,6 +43,7 @@ import {
   MembershipRole,
   MembershipState,
   Product,
+  ProductVisibility,
   UserSession,
 } from "@/types";
 import { match } from "ts-pattern";
@@ -455,6 +456,50 @@ function viewDataConnectionCredentials(
   }
 
   return false;
+}
+
+/**
+ * Whether `principal` is affiliated with `account_id` — it *is* that account
+ * (individual account) or is an active member of it (any role).
+ */
+function isAffiliatedWith(
+  principal: UserSession | null,
+  account_id: string
+): boolean {
+  if (principal?.account?.account_id === account_id) {
+    return true;
+  }
+
+  return (principal?.memberships ?? []).some(
+    (membership) =>
+      membership.state === MembershipState.Member &&
+      membership.membership_account_id === account_id
+  );
+}
+
+/**
+ * Whether the caller may view a data connection's *secret-less* config (e.g. a
+ * federated role ARN). This is independent of `ViewDataConnectionCredentials`,
+ * which gates *secret-bearing* config (static keys/tokens).
+ *
+ * - `public` in `allowed_visibilities` → anyone, **including anonymous**: the
+ *   connection backs public products that must be servable without a session.
+ * - no `owner` → anyone (unowned / Source Cooperative-managed).
+ * - otherwise → members of the owner account.
+ */
+export function canViewDataConnectionConfig(
+  principal: UserSession | null,
+  connection: DataConnection
+): boolean {
+  if (connection.allowed_visibilities.includes(ProductVisibility.Public)) {
+    return true;
+  }
+
+  if (!connection.owner) {
+    return true;
+  }
+
+  return isAffiliatedWith(principal, connection.owner);
 }
 
 function putDataConnection(

--- a/src/lib/api/sanitize-data-connection.test.ts
+++ b/src/lib/api/sanitize-data-connection.test.ts
@@ -1,0 +1,124 @@
+/** @jest-environment node */
+import { canViewDataConnectionConfig } from "./authz";
+import { sanitizeDataConnection } from "./sanitize-data-connection";
+import { sessions } from "./utils.mock";
+import {
+  DataConnection,
+  DataConnectionAuthenticationType,
+  MembershipState,
+  ProductVisibility,
+  UserSession,
+} from "@/types";
+
+const memberOfAcme = {
+  identity_id: "alice",
+  account: { account_id: "alice" },
+  memberships: [
+    { membership_account_id: "acme", state: MembershipState.Member },
+  ],
+} as unknown as UserSession;
+
+const nonMember = {
+  identity_id: "bob",
+  account: { account_id: "bob" },
+  memberships: [],
+} as unknown as UserSession;
+
+function conn(over: Partial<DataConnection>): DataConnection {
+  return {
+    data_connection_id: "conn-1",
+    name: "Conn",
+    read_only: true,
+    allowed_visibilities: [],
+    details: {
+      provider: "s3",
+      bucket: "b",
+      base_prefix: "",
+      region: "us-west-2",
+    },
+    ...over,
+  } as DataConnection;
+}
+
+const roleAuth = {
+  type: DataConnectionAuthenticationType.S3WebIdentityRole,
+  role_arn: "arn:aws:iam::1:role/r",
+};
+const keyAuth = {
+  type: DataConnectionAuthenticationType.S3AccessKey,
+  access_key_id: "AKIA",
+  secret_access_key: "secret",
+};
+
+describe("canViewDataConnectionConfig", () => {
+  test("public ⇒ anyone, including anonymous", () => {
+    const c = conn({
+      allowed_visibilities: [ProductVisibility.Public],
+      owner: "acme",
+    });
+    expect(canViewDataConnectionConfig(sessions["anonymous"], c)).toBe(true);
+    expect(canViewDataConnectionConfig(nonMember, c)).toBe(true);
+  });
+
+  test("unowned + non-public ⇒ anyone", () => {
+    const c = conn({ allowed_visibilities: [ProductVisibility.Restricted] });
+    expect(canViewDataConnectionConfig(sessions["anonymous"], c)).toBe(true);
+    expect(canViewDataConnectionConfig(nonMember, c)).toBe(true);
+  });
+
+  test("owned + non-public ⇒ members of the owner only", () => {
+    const c = conn({
+      allowed_visibilities: [ProductVisibility.Restricted],
+      owner: "acme",
+    });
+    expect(canViewDataConnectionConfig(memberOfAcme, c)).toBe(true);
+    expect(canViewDataConnectionConfig(nonMember, c)).toBe(false);
+    expect(canViewDataConnectionConfig(sessions["anonymous"], c)).toBe(false);
+  });
+
+  test("the owner's own (individual) account counts", () => {
+    const c = conn({ allowed_visibilities: [], owner: "bob" });
+    expect(canViewDataConnectionConfig(nonMember, c)).toBe(true);
+  });
+});
+
+describe("sanitizeDataConnection", () => {
+  test("strips secret-bearing auth for non-admins even when visible", () => {
+    const c = conn({
+      allowed_visibilities: [ProductVisibility.Public],
+      authentication: keyAuth as never,
+    });
+    expect(
+      sanitizeDataConnection(c, sessions["anonymous"]).authentication
+    ).toBeUndefined();
+  });
+
+  test("keeps secret-less auth when the caller may view the config", () => {
+    const c = conn({
+      allowed_visibilities: [ProductVisibility.Public],
+      authentication: roleAuth as never,
+    });
+    expect(
+      sanitizeDataConnection(c, sessions["anonymous"]).authentication
+    ).toEqual(roleAuth);
+  });
+
+  test("strips secret-less auth when the caller may NOT view the config", () => {
+    const c = conn({
+      allowed_visibilities: [ProductVisibility.Restricted],
+      owner: "acme",
+      authentication: roleAuth as never,
+    });
+    expect(sanitizeDataConnection(c, nonMember).authentication).toBeUndefined();
+  });
+
+  test("admins still see secret-bearing auth", () => {
+    const c = conn({
+      allowed_visibilities: [],
+      authentication: keyAuth as never,
+    });
+    expect(sanitizeDataConnection(c, sessions["admin"]).authentication).toEqual(
+      keyAuth
+    );
+  });
+});

--- a/src/lib/api/sanitize-data-connection.test.ts
+++ b/src/lib/api/sanitize-data-connection.test.ts
@@ -42,7 +42,7 @@ function conn(over: Partial<DataConnection>): DataConnection {
 
 const roleAuth = {
   type: DataConnectionAuthenticationType.S3WebIdentityRole,
-  role_arn: "arn:aws:iam::1:role/r",
+  role_arn: "arn:aws:iam::123456789012:role/r",
 };
 const keyAuth = {
   type: DataConnectionAuthenticationType.S3AccessKey,

--- a/src/lib/api/sanitize-data-connection.ts
+++ b/src/lib/api/sanitize-data-connection.ts
@@ -1,0 +1,44 @@
+import {
+  Actions,
+  DataConnection,
+  DataConnectionSchema,
+  isSecretBearingAuth,
+  UserSession,
+} from "@/types";
+import { canViewDataConnectionConfig, isAuthorized } from "./authz";
+
+/**
+ * Redact a data connection's `authentication` for a read response.
+ *
+ * - **Credential viewers** (admins, `ViewDataConnectionCredentials`) → full
+ *   connection, secrets included.
+ * - Otherwise, a **secret-less** `authentication` (federated role ARN /
+ *   workload identity) is kept iff the caller may view the connection's config
+ *   (see {@link canViewDataConnectionConfig}).
+ * - **Secret-bearing** `authentication` (static keys/tokens), and any config the
+ *   caller isn't allowed to see, are stripped.
+ *
+ * Connections with no `authentication` pass through unchanged.
+ */
+export function sanitizeDataConnection(
+  connection: DataConnection,
+  principal: UserSession | null
+): DataConnection {
+  if (
+    isAuthorized(principal, connection, Actions.ViewDataConnectionCredentials)
+  ) {
+    return DataConnectionSchema.parse(connection);
+  }
+
+  const auth = connection.authentication;
+  const keepSecretlessConfig =
+    auth !== undefined &&
+    !isSecretBearingAuth(auth) &&
+    canViewDataConnectionConfig(principal, connection);
+
+  if (keepSecretlessConfig) {
+    return DataConnectionSchema.parse(connection);
+  }
+
+  return DataConnectionSchema.omit({ authentication: true }).parse(connection);
+}

--- a/src/types/data-connection.test.ts
+++ b/src/types/data-connection.test.ts
@@ -1,0 +1,62 @@
+/** @jest-environment node */
+import {
+  DataConnectionAuthenticationSchema,
+  DataConnectionAuthenticationType,
+  DataConnectionSchema,
+} from "./data-connection";
+
+describe("DataConnectionAuthentication (V2 web-identity role)", () => {
+  test("parses the s3_web_identity_role variant", () => {
+    const auth = DataConnectionAuthenticationSchema.parse({
+      type: "s3_web_identity_role",
+      role_arn: "arn:aws:iam::123456789012:role/source-coop",
+    });
+    expect(auth.type).toBe(DataConnectionAuthenticationType.S3WebIdentityRole);
+    expect(auth).toMatchObject({
+      role_arn: "arn:aws:iam::123456789012:role/source-coop",
+    });
+  });
+
+  test("rejects s3_web_identity_role without a role_arn", () => {
+    expect(() =>
+      DataConnectionAuthenticationSchema.parse({ type: "s3_web_identity_role" })
+    ).toThrow();
+  });
+
+  test("parses the scaffolded gcp_workload_identity variant", () => {
+    const auth = DataConnectionAuthenticationSchema.parse({
+      type: "gcp_workload_identity",
+      workload_identity_provider:
+        "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/p/providers/pr",
+      service_account: "sa@project.iam.gserviceaccount.com",
+    });
+    expect(auth.type).toBe(DataConnectionAuthenticationType.GcpWorkloadIdentity);
+  });
+
+  test("parses the scaffolded azure_workload_identity variant", () => {
+    const auth = DataConnectionAuthenticationSchema.parse({
+      type: "azure_workload_identity",
+      tenant_id: "00000000-0000-0000-0000-000000000000",
+      client_id: "11111111-1111-1111-1111-111111111111",
+    });
+    expect(auth.type).toBe(
+      DataConnectionAuthenticationType.AzureWorkloadIdentity
+    );
+  });
+
+  test("authentication is optional on a data connection (omitted = unsigned)", () => {
+    const dc = DataConnectionSchema.parse({
+      data_connection_id: "conn-1",
+      name: "Conn",
+      read_only: false,
+      allowed_visibilities: [],
+      details: {
+        provider: "s3",
+        bucket: "example-bucket",
+        base_prefix: "",
+        region: "us-west-2",
+      },
+    });
+    expect(dc.authentication).toBeUndefined();
+  });
+});

--- a/src/types/data-connection.test.ts
+++ b/src/types/data-connection.test.ts
@@ -53,7 +53,35 @@ describe("DataConnectionAuthentication (V2 web-identity role)", () => {
     ).toThrow();
   });
 
-  test("parses the scaffolded gcp_workload_identity variant", () => {
+  test("rejects gcp_workload_identity without service_account", () => {
+    expect(() =>
+      DataConnectionAuthenticationSchema.parse({
+        type: "gcp_workload_identity",
+        workload_identity_provider:
+          "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/p/providers/pr",
+      })
+    ).toThrow();
+  });
+
+  test("rejects azure_workload_identity without tenant_id", () => {
+    expect(() =>
+      DataConnectionAuthenticationSchema.parse({
+        type: "azure_workload_identity",
+        client_id: "11111111-1111-1111-1111-111111111111",
+      })
+    ).toThrow();
+  });
+
+  test("rejects azure_workload_identity without client_id", () => {
+    expect(() =>
+      DataConnectionAuthenticationSchema.parse({
+        type: "azure_workload_identity",
+        tenant_id: "00000000-0000-0000-0000-000000000000",
+      })
+    ).toThrow();
+  });
+
+  test("authentication field is optional and absent by default", () => {
     const dc = DataConnectionSchema.parse({
       data_connection_id: "conn-1",
       name: "Conn",

--- a/src/types/data-connection.test.ts
+++ b/src/types/data-connection.test.ts
@@ -5,6 +5,7 @@ import {
   DataConnectionSchema,
   DataConnnectionDetailsSchema,
   DataProvider,
+  isSecretBearingAuth,
 } from "./data-connection";
 
 describe("DataConnection V2 workload-identity variants", () => {
@@ -239,7 +240,7 @@ describe("isSecretBearingAuth", () => {
       })
     ).toBe(false);
   });
-}
+});
 
 describe("DataConnectionDetails (S3-compatible + GCP variants)", () => {
   test("parses an S3-compatible (R2) connection with a custom endpoint", () => {

--- a/src/types/data-connection.test.ts
+++ b/src/types/data-connection.test.ts
@@ -44,7 +44,16 @@ describe("DataConnectionAuthentication (V2 web-identity role)", () => {
     );
   });
 
-  test("authentication is optional on a data connection (omitted = unsigned)", () => {
+  test("rejects gcp_workload_identity without workload_identity_provider", () => {
+    expect(() =>
+      DataConnectionAuthenticationSchema.parse({
+        type: "gcp_workload_identity",
+        service_account: "sa@project.iam.gserviceaccount.com",
+      })
+    ).toThrow();
+  });
+
+  test("parses the scaffolded gcp_workload_identity variant", () => {
     const dc = DataConnectionSchema.parse({
       data_connection_id: "conn-1",
       name: "Conn",

--- a/src/types/data-connection.test.ts
+++ b/src/types/data-connection.test.ts
@@ -3,6 +3,7 @@ import {
   DataConnectionAuthenticationSchema,
   DataConnectionAuthenticationType,
   DataConnectionSchema,
+  isSecretBearingAuth,
 } from "./data-connection";
 
 describe("DataConnectionAuthentication (V2 workload-identity variants)", () => {
@@ -95,5 +96,39 @@ describe("DataConnectionAuthentication (V2 workload-identity variants)", () => {
       },
     });
     expect(dc.authentication).toBeUndefined();
+  });
+});
+
+describe("isSecretBearingAuth", () => {
+  test("static-credential variants are secret-bearing", () => {
+    expect(
+      isSecretBearingAuth({
+        type: DataConnectionAuthenticationType.S3AccessKey,
+        access_key_id: "AKIA",
+        secret_access_key: "s",
+      })
+    ).toBe(true);
+    expect(
+      isSecretBearingAuth({
+        type: DataConnectionAuthenticationType.AzureSasToken,
+        sas_token: "t",
+      })
+    ).toBe(true);
+  });
+
+  test("federation variants are secret-less", () => {
+    expect(
+      isSecretBearingAuth({
+        type: DataConnectionAuthenticationType.S3WebIdentityRole,
+        role_arn: "arn:aws:iam::1:role/r",
+      })
+    ).toBe(false);
+    expect(
+      isSecretBearingAuth({
+        type: DataConnectionAuthenticationType.GcpWorkloadIdentity,
+        workload_identity_provider: "p",
+        service_account: "sa",
+      })
+    ).toBe(false);
   });
 });

--- a/src/types/data-connection.test.ts
+++ b/src/types/data-connection.test.ts
@@ -5,7 +5,7 @@ import {
   DataConnectionSchema,
 } from "./data-connection";
 
-describe("DataConnectionAuthentication (V2 web-identity role)", () => {
+describe("DataConnectionAuthentication (V2 workload-identity variants)", () => {
   test("parses the s3_web_identity_role variant", () => {
     const auth = DataConnectionAuthenticationSchema.parse({
       type: "s3_web_identity_role",

--- a/src/types/data-connection.ts
+++ b/src/types/data-connection.ts
@@ -254,8 +254,18 @@ export type DataConnection = z.infer<typeof DataConnectionSchema>;
 export function isSecretBearingAuth(
   auth: DataConnectionAuthentication
 ): boolean {
-  return (
-    auth.type === DataConnectionAuthenticationType.S3AccessKey ||
-    auth.type === DataConnectionAuthenticationType.AzureSasToken
-  );
+  // Exhaustive over the discriminated union so a newly-added variant that isn't
+  // classified here is a compile error ("lacks ending return statement") rather
+  // than silently defaulting to secret-less and being exposed to non-admins.
+  switch (auth.type) {
+    case DataConnectionAuthenticationType.S3AccessKey:
+    case DataConnectionAuthenticationType.AzureSasToken:
+      return true;
+    case DataConnectionAuthenticationType.S3WebIdentityRole:
+    case DataConnectionAuthenticationType.GcpWorkloadIdentity:
+    case DataConnectionAuthenticationType.AzureWorkloadIdentity:
+    case DataConnectionAuthenticationType.S3ECSTaskRole:
+    case DataConnectionAuthenticationType.S3Local:
+      return false;
+  }
 }

--- a/src/types/data-connection.ts
+++ b/src/types/data-connection.ts
@@ -223,12 +223,39 @@ export const DataConnectionSchema = z
     name: z.string(),
     prefix_template: z.optional(z.string()),
     read_only: z.boolean(),
-    // NOTE: allowed_visibilities is currently unenforced
     allowed_visibilities: z.array(z.nativeEnum(ProductVisibility)),
     required_flag: z.optional(z.nativeEnum(AccountFlags)),
+    /**
+     * Account (individual or organization) that owns this connection. Governs
+     * who may view its *secret-less* config when it isn't public: absent =
+     * unowned (e.g. Source Cooperative-managed) ⇒ viewable by anyone; set ⇒
+     * viewable by members of that account. (See `canViewDataConnectionConfig`.)
+     */
+    owner: z.optional(
+      z
+        .string()
+        .min(MIN_ID_LENGTH)
+        .max(MAX_ID_LENGTH)
+        .regex(ID_REGEX, "Invalid account ID format")
+    ),
     details: DataConnnectionDetailsSchema,
     authentication: z.optional(DataConnectionAuthenticationSchema),
   })
   .openapi("DataConnection");
 
 export type DataConnection = z.infer<typeof DataConnectionSchema>;
+
+/**
+ * Whether an authentication variant carries a usable secret — and so must never
+ * be exposed outside the `ViewDataConnectionCredentials` (admin) path. The V2
+ * federation variants (web identity / workload identity) are secret-less; only
+ * the static-credential variants carry secrets.
+ */
+export function isSecretBearingAuth(
+  auth: DataConnectionAuthentication
+): boolean {
+  return (
+    auth.type === DataConnectionAuthenticationType.S3AccessKey ||
+    auth.type === DataConnectionAuthenticationType.AzureSasToken
+  );
+}

--- a/src/types/data-connection.ts
+++ b/src/types/data-connection.ts
@@ -257,9 +257,6 @@ export const DataConnectionSchema = z
     name: z.string(),
     prefix_template: z.optional(z.string()),
     read_only: z.boolean(),
-    // Optional account that owns this connection. Source-Coop-managed
-    // connections have no owner and are available to all accounts.
-    owner: z.optional(z.string()),
     // Visibilities a product may use on this connection; enforced at product
     // creation (see createProduct in src/lib/actions/products.ts).
     allowed_visibilities: z.array(z.nativeEnum(ProductVisibility)),

--- a/src/types/data-connection.ts
+++ b/src/types/data-connection.ts
@@ -254,18 +254,18 @@ export type DataConnection = z.infer<typeof DataConnectionSchema>;
 export function isSecretBearingAuth(
   auth: DataConnectionAuthentication
 ): boolean {
-  // Exhaustive over the discriminated union so a newly-added variant that isn't
-  // classified here is a compile error ("lacks ending return statement") rather
-  // than silently defaulting to secret-less and being exposed to non-admins.
+  // Default-deny on exposure: a type is treated as secret-bearing (kept out of
+  // non-admin responses) unless it is explicitly listed below as secret-less.
+  // So a newly-added or unknown variant fails safe — never accidentally exposed;
+  // exposing a type requires a deliberate edit to this allowlist.
   switch (auth.type) {
-    case DataConnectionAuthenticationType.S3AccessKey:
-    case DataConnectionAuthenticationType.AzureSasToken:
-      return true;
     case DataConnectionAuthenticationType.S3WebIdentityRole:
     case DataConnectionAuthenticationType.GcpWorkloadIdentity:
     case DataConnectionAuthenticationType.AzureWorkloadIdentity:
     case DataConnectionAuthenticationType.S3ECSTaskRole:
     case DataConnectionAuthenticationType.S3Local:
       return false;
+    default:
+      return true;
   }
 }

--- a/src/types/data-connection.ts
+++ b/src/types/data-connection.ts
@@ -65,7 +65,25 @@ export enum AzureRegions {
 
 export enum DataConnectionAuthenticationType {
   S3AccessKey = "s3_access_key",
-  S3IAMRole = "s3_iam_role",
+  /**
+   * V2 federated backend access: the proxy presents its own OIDC identity to the
+   * data provider's AWS account and assumes `role_arn` via
+   * `AssumeRoleWithWebIdentity`, so no long-lived backend credentials are stored.
+   * (Renamed from the unused V1 `s3_iam_role` placeholder.)
+   */
+  S3WebIdentityRole = "s3_web_identity_role",
+  /**
+   * V2 federated GCS access via GCP Workload Identity Federation: the proxy's
+   * OIDC token is exchanged at GCP STS for a token that impersonates a service
+   * account. Scaffolded — not yet implemented by the proxy/multistore.
+   */
+  GcpWorkloadIdentity = "gcp_workload_identity",
+  /**
+   * V2 federated Azure Blob access via Azure Workload Identity Federation: the
+   * proxy's OIDC token is exchanged at Azure AD for a bearer token. Scaffolded —
+   * not yet implemented by the proxy/multistore.
+   */
+  AzureWorkloadIdentity = "azure_workload_identity",
   AzureSasToken = "az_sas_token",
   S3ECSTaskRole = "s3_ecs_task_role",
   S3Local = "s3_local",
@@ -98,9 +116,58 @@ export const AzureSasTokenAuthenticationSchema = z
   })
   .openapi("AzureSasTokenAuthentication");
 
+/**
+ * V2 federated S3 access. `role_arn` is the customer-owned IAM role the proxy
+ * assumes via `AssumeRoleWithWebIdentity`. It is *not* a secret (it's an ARN),
+ * so it can be surfaced to the proxy without exposing credentials.
+ */
+export const S3WebIdentityRoleAuthenticationSchema = z
+  .object({
+    type: z.literal(DataConnectionAuthenticationType.S3WebIdentityRole),
+    role_arn: z.string(),
+  })
+  .openapi("S3WebIdentityRoleAuthentication");
+
+/**
+ * V2 federated GCS access via GCP Workload Identity Federation. The proxy
+ * exchanges its OIDC assertion at GCP STS — the `workload_identity_provider`
+ * resource is itself the exchange audience — for a token that impersonates
+ * `service_account`. Neither field is a secret. Scaffolded — not yet wired in
+ * the proxy/multistore.
+ */
+export const GcpWorkloadIdentityAuthenticationSchema = z
+  .object({
+    type: z.literal(DataConnectionAuthenticationType.GcpWorkloadIdentity),
+    /** Full WIF provider resource: `//iam.googleapis.com/projects/.../providers/...`. */
+    workload_identity_provider: z.string(),
+    /** Service account email the exchanged token impersonates for GCS. */
+    service_account: z.string(),
+  })
+  .openapi("GcpWorkloadIdentityAuthentication");
+
+/**
+ * V2 federated Azure Blob access via Azure Workload Identity Federation. The
+ * proxy exchanges its OIDC assertion at Azure AD (audience
+ * `api://AzureADTokenExchange`, a constant) for a bearer token, using the app
+ * registration identified by `tenant_id` + `client_id`. Neither field is a
+ * secret. Scaffolded — not yet wired in the proxy/multistore.
+ */
+export const AzureWorkloadIdentityAuthenticationSchema = z
+  .object({
+    type: z.literal(DataConnectionAuthenticationType.AzureWorkloadIdentity),
+    /** Azure AD tenant (directory) ID. */
+    tenant_id: z.string(),
+    /** App registration (client) ID holding the federated identity credential. */
+    client_id: z.string(),
+  })
+  .openapi("AzureWorkloadIdentityAuthentication");
+
 export const DataConnectionAuthenticationSchema = z
   .discriminatedUnion("type", [
     S3AccessKeyAuthenticationSchema,
+    S3WebIdentityRoleAuthenticationSchema,
+    GcpWorkloadIdentityAuthenticationSchema,
+    AzureWorkloadIdentityAuthenticationSchema,
     AzureSasTokenAuthenticationSchema,
     S3ECSTaskRoleAuthenticationSchema,
     S3LocalAuthenticationSchema,


### PR DESCRIPTION
**Stacked on #332** (base `feat/data-connection-web-identity-auth`). Implements #327; supersedes the service-identity approach in #329. Design discussion: #329 / #327 comments.

## Problem
The data-connection API stripped the **entire** `authentication` field for any non-admin caller. The proxy authenticates to the API **as the end user** (never admin), so it never received a federated connection's role ARN → federation stays dormant.

## Approach — authorize secret-less config by the connection's own visibility
Treat the connection as a resource with its own visibility; no proxy service identity, no product join.

- **Schema:** optional `owner` (account_id — individual or org) on the data connection.
- **`canViewDataConnectionConfig`:**
  - `public ∈ allowed_visibilities` → anyone, **including anonymous** (so a public product on org-owned storage serves with no session),
  - no `owner` → anyone (unowned / Source-Coop-managed),
  - else → members of the owner account.
- **`sanitizeDataConnection`** (applied to `route.ts`, `[data_connection_id]/route.ts`, `available/route.ts`):
  - admins (`ViewDataConnectionCredentials`) → full, secrets included;
  - else **secret-less** auth (`s3_web_identity_role` / workload identity) returned iff `canViewDataConnectionConfig`;
  - **secret-bearing** auth (`s3_access_key`, `az_sas_token`) → always stripped.

## Notes
- This makes the previously **unenforced** `allowed_visibilities` load-bearing — it must be set on every connection (small backfill).
- "Anyone" deliberately includes **unauthenticated** (the proxy serves public products with no session).
- Tests: the visibility/owner rule (public/unowned/owned × member/non-member/anonymous), the secret strip, and the admin path. Typecheck + 17 tests green.

## Follow-up (separate, proxy repo)
Switch the proxy from listing `/data-connections` to a **by-id** lookup (it always has `connection_id` from the product mirror) — data.source.coop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
