### PR TITLE
fix: return user to current view after login

### DIFF
--- a/src/app/(app)/edit/account/[account_id]/layout.tsx
+++ b/src/app/(app)/edit/account/[account_id]/layout.tsx
@@ -9,7 +9,7 @@ import { isAuthorized } from "@/lib/api/authz";
 import { Actions } from "@/types";
 import { accountsTable } from "@/lib/clients/database";
 import { notFound, redirect } from "next/navigation";
-import { CONFIG } from "@/lib/config";
+import { getReturnToUrl } from "@/lib/baseUrl";
 import {
   PersonIcon,
   LockClosedIcon,
@@ -18,6 +18,7 @@ import {
   ImageIcon,
 } from "@radix-ui/react-icons";
 import {
+  loginUrl,
   editAccountProfileUrl,
   editAccountProfilePictureUrl,
   editAccountPermissionsUrl,
@@ -41,7 +42,7 @@ export default async function AccountLayout({
   const userSession = await getPageSession();
 
   if (!userSession?.account) {
-    redirect(CONFIG.auth.routes.login);
+    redirect(loginUrl(await getReturnToUrl()));
   }
 
   const accountToEdit = await accountsTable.fetchById(account_id);

--- a/src/app/(app)/edit/page.tsx
+++ b/src/app/(app)/edit/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { getPageSession } from "@/lib/api/utils";
 import { editProfileUrl, homeUrl, loginUrl } from "@/lib/urls";
+import { getReturnToUrl } from "@/lib/baseUrl";
 
 interface SettingsPageProps {
   params: Promise<{ account_id: string }>;
@@ -9,7 +10,7 @@ interface SettingsPageProps {
 export default async function Redirect({ params }: SettingsPageProps) {
   const session = await getPageSession();
   if (!session) {
-    redirect(loginUrl());
+    redirect(loginUrl(await getReturnToUrl()));
   }
 
   if (!session.account?.account_id) {

--- a/src/app/(app)/edit/product/[account_id]/[product_id]/layout.tsx
+++ b/src/app/(app)/edit/product/[account_id]/[product_id]/layout.tsx
@@ -12,9 +12,10 @@ import { isAuthorized } from "@/lib/api/authz";
 import { Actions } from "@/types";
 import { productsTable } from "@/lib/clients/database";
 import { notFound, redirect } from "next/navigation";
-import { CONFIG } from "@/lib/config";
+import { getReturnToUrl } from "@/lib/baseUrl";
 import { ExternalLink } from "@/components/core/ExternalLink";
 import {
+  loginUrl,
   productUrl,
   editProductDetailsUrl,
   editProductMembershipsUrl,
@@ -35,7 +36,7 @@ export default async function ProductLayout({
   const session = await getPageSession();
 
   if (!session?.account) {
-    redirect(CONFIG.auth.routes.login);
+    redirect(loginUrl(await getReturnToUrl()));
   }
 
   const product = await productsTable.fetchById(account_id, product_id);

--- a/src/components/layout/AuthButtons.tsx
+++ b/src/components/layout/AuthButtons.tsx
@@ -1,9 +1,9 @@
 import { AccountDropdown } from "./AccountDropdown";
 import { getPageSession } from "@/lib/api/utils";
 import { Button, Callout, Link } from "@radix-ui/themes";
-import { CONFIG } from "@/lib/config";
 import { ExclamationTriangleIcon } from "@radix-ui/react-icons";
-import { onboardingUrl } from "@/lib/urls";
+import { loginUrl, onboardingUrl } from "@/lib/urls";
+import { getReturnToUrl } from "@/lib/baseUrl";
 
 export async function AuthButtons() {
   const session = await getPageSession();
@@ -26,8 +26,10 @@ export async function AuthButtons() {
     );
   }
 
+  const returnTo = await getReturnToUrl();
+
   return (
-    <Link href={CONFIG.auth.routes.login}>
+    <Link href={loginUrl(returnTo)}>
       <Button>Log In / Register</Button>
     </Link>
   );

--- a/src/lib/baseUrl.ts
+++ b/src/lib/baseUrl.ts
@@ -12,3 +12,16 @@ export async function getBaseUrl(): Promise<string> {
   const protocol = headersList.get("x-forwarded-proto") || "http";
   return `${protocol}://${host}`;
 }
+
+/**
+ * Get the full URL of the current request, including path and query string.
+ * Requires x-pathname and x-search headers injected by middleware.
+ */
+export async function getReturnToUrl(): Promise<string> {
+  const headersList = await headers();
+  const host = headersList.get("host") || "source.coop";
+  const protocol = headersList.get("x-forwarded-proto") || "http";
+  const pathname = headersList.get("x-pathname") || "/";
+  const search = headersList.get("x-search") || "";
+  return `${protocol}://${host}${pathname}${search}`;
+}

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -16,8 +16,9 @@ export const newProductUrl = () => "/products/new";
 export const loginUrl = (returnTo?: string) => {
   const base = CONFIG.auth.routes.login;
   if (!returnTo) return base;
-  return `${base}?return_to=${encodeURIComponent(returnTo)}`;
-};
+  if (!returnTo) return base;
+  const sep = base.includes('?') ? '&' : '?';
+  return `${base}${sep}return_to=${encodeURIComponent(returnTo)}`;
 export const onboardingUrl = () => "/onboarding";
 
 // Object URLs

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -13,7 +13,11 @@ export const productListUrl = () => "/products";
 export const newProductUrl = () => "/products/new";
 
 // Auth URLs
-export const loginUrl = () => CONFIG.auth.routes.login;
+export const loginUrl = (returnTo?: string) => {
+  const base = CONFIG.auth.routes.login;
+  if (!returnTo) return base;
+  return `${base}?return_to=${encodeURIComponent(returnTo)}`;
+};
 export const onboardingUrl = () => "/onboarding";
 
 // Object URLs

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -66,10 +66,20 @@ const handleLegacyRedirects = (request: NextRequest): NextResponse | null => {
 const ory = createOryMiddleware({});
 
 export const middleware = async (request: NextRequest) => {
-  for (const handler of [handleLegacyRedirects, handleChromeDevTools, ory]) {
+  for (const handler of [handleLegacyRedirects, handleChromeDevTools]) {
     const response = await handler(request);
     if (response) return response;
   }
+
+  const oryResponse = await ory(request);
+  if (oryResponse) return oryResponse;
+
+  // Inject current path into request headers so server components can read it
+  // via headers() from next/headers (used to build return_to login URLs).
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-pathname", request.nextUrl.pathname);
+  requestHeaders.set("x-search", request.nextUrl.search);
+  return NextResponse.next({ request: { headers: requestHeaders } });
 };
 
 export const config = {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -65,14 +65,33 @@ const handleLegacyRedirects = (request: NextRequest): NextResponse | null => {
 
 const ory = createOryMiddleware({});
 
+// Paths the Ory middleware proxies (self-service flows, session checks). For
+// everything else its middleware just returns a no-op NextResponse.next(), so
+// we own the response and inject the current-path headers below.
+// See node_modules/@ory/nextjs/dist/middleware (proxyRequest match list).
+const ORY_PROXIED_PREFIXES = [
+  "/self-service",
+  "/sessions/whoami",
+  "/ui",
+  "/.well-known/ory",
+  "/.ory",
+];
+
 export const middleware = async (request: NextRequest) => {
   for (const handler of [handleLegacyRedirects, handleChromeDevTools]) {
     const response = await handler(request);
     if (response) return response;
   }
 
-  const oryResponse = await ory(request);
-  if (oryResponse) return oryResponse;
+  // Let Ory handle its own endpoints (it returns proxied responses with
+  // redirects / Set-Cookie that we must not discard).
+  if (
+    ORY_PROXIED_PREFIXES.some((prefix) =>
+      request.nextUrl.pathname.startsWith(prefix),
+    )
+  ) {
+    return ory(request);
+  }
 
   // Inject current path into request headers so server components can read it
   // via headers() from next/headers (used to build return_to login URLs).


### PR DESCRIPTION
Pass `return_to` to the Ory login URL so users are redirected back to the page they were on instead of the app root after authentication.

Closes #345

Generated with [Claude Code](https://claude.ai/code)