### PR TITLE
ci: stop auto-review from posting stray "test" comments

### DIFF
--- a/.github/workflows/pr-review-comprehensive.yml
+++ b/.github/workflows/pr-review-comprehensive.yml
@@ -34,6 +34,15 @@ jobs:
             You are reviewing this pull request. Deliver exactly ONE formal GitHub
             pull request review per run, replacing any prior review from earlier runs.
 
+            ABSOLUTE RULE — NO PROBE/TEST WRITES. The ONLY thing you may write to the
+            PR is the single final review in STEP 3 (plus the dismissals in STEP 1).
+            Never post a "test", "test123", placeholder, scratch, or trial comment to
+            verify that the API or line-anchoring works — not as a standalone comment,
+            not as an inline comment, not "just to check". If you are unsure a `gh api`
+            call is correct, reason about it or dry-run the JSON locally with `cat`/`jq`;
+            do NOT probe by posting to the live PR. Any stray comment you leave is
+            visible to the author and is a defect.
+
             STEP 1 — Supersede prior rounds.
             List existing reviews:
               `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews --paginate`
@@ -51,6 +60,9 @@ jobs:
             STEP 3 — Submit ONE formal review in a single API call, bundling every
             inline note in the `comments` array. Build a JSON file and post it:
               `gh api -X POST repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews --input <file>`
+            This POST is the ONLY write you make to the PR in this step, and you make it
+            exactly once. Do not post any comment before it to test the call — build the
+            JSON file, inspect it with `cat`, then post it directly.
 
             Requirements for that JSON:
             - "event": "REQUEST_CHANGES" if there are blocking issues, otherwise "COMMENT".


### PR DESCRIPTION
## What I'm changing

Harden the `Claude Auto Review` workflow (`pr-review-comprehensive.yml`) prompt so it can no longer leave stray `test` / `test123` comments on PRs.

## Why

The review model was occasionally posting throwaway inline comments — `test123`, `test inline`, `test comment 1`, `` test `comment` `` — on open PRs (cluster on #283, e.g. [this one](https://github.com/source-cooperative/source.coop/pull/283#discussion_r3378050923)). These were **not** manual `@claude` prompts: timing places each `test*` comment inside an automated `Claude Auto Review` run (e.g. `test123` at 05:05:27Z sits inside run `27184539560`, 04:49→05:10), with no other active Claude job. The likely cause is the model probing its `gh api .../reviews` call with a test comment to verify line-anchoring, then leaving the probe behind.

## The fix

Two prompt additions, no behavior change to real reviews:
- An **ABSOLUTE RULE** near the top: the only writes to the PR are the dismissals (STEP 1) and the single final review (STEP 3); never post a test/placeholder/probe comment.
- A reminder at the POST step to verify the JSON locally with `cat`/`jq` instead of probing the live PR.

## Testing

- YAML structural check passed; additions are inside the existing `prompt: |` block at the same indentation. No schema/key changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)