### PR TITLE
feat(auth): verify email status on every authenticated page load

### DIFF
--- a/src/app/(app)/email-verified/page.tsx
+++ b/src/app/(app)/email-verified/page.tsx
@@ -9,6 +9,10 @@ import { redirect } from "next/navigation";
 import { accountUrl, homeUrl, onboardingUrl, verifyEmailUrl } from "@/lib/urls";
 import { getPageSession } from "@/lib/api/utils";
 import { accountsTable } from "@/lib";
+import {
+  isEmailVerifiedInOry,
+  oryAddressesToAccountEmails,
+} from "@/lib/accounts/email-verification";
 import Link from "next/link";
 
 export default async function EmailVerifiedPage() {
@@ -21,18 +25,11 @@ export default async function EmailVerifiedPage() {
   }
   const verifiedAddresses = session.orySession?.identity?.verifiable_addresses;
 
-  if (verifiedAddresses?.some((address) => address.verified)) {
+  if (isEmailVerifiedInOry(session.orySession)) {
     await accountsTable.update({
       ...session.account,
-
       // Copy over the verified email addresses from Ory
-      emails: verifiedAddresses?.map((address, index) => ({
-        address: address.value,
-        verified: address.verified,
-        is_primary: index === 0,
-        added_at: (address.created_at || new Date()).toISOString(),
-        verified_at: (address.verified_at || new Date()).toISOString(),
-      })),
+      emails: oryAddressesToAccountEmails(session.orySession),
     });
     redirect(accountUrl(session.account.account_id) + "?verified");
   }

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,5 +1,7 @@
+import { Suspense } from "react";
 import { Box, Container, Flex } from "@radix-ui/themes";
 import { Navigation, Footer } from "@/components";
+import { VerificationBanner } from "@/components/features/auth/VerificationBanner";
 
 interface AppLayoutProps {
   children: React.ReactNode;
@@ -9,6 +11,9 @@ export default async function AppLayout({ children }: AppLayoutProps) {
   return (
     <Flex direction="column" minHeight="100vh">
       <Navigation />
+      <Suspense fallback={null}>
+        <VerificationBanner />
+      </Suspense>
       <Box flexGrow="1" m="2">
         <Container size="4" py="4">
           {children}

--- a/src/components/features/auth/VerificationBanner.tsx
+++ b/src/components/features/auth/VerificationBanner.tsx
@@ -1,0 +1,71 @@
+import { Callout, Container, Link } from "@radix-ui/themes";
+import { CheckCircledIcon, InfoCircledIcon } from "@radix-ui/react-icons";
+import { accountsTable, isIndividualAccount } from "@/lib";
+import { getPageSession } from "@/lib/api/utils";
+import { verifyEmailUrl } from "@/lib/urls";
+import {
+  isEmailVerifiedInDb,
+  isEmailVerifiedInOry,
+  oryAddressesToAccountEmails,
+} from "@/lib/accounts/email-verification";
+
+/**
+ * Email-verification banner rendered on every authenticated app page load.
+ *
+ * The check only runs while our DynamoDB record does not yet track the account
+ * as verified. Once it does, this renders nothing and incurs no further work.
+ *
+ * - Unauthenticated, no individual account, or already verified in our DB →
+ *   nothing.
+ * - Not verified in our DB but verified on Ory → our record is stale, so we sync
+ *   it to match Ory and thank the user. The next page load reads the synced
+ *   record and renders nothing.
+ * - Not verified anywhere → nudge the user to verify their email.
+ */
+export async function VerificationBanner() {
+  const session = await getPageSession();
+  if (!session?.account || !isIndividualAccount(session.account)) {
+    return null;
+  }
+
+  // Our DB already tracks the user as verified — nothing to do.
+  if (isEmailVerifiedInDb(session.account)) {
+    return null;
+  }
+
+  // Verified upstream on Ory but our record is stale: persist it and say thanks.
+  if (isEmailVerifiedInOry(session.orySession)) {
+    await accountsTable.update({
+      ...session.account,
+      emails: oryAddressesToAccountEmails(session.orySession),
+    });
+
+    return (
+      <Container size="4" px="2" mt="2">
+        <Callout.Root color="green" role="status">
+          <Callout.Icon>
+            <CheckCircledIcon />
+          </Callout.Icon>
+          <Callout.Text>
+            Thank you for verifying your email address.
+          </Callout.Text>
+        </Callout.Root>
+      </Container>
+    );
+  }
+
+  // Authenticated but unverified everywhere: nudge the user to verify.
+  return (
+    <Container size="4" px="2" mt="2">
+      <Callout.Root color="amber" role="status">
+        <Callout.Icon>
+          <InfoCircledIcon />
+        </Callout.Icon>
+        <Callout.Text>
+          Please verify your email address to unlock all features.{" "}
+          <Link href={verifyEmailUrl()}>Verify now</Link>.
+        </Callout.Text>
+      </Callout.Root>
+    </Container>
+  );
+}

--- a/src/lib/accounts/email-verification.test.ts
+++ b/src/lib/accounts/email-verification.test.ts
@@ -1,0 +1,142 @@
+import {
+  isEmailVerifiedInDb,
+  isEmailVerifiedInOry,
+  oryAddressesToAccountEmails,
+} from "./email-verification";
+import { AccountType, type Account } from "@/types";
+import type { Session } from "@ory/client-fetch";
+
+function makeAccount(emails?: Account["emails"]): Account {
+  return {
+    account_id: "test-user",
+    type: AccountType.INDIVIDUAL,
+    identity_id: "identity-123",
+    name: "Test User",
+    emails,
+    created_at: "2024-01-01T00:00:00.000Z",
+    updated_at: "2024-01-01T00:00:00.000Z",
+    disabled: false,
+    flags: [],
+    metadata_public: {},
+  } as Account;
+}
+
+function makeOrySession(
+  verifiableAddresses?: Array<{
+    value: string;
+    verified: boolean;
+    verified_at?: Date;
+    created_at?: Date;
+  }>
+): Session {
+  return {
+    identity: {
+      verifiable_addresses: verifiableAddresses,
+    },
+  } as unknown as Session;
+}
+
+describe("isEmailVerifiedInDb", () => {
+  it("returns false when the account has no emails", () => {
+    expect(isEmailVerifiedInDb(makeAccount(undefined))).toBe(false);
+  });
+
+  it("returns false when no email is verified", () => {
+    expect(
+      isEmailVerifiedInDb(
+        makeAccount([
+          {
+            address: "a@example.com",
+            verified: false,
+            is_primary: true,
+            added_at: "2024-01-01T00:00:00.000Z",
+          },
+        ])
+      )
+    ).toBe(false);
+  });
+
+  it("returns true when at least one email is verified", () => {
+    expect(
+      isEmailVerifiedInDb(
+        makeAccount([
+          {
+            address: "a@example.com",
+            verified: false,
+            is_primary: false,
+            added_at: "2024-01-01T00:00:00.000Z",
+          },
+          {
+            address: "b@example.com",
+            verified: true,
+            is_primary: true,
+            added_at: "2024-01-01T00:00:00.000Z",
+          },
+        ])
+      )
+    ).toBe(true);
+  });
+});
+
+describe("isEmailVerifiedInOry", () => {
+  it("returns false for an undefined session", () => {
+    expect(isEmailVerifiedInOry(undefined)).toBe(false);
+  });
+
+  it("returns false when no address is verified", () => {
+    expect(
+      isEmailVerifiedInOry(
+        makeOrySession([{ value: "a@example.com", verified: false }])
+      )
+    ).toBe(false);
+  });
+
+  it("returns true when an address is verified", () => {
+    expect(
+      isEmailVerifiedInOry(
+        makeOrySession([{ value: "a@example.com", verified: true }])
+      )
+    ).toBe(true);
+  });
+});
+
+describe("oryAddressesToAccountEmails", () => {
+  it("returns an empty array when there are no addresses", () => {
+    expect(oryAddressesToAccountEmails(makeOrySession(undefined))).toEqual([]);
+  });
+
+  it("marks the first address as primary and preserves timestamps", () => {
+    const emails = oryAddressesToAccountEmails(
+      makeOrySession([
+        {
+          value: "primary@example.com",
+          verified: true,
+          verified_at: new Date("2024-02-02T00:00:00.000Z"),
+          created_at: new Date("2024-01-01T00:00:00.000Z"),
+        },
+        {
+          value: "secondary@example.com",
+          verified: false,
+          created_at: new Date("2024-01-03T00:00:00.000Z"),
+        },
+      ])
+    );
+
+    expect(emails).toEqual([
+      {
+        address: "primary@example.com",
+        verified: true,
+        is_primary: true,
+        added_at: "2024-01-01T00:00:00.000Z",
+        verified_at: "2024-02-02T00:00:00.000Z",
+      },
+      {
+        address: "secondary@example.com",
+        verified: false,
+        is_primary: false,
+        added_at: "2024-01-03T00:00:00.000Z",
+        verified_at: undefined,
+      },
+    ]);
+  });
+});

--- a/src/lib/accounts/email-verification.ts
+++ b/src/lib/accounts/email-verification.ts
@@ -1,0 +1,51 @@
+/**
+ * @fileoverview Helpers for reconciling email-verification state between Ory
+ * (the upstream identity provider) and our own DynamoDB account record.
+ *
+ * Ory is the source of truth for whether an email has been verified. We mirror
+ * that state onto the account so the rest of the app can read it without a
+ * round-trip to Ory. These helpers are intentionally pure so they can be unit
+ * tested and shared between the page-load banner and the email-verified page.
+ */
+
+import type { Session } from "@ory/client-fetch";
+import type { Account, AccountEmail } from "@/types";
+
+/**
+ * Whether our own DynamoDB record already tracks the account as having a
+ * verified email. This is the state we maintain locally.
+ */
+export function isEmailVerifiedInDb(account: Account): boolean {
+  return Boolean(account.emails?.some((email) => email.verified));
+}
+
+/**
+ * Whether Ory reports at least one verified email address for this session.
+ */
+export function isEmailVerifiedInOry(orySession?: Session): boolean {
+  return Boolean(
+    orySession?.identity?.verifiable_addresses?.some(
+      (address) => address.verified
+    )
+  );
+}
+
+/**
+ * Projects Ory's verifiable addresses onto our {@link AccountEmail} shape so the
+ * verified state can be persisted to DynamoDB. The first address is treated as
+ * primary, mirroring Ory's ordering.
+ */
+export function oryAddressesToAccountEmails(
+  orySession?: Session
+): AccountEmail[] {
+  const addresses = orySession?.identity?.verifiable_addresses ?? [];
+  return addresses.map((address, index) => ({
+    address: address.value,
+    verified: address.verified,
+    is_primary: index === 0,
+    added_at: (address.created_at ?? new Date()).toISOString(),
+    verified_at: address.verified
+      ? (address.verified_at ?? new Date()).toISOString()
+      : undefined,
+  }));
+}


### PR DESCRIPTION
## What

Adds a `VerificationBanner` to the `(app)` layout so that on **every authenticated page load**, while the signed-in user's account is **not yet marked verified in DynamoDB**, we reconcile verification state with Ory and surface the right banner.

Decision flow (only runs while our DB record is unverified — once synced it short-circuits to nothing):

| State | Behavior |
|-------|----------|
| Unauthenticated / no individual account / already verified in our DB | Render nothing |
| Unverified in our DB **and** on Ory | Render a **"please verify your email"** reminder with a link to Ory verification |
| Unverified in our DB **but** verified on Ory | **Sync our DynamoDB record** to match Ory, then render a **"thank you for verifying"** banner. The next load reads the synced record and renders nothing. |

## How

- New server component `src/components/features/auth/VerificationBanner.tsx`, mounted in `src/app/(app)/layout.tsx` inside a `<Suspense fallback={null}>` so the session/DB read streams in without blocking navigation.
- New pure, unit-tested helpers in `src/lib/accounts/email-verification.ts`:
  - `isEmailVerifiedInDb(account)`
  - `isEmailVerifiedInOry(orySession)`
  - `oryAddressesToAccountEmails(orySession)` — projects Ory's `verifiable_addresses` onto our `AccountEmail` shape.
- Refactored the existing `email-verified` page to reuse these helpers, removing the duplicated mapping. (Minor correctness improvement: `verified_at` is now only set for addresses that are actually verified.)

The DB sync is written during render of the banner, matching the existing precedent in the `email-verified` page. It is idempotent and only fires in the narrow window where Ory is verified but our record is stale.

## Testing

- `src/lib/accounts/email-verification.test.ts` — 8 passing unit tests covering the DB/Ory predicates and the address mapping (primary flag, timestamp passthrough, unverified `verified_at` omission, empty input).
- `tsc --noEmit`: 0 errors.
- `next lint` on changed files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)