### PR TITLE
feat(admin): data connection management (CRUD, S3/Azure/GCP/R2, product mirrors)

### DIFF
--- a/src/app/(app)/[account_id]/[product_id]/(product)/[[...path]]/page.tsx
+++ b/src/app/(app)/[account_id]/[product_id]/(product)/[[...path]]/page.tsx
@@ -84,12 +84,14 @@ export default async function ProductPathPage({ params }: PageProps) {
         | { primaryMirror: ProductMirror; dataConnection: DataConnection }
         | undefined;
 
+      // primary_mirror may be empty or stale (e.g. its mirror/connection was
+      // removed), so guard before dereferencing.
       const primaryMirror =
         product.metadata.mirrors[product.metadata.primary_mirror];
-      const dataConnection = await dataConnectionsTable.fetchById(
-        primaryMirror.connection_id,
-      );
-      if (dataConnection) {
+      const dataConnection = primaryMirror
+        ? await dataConnectionsTable.fetchById(primaryMirror.connection_id)
+        : null;
+      if (primaryMirror && dataConnection) {
         connectionDetails = { primaryMirror, dataConnection };
       }
 

--- a/src/app/(app)/admin/data-connections/[data_connection_id]/page.tsx
+++ b/src/app/(app)/admin/data-connections/[data_connection_id]/page.tsx
@@ -1,11 +1,13 @@
 import { Metadata } from "next";
-import { Flex, Heading } from "@radix-ui/themes";
+import { Suspense } from "react";
+import { Flex, Heading, Text } from "@radix-ui/themes";
 import { notFound } from "next/navigation";
 import { dataConnectionsTable } from "@/lib/clients";
 import {
   DataConnectionForm,
   DeleteDataConnectionButton,
 } from "@/components/features/data-connections";
+import { ConnectionUsage } from "@/components/features/data-connections/ConnectionUsage";
 import { toEditableDataConnection } from "@/components/features/data-connections/redact";
 
 export const metadata: Metadata = {
@@ -40,6 +42,16 @@ export default async function EditDataConnectionPage({
         mode="edit"
         dataConnection={toEditableDataConnection(dataConnection)}
       />
+
+      <Suspense
+        fallback={
+          <Text size="2" color="gray">
+            Loading product usage…
+          </Text>
+        }
+      >
+        <ConnectionUsage connectionId={dataConnection.data_connection_id} />
+      </Suspense>
     </Flex>
   );
 }

--- a/src/app/(app)/admin/data-connections/[data_connection_id]/page.tsx
+++ b/src/app/(app)/admin/data-connections/[data_connection_id]/page.tsx
@@ -1,3 +1,4 @@
+import { Metadata } from "next";
 import { Flex, Heading } from "@radix-ui/themes";
 import { notFound } from "next/navigation";
 import { dataConnectionsTable } from "@/lib/clients";
@@ -5,6 +6,11 @@ import {
   DataConnectionForm,
   DeleteDataConnectionButton,
 } from "@/components/features/data-connections";
+import { toEditableDataConnection } from "@/components/features/data-connections/redact";
+
+export const metadata: Metadata = {
+  title: "Admin — Edit data connection",
+};
 
 interface EditDataConnectionPageProps {
   params: Promise<{ data_connection_id: string }>;
@@ -30,7 +36,10 @@ export default async function EditDataConnectionPage({
           dataConnectionId={dataConnection.data_connection_id}
         />
       </Flex>
-      <DataConnectionForm mode="edit" dataConnection={dataConnection} />
+      <DataConnectionForm
+        mode="edit"
+        dataConnection={toEditableDataConnection(dataConnection)}
+      />
     </Flex>
   );
 }

--- a/src/app/(app)/admin/data-connections/[data_connection_id]/page.tsx
+++ b/src/app/(app)/admin/data-connections/[data_connection_id]/page.tsx
@@ -1,0 +1,36 @@
+import { Flex, Heading } from "@radix-ui/themes";
+import { notFound } from "next/navigation";
+import { dataConnectionsTable } from "@/lib/clients";
+import {
+  DataConnectionForm,
+  DeleteDataConnectionButton,
+} from "@/components/features/data-connections";
+
+interface EditDataConnectionPageProps {
+  params: Promise<{ data_connection_id: string }>;
+}
+
+export default async function EditDataConnectionPage({
+  params,
+}: EditDataConnectionPageProps) {
+  const { data_connection_id } = await params;
+  const dataConnection = await dataConnectionsTable.fetchById(
+    data_connection_id
+  );
+
+  if (!dataConnection) {
+    notFound();
+  }
+
+  return (
+    <Flex direction="column" gap="4">
+      <Flex justify="between" align="center">
+        <Heading size="4">Edit Data Connection</Heading>
+        <DeleteDataConnectionButton
+          dataConnectionId={dataConnection.data_connection_id}
+        />
+      </Flex>
+      <DataConnectionForm mode="edit" dataConnection={dataConnection} />
+    </Flex>
+  );
+}

--- a/src/app/(app)/admin/data-connections/[data_connection_id]/page.tsx
+++ b/src/app/(app)/admin/data-connections/[data_connection_id]/page.tsx
@@ -1,8 +1,8 @@
 import { Metadata } from "next";
 import { Suspense } from "react";
-import { Flex, Heading, Text } from "@radix-ui/themes";
+import { Button, Flex, Heading, Text } from "@radix-ui/themes";
 import { notFound } from "next/navigation";
-import { dataConnectionsTable } from "@/lib/clients";
+import { dataConnectionsTable, productsTable } from "@/lib/clients";
 import {
   DataConnectionForm,
   DeleteDataConnectionButton,
@@ -34,9 +34,17 @@ export default async function EditDataConnectionPage({
     <Flex direction="column" gap="4">
       <Flex justify="between" align="center">
         <Heading size="4">Edit Data Connection</Heading>
-        <DeleteDataConnectionButton
-          dataConnectionId={dataConnection.data_connection_id}
-        />
+        <Suspense
+          fallback={
+            <Button size="2" color="red" variant="soft" disabled>
+              Delete
+            </Button>
+          }
+        >
+          <DeleteConnectionControl
+            connectionId={dataConnection.data_connection_id}
+          />
+        </Suspense>
       </Flex>
       <DataConnectionForm
         mode="edit"
@@ -53,5 +61,22 @@ export default async function EditDataConnectionPage({
         <ConnectionUsage connectionId={dataConnection.data_connection_id} />
       </Suspense>
     </Flex>
+  );
+}
+
+// Fetches the dependent-product count so the delete confirm can be disabled when
+// the connection is in use. The scan is request-deduped with <ConnectionUsage>,
+// so this adds no extra DB work; Suspense keeps it off the form's critical path.
+async function DeleteConnectionControl({
+  connectionId,
+}: {
+  connectionId: string;
+}) {
+  const products = await productsTable.listProductsByConnectionId(connectionId);
+  return (
+    <DeleteDataConnectionButton
+      dataConnectionId={connectionId}
+      productsInUse={products.length}
+    />
   );
 }

--- a/src/app/(app)/admin/data-connections/create/page.tsx
+++ b/src/app/(app)/admin/data-connections/create/page.tsx
@@ -1,0 +1,11 @@
+import { Flex, Heading } from "@radix-ui/themes";
+import { DataConnectionForm } from "@/components/features/data-connections";
+
+export default function CreateDataConnectionPage() {
+  return (
+    <Flex direction="column" gap="4">
+      <Heading size="4">Create Data Connection</Heading>
+      <DataConnectionForm mode="create" />
+    </Flex>
+  );
+}

--- a/src/app/(app)/admin/data-connections/create/page.tsx
+++ b/src/app/(app)/admin/data-connections/create/page.tsx
@@ -1,5 +1,10 @@
+import { Metadata } from "next";
 import { Flex, Heading } from "@radix-ui/themes";
 import { DataConnectionForm } from "@/components/features/data-connections";
+
+export const metadata: Metadata = {
+  title: "Admin — Create data connection",
+};
 
 export default function CreateDataConnectionPage() {
   return (

--- a/src/app/(app)/admin/data-connections/page.tsx
+++ b/src/app/(app)/admin/data-connections/page.tsx
@@ -1,3 +1,4 @@
+import { Metadata } from "next";
 import { dataConnectionsTable } from "@/lib/clients";
 import { Text, Table, Flex, Badge, Button, Heading, Code } from "@radix-ui/themes";
 import { Link1Icon } from "@radix-ui/react-icons";
@@ -7,6 +8,10 @@ import {
   adminDataConnectionCreateUrl,
   adminDataConnectionEditUrl,
 } from "@/lib/urls";
+
+export const metadata: Metadata = {
+  title: "Admin — Data connections",
+};
 
 export default async function DataConnectionsPage() {
   const connections = await dataConnectionsTable.listAll();

--- a/src/app/(app)/admin/data-connections/page.tsx
+++ b/src/app/(app)/admin/data-connections/page.tsx
@@ -13,6 +13,15 @@ export const metadata: Metadata = {
   title: "Admin — Data connections",
 };
 
+const PROVIDER_BADGE: Record<
+  DataProvider,
+  { label: string; color: "orange" | "blue" | "green" }
+> = {
+  [DataProvider.S3]: { label: "S3", color: "orange" },
+  [DataProvider.Azure]: { label: "Azure", color: "blue" },
+  [DataProvider.GCP]: { label: "GCP", color: "green" },
+};
+
 export default async function DataConnectionsPage() {
   const connections = await dataConnectionsTable.listAll();
 
@@ -73,18 +82,14 @@ export default async function DataConnectionsPage() {
                   </Flex>
                 </Table.Cell>
                 <Table.Cell>
-                  <Badge
-                    color={
-                      conn.details.provider === DataProvider.S3
-                        ? "orange"
-                        : "blue"
-                    }
-                  >
-                    {conn.details.provider === DataProvider.S3 ? "S3" : "Azure"}
+                  <Badge color={PROVIDER_BADGE[conn.details.provider].color}>
+                    {PROVIDER_BADGE[conn.details.provider].label}
                   </Badge>
                 </Table.Cell>
                 <Table.Cell>
-                  <Text size="2">{conn.details.region}</Text>
+                  <Text size="2">
+                    {"region" in conn.details ? conn.details.region : "—"}
+                  </Text>
                 </Table.Cell>
                 <Table.Cell>
                   <Badge color={conn.read_only ? "red" : "green"}>

--- a/src/app/(app)/admin/data-connections/page.tsx
+++ b/src/app/(app)/admin/data-connections/page.tsx
@@ -23,7 +23,11 @@ const PROVIDER_BADGE: Record<
 };
 
 export default async function DataConnectionsPage() {
-  const connections = await dataConnectionsTable.listAll();
+  const connections = (await dataConnectionsTable.listAll()).sort(
+    (a, b) =>
+      a.details.provider.localeCompare(b.details.provider) ||
+      a.name.localeCompare(b.name)
+  );
 
   return (
     <Flex direction="column" gap="4">

--- a/src/app/(app)/admin/data-connections/page.tsx
+++ b/src/app/(app)/admin/data-connections/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from "next";
 import { dataConnectionsTable } from "@/lib/clients";
-import { Text, Table, Flex, Badge, Button, Heading, Code } from "@radix-ui/themes";
+import { Text, Table, Flex, Badge, Button, Heading } from "@radix-ui/themes";
 import { Link1Icon } from "@radix-ui/react-icons";
 import Link from "next/link";
 import { DataProvider } from "@/types";
@@ -46,7 +46,6 @@ export default async function DataConnectionsPage() {
           <Table.Header>
             <Table.Row>
               <Table.ColumnHeaderCell>Name</Table.ColumnHeaderCell>
-              <Table.ColumnHeaderCell>ID</Table.ColumnHeaderCell>
               <Table.ColumnHeaderCell>Provider</Table.ColumnHeaderCell>
               <Table.ColumnHeaderCell>Region</Table.ColumnHeaderCell>
               <Table.ColumnHeaderCell>Read Only</Table.ColumnHeaderCell>
@@ -57,15 +56,21 @@ export default async function DataConnectionsPage() {
             {connections.map((conn) => (
               <Table.Row key={conn.data_connection_id}>
                 <Table.Cell>
-                  <Link
-                    href={adminDataConnectionEditUrl(conn.data_connection_id)}
-                    style={{ color: "var(--accent-11)" }}
-                  >
-                    {conn.name}
-                  </Link>
-                </Table.Cell>
-                <Table.Cell>
-                  <Code size="2">{conn.data_connection_id}</Code>
+                  <Flex direction="column">
+                    <Link
+                      href={adminDataConnectionEditUrl(conn.data_connection_id)}
+                      style={{ color: "var(--accent-11)" }}
+                    >
+                      {conn.name}
+                    </Link>
+                    <Text
+                      size="1"
+                      color="gray"
+                      style={{ fontFamily: "var(--code-font-family)" }}
+                    >
+                      {conn.data_connection_id}
+                    </Text>
+                  </Flex>
                 </Table.Cell>
                 <Table.Cell>
                   <Badge

--- a/src/app/(app)/admin/data-connections/page.tsx
+++ b/src/app/(app)/admin/data-connections/page.tsx
@@ -1,0 +1,106 @@
+import { dataConnectionsTable } from "@/lib/clients";
+import { Text, Table, Flex, Badge, Button, Heading, Code } from "@radix-ui/themes";
+import { Link1Icon } from "@radix-ui/react-icons";
+import Link from "next/link";
+import { DataProvider } from "@/types";
+import {
+  adminDataConnectionCreateUrl,
+  adminDataConnectionEditUrl,
+} from "@/lib/urls";
+
+export default async function DataConnectionsPage() {
+  const connections = await dataConnectionsTable.listAll();
+
+  return (
+    <Flex direction="column" gap="4">
+      <Flex justify="between" align="center">
+        <Heading size="4">Data Connections</Heading>
+        <Button asChild size="2">
+          <Link href={adminDataConnectionCreateUrl()}>New Connection</Link>
+        </Button>
+      </Flex>
+
+      {connections.length === 0 ? (
+        <Flex
+          direction="column"
+          align="center"
+          gap="2"
+          py="8"
+          style={{ userSelect: "none" }}
+        >
+          <Link1Icon width="48" height="48" color="var(--gray-8)" />
+          <Text size="4" weight="medium" color="gray">
+            No data connections
+          </Text>
+          <Text size="2" color="gray">
+            Create a data connection to get started.
+          </Text>
+        </Flex>
+      ) : (
+        <Table.Root>
+          <Table.Header>
+            <Table.Row>
+              <Table.ColumnHeaderCell>Name</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>ID</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Provider</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Region</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Read Only</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Visibilities</Table.ColumnHeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {connections.map((conn) => (
+              <Table.Row key={conn.data_connection_id}>
+                <Table.Cell>
+                  <Link
+                    href={adminDataConnectionEditUrl(conn.data_connection_id)}
+                    style={{ color: "var(--accent-11)" }}
+                  >
+                    {conn.name}
+                  </Link>
+                </Table.Cell>
+                <Table.Cell>
+                  <Code size="2">{conn.data_connection_id}</Code>
+                </Table.Cell>
+                <Table.Cell>
+                  <Badge
+                    color={
+                      conn.details.provider === DataProvider.S3
+                        ? "orange"
+                        : "blue"
+                    }
+                  >
+                    {conn.details.provider === DataProvider.S3 ? "S3" : "Azure"}
+                  </Badge>
+                </Table.Cell>
+                <Table.Cell>
+                  <Text size="2">{conn.details.region}</Text>
+                </Table.Cell>
+                <Table.Cell>
+                  <Badge color={conn.read_only ? "red" : "green"}>
+                    {conn.read_only ? "Yes" : "No"}
+                  </Badge>
+                </Table.Cell>
+                <Table.Cell>
+                  <Flex gap="1" wrap="wrap">
+                    {conn.allowed_visibilities.length === 0 ? (
+                      <Text size="2" color="gray">
+                        -
+                      </Text>
+                    ) : (
+                      conn.allowed_visibilities.map((visibility) => (
+                        <Badge key={visibility} variant="soft" size="1">
+                          {visibility}
+                        </Badge>
+                      ))
+                    )}
+                  </Flex>
+                </Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table.Root>
+      )}
+    </Flex>
+  );
+}

--- a/src/app/(app)/edit/product/[account_id]/[product_id]/data-connections/page.tsx
+++ b/src/app/(app)/edit/product/[account_id]/[product_id]/data-connections/page.tsx
@@ -1,0 +1,38 @@
+import { getPageSession } from "@/lib/api/utils";
+import { isAdmin } from "@/lib/api/authz";
+import { productsTable, dataConnectionsTable } from "@/lib/clients";
+import { notFound } from "next/navigation";
+import { ProductMirrorsManager } from "@/components/features/data-connections";
+
+interface ProductDataConnectionsPageProps {
+  params: Promise<{ account_id: string; product_id: string }>;
+}
+
+export default async function ProductDataConnectionsPage({
+  params,
+}: ProductDataConnectionsPageProps) {
+  const { account_id, product_id } = await params;
+
+  const session = await getPageSession();
+  const product = await productsTable.fetchById(account_id, product_id);
+
+  if (!product) {
+    notFound();
+  }
+
+  const userIsAdmin = isAdmin(session);
+
+  // Connections are only needed to populate the admin "add" picker; non-admins
+  // see their existing mirrors read-only.
+  const availableConnections = userIsAdmin
+    ? await dataConnectionsTable.listAll()
+    : [];
+
+  return (
+    <ProductMirrorsManager
+      product={product}
+      availableConnections={availableConnections}
+      isAdmin={userIsAdmin}
+    />
+  );
+}

--- a/src/app/(app)/edit/product/[account_id]/[product_id]/data-connections/page.tsx
+++ b/src/app/(app)/edit/product/[account_id]/[product_id]/data-connections/page.tsx
@@ -3,6 +3,7 @@ import { isAdmin } from "@/lib/api/authz";
 import { productsTable, dataConnectionsTable } from "@/lib/clients";
 import { notFound } from "next/navigation";
 import { ProductMirrorsManager } from "@/components/features/data-connections";
+import { toDataConnectionOption } from "@/components/features/data-connections/redact";
 
 interface ProductDataConnectionsPageProps {
   params: Promise<{ account_id: string; product_id: string }>;
@@ -23,9 +24,10 @@ export default async function ProductDataConnectionsPage({
   const userIsAdmin = isAdmin(session);
 
   // Connections are only needed to populate the admin "add" picker; non-admins
-  // see their existing mirrors read-only.
+  // see their existing mirrors read-only. Redact to a secret-free option shape
+  // so credentials never reach the client.
   const availableConnections = userIsAdmin
-    ? await dataConnectionsTable.listAll()
+    ? (await dataConnectionsTable.listAll()).map(toDataConnectionOption)
     : [];
 
   return (

--- a/src/app/(app)/edit/product/[account_id]/[product_id]/layout.tsx
+++ b/src/app/(app)/edit/product/[account_id]/[product_id]/layout.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from "react";
-import { Pencil1Icon, PersonIcon } from "@radix-ui/react-icons";
+import { Pencil1Icon, PersonIcon, Link1Icon } from "@radix-ui/react-icons";
 import { Flex } from "@radix-ui/themes";
 import {
   SettingsLayout,
@@ -8,7 +8,7 @@ import {
   AccountSelector,
 } from "@/components/features/settings";
 import { getPageSession } from "@/lib/api/utils";
-import { isAuthorized } from "@/lib/api/authz";
+import { isAuthorized, isAdmin } from "@/lib/api/authz";
 import { Actions } from "@/types";
 import { productsTable } from "@/lib/clients/database";
 import { notFound, redirect } from "next/navigation";
@@ -19,6 +19,7 @@ import {
   productUrl,
   editProductDetailsUrl,
   editProductMembershipsUrl,
+  editProductDataConnectionsUrl,
 } from "@/lib/urls";
 import { getManageableAccounts } from "@/lib/clients/lookups";
 
@@ -81,6 +82,13 @@ export default async function ProductLayout({
       href: editProductMembershipsUrl(account_id, product_id),
       icon: <PersonIcon width="16" height="16" />,
       condition: canReadMembership,
+    },
+    {
+      id: "data-connections",
+      label: "Data Connections",
+      href: editProductDataConnectionsUrl(account_id, product_id),
+      icon: <Link1Icon width="16" height="16" />,
+      condition: canEditProduct || isAdmin(session),
     },
   ];
 

--- a/src/components/core/DynamicForm.tsx
+++ b/src/components/core/DynamicForm.tsx
@@ -58,7 +58,9 @@ interface DynamicFormProps<T extends Record<string, any>> {
   onSuccess?: () => void; // Callback when form submission is successful
 }
 
-const style: React.CSSProperties = {
+// Shared input/select styling for app forms. Exported so bespoke forms (e.g.
+// the data-connection form) render identical fields without copying the rule.
+export const formFieldStyle: React.CSSProperties = {
   fontFamily: "var(--code-font-family)",
   width: "100%",
   padding: "8px 12px",
@@ -68,6 +70,8 @@ const style: React.CSSProperties = {
   lineHeight: "1.5",
   boxSizing: "border-box",
 };
+
+const style = formFieldStyle;
 
 export function DynamicForm<T extends Record<string, any>>({
   fields,

--- a/src/components/features/admin/tools.ts
+++ b/src/components/features/admin/tools.ts
@@ -1,6 +1,6 @@
 import type { ComponentType, ComponentProps } from "react";
-import { MagnifyingGlassIcon } from "@radix-ui/react-icons";
-import { adminUserLookupUrl } from "@/lib";
+import { MagnifyingGlassIcon, Link1Icon } from "@radix-ui/react-icons";
+import { adminUserLookupUrl, adminDataConnectionsUrl } from "@/lib";
 
 type IconProps = ComponentProps<typeof MagnifyingGlassIcon>;
 
@@ -22,5 +22,11 @@ export const ADMIN_TOOLS: AdminTool[] = [
     description: "Find a user by email and open their profile.",
     href: adminUserLookupUrl(),
     Icon: MagnifyingGlassIcon,
+  },
+  {
+    name: "Data Connections",
+    description: "Manage the storage backends products mirror their data to.",
+    href: adminDataConnectionsUrl(),
+    Icon: Link1Icon,
   },
 ];

--- a/src/components/features/data-connections/ConnectionUsage.tsx
+++ b/src/components/features/data-connections/ConnectionUsage.tsx
@@ -30,6 +30,7 @@ export async function ConnectionUsage({
             <Table.Row>
               <Table.ColumnHeaderCell>Product</Table.ColumnHeaderCell>
               <Table.ColumnHeaderCell>ID</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Disabled</Table.ColumnHeaderCell>
               <Table.ColumnHeaderCell>Primary</Table.ColumnHeaderCell>
             </Table.Row>
           </Table.Header>
@@ -54,6 +55,15 @@ export async function ConnectionUsage({
                     <Code size="2">
                       {product.account_id}/{product.product_id}
                     </Code>
+                  </Table.Cell>
+                  <Table.Cell>
+                    {product.disabled ? (
+                      <Badge color="red">Disabled</Badge>
+                    ) : (
+                      <Badge color="gray" variant="soft">
+                        Active
+                      </Badge>
+                    )}
                   </Table.Cell>
                   <Table.Cell>
                     {isPrimary ? (

--- a/src/components/features/data-connections/ConnectionUsage.tsx
+++ b/src/components/features/data-connections/ConnectionUsage.tsx
@@ -1,0 +1,75 @@
+import { Flex, Heading, Text, Table, Badge, Code } from "@radix-ui/themes";
+import Link from "next/link";
+import { productsTable } from "@/lib/clients";
+import { productUrl } from "@/lib/urls";
+
+/**
+ * Lists the products that mirror data through a given data connection. The
+ * lookup is a full product-table scan (see
+ * ProductsTable.listProductsByConnectionId), so render this inside <Suspense>
+ * to keep it off the form's critical path.
+ */
+export async function ConnectionUsage({
+  connectionId,
+}: {
+  connectionId: string;
+}) {
+  const products = await productsTable.listProductsByConnectionId(connectionId);
+
+  return (
+    <Flex direction="column" gap="3">
+      <Heading size="4">Products using this connection</Heading>
+
+      {products.length === 0 ? (
+        <Text size="2" color="gray">
+          No products use this connection.
+        </Text>
+      ) : (
+        <Table.Root>
+          <Table.Header>
+            <Table.Row>
+              <Table.ColumnHeaderCell>Product</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>ID</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Primary</Table.ColumnHeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {products.map((product) => {
+              const isPrimary =
+                product.metadata.mirrors[product.metadata.primary_mirror]
+                  ?.connection_id === connectionId;
+              return (
+                <Table.Row
+                  key={`${product.account_id}/${product.product_id}`}
+                >
+                  <Table.Cell>
+                    <Link
+                      href={productUrl(product.account_id, product.product_id)}
+                      style={{ color: "var(--accent-11)" }}
+                    >
+                      {product.title || product.product_id}
+                    </Link>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Code size="2">
+                      {product.account_id}/{product.product_id}
+                    </Code>
+                  </Table.Cell>
+                  <Table.Cell>
+                    {isPrimary ? (
+                      <Badge color="green">Primary</Badge>
+                    ) : (
+                      <Text size="2" color="gray">
+                        -
+                      </Text>
+                    )}
+                  </Table.Cell>
+                </Table.Row>
+              );
+            })}
+          </Table.Body>
+        </Table.Root>
+      )}
+    </Flex>
+  );
+}

--- a/src/components/features/data-connections/ConnectionUsage.tsx
+++ b/src/components/features/data-connections/ConnectionUsage.tsx
@@ -29,9 +29,8 @@ export async function ConnectionUsage({
           <Table.Header>
             <Table.Row>
               <Table.ColumnHeaderCell>Product</Table.ColumnHeaderCell>
-              <Table.ColumnHeaderCell>ID</Table.ColumnHeaderCell>
-              <Table.ColumnHeaderCell>Disabled</Table.ColumnHeaderCell>
               <Table.ColumnHeaderCell>Primary</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Disabled</Table.ColumnHeaderCell>
             </Table.Row>
           </Table.Header>
           <Table.Body>
@@ -44,26 +43,20 @@ export async function ConnectionUsage({
                   key={`${product.account_id}/${product.product_id}`}
                 >
                   <Table.Cell>
-                    <Link
-                      href={productUrl(product.account_id, product.product_id)}
-                      style={{ color: "var(--accent-11)" }}
-                    >
-                      {product.title || product.product_id}
-                    </Link>
-                  </Table.Cell>
-                  <Table.Cell>
-                    <Code size="2">
-                      {product.account_id}/{product.product_id}
-                    </Code>
-                  </Table.Cell>
-                  <Table.Cell>
-                    {product.disabled ? (
-                      <Badge color="red">Disabled</Badge>
-                    ) : (
-                      <Badge color="gray" variant="soft">
-                        Active
-                      </Badge>
-                    )}
+                    <Flex direction="column" gap="1">
+                      <Link
+                        href={productUrl(
+                          product.account_id,
+                          product.product_id
+                        )}
+                        style={{ color: "var(--accent-11)" }}
+                      >
+                        {product.title || product.product_id}
+                      </Link>
+                      <Code size="1" variant="ghost" color="gray">
+                        {product.account_id}/{product.product_id}
+                      </Code>
+                    </Flex>
                   </Table.Cell>
                   <Table.Cell>
                     {isPrimary ? (
@@ -72,6 +65,15 @@ export async function ConnectionUsage({
                       <Text size="2" color="gray">
                         -
                       </Text>
+                    )}
+                  </Table.Cell>
+                  <Table.Cell>
+                    {product.disabled ? (
+                      <Badge color="red">Disabled</Badge>
+                    ) : (
+                      <Badge color="gray" variant="soft">
+                        Active
+                      </Badge>
                     )}
                   </Table.Cell>
                 </Table.Row>

--- a/src/components/features/data-connections/DataConnectionForm.tsx
+++ b/src/components/features/data-connections/DataConnectionForm.tsx
@@ -272,9 +272,12 @@ export function DataConnectionForm({
             type="text"
             name="prefix_template"
             defaultValue={
-              (state.data.get("prefix_template") as string) ||
-              dataConnection?.prefix_template ||
-              "{{repository.account_id}}/{{repository.repository_id}}/"
+              // has()-check, not ||: preserve a user-cleared value across a
+              // failed submit instead of reverting to the stored value.
+              state.data.has("prefix_template")
+                ? (state.data.get("prefix_template") as string)
+                : (dataConnection?.prefix_template ??
+                  "{{repository.account_id}}/{{repository.repository_id}}/")
             }
             style={fieldStyle}
           />
@@ -330,9 +333,11 @@ export function DataConnectionForm({
           <select
             name="required_flag"
             defaultValue={
-              (state.data.get("required_flag") as string) ||
-              dataConnection?.required_flag ||
-              ""
+              // has()-check, not ||: a user-selected "None" ("") must survive a
+              // failed submit instead of reverting to the stored flag.
+              state.data.has("required_flag")
+                ? (state.data.get("required_flag") as string)
+                : (dataConnection?.required_flag ?? "")
             }
             style={fieldStyle}
           >

--- a/src/components/features/data-connections/DataConnectionForm.tsx
+++ b/src/components/features/data-connections/DataConnectionForm.tsx
@@ -55,6 +55,25 @@ const AUTH_TYPE_LABELS: Record<DataConnectionAuthenticationType, string> = {
     "Workload Identity (federated)",
 };
 
+// One-line description of what each authentication type means, shown under the
+// Authentication Type select so the admin knows what they're choosing.
+const AUTH_TYPE_DESCRIPTIONS: Partial<
+  Record<DataConnectionAuthenticationType, string>
+> = {
+  [DataConnectionAuthenticationType.S3ECSTaskRole]:
+    "Use the proxy's ECS task role — no stored credentials.",
+  [DataConnectionAuthenticationType.S3AccessKey]:
+    "Static IAM access key and secret you provide.",
+  [DataConnectionAuthenticationType.S3WebIdentityRole]:
+    "Keyless: the proxy assumes a customer IAM role via web identity.",
+  [DataConnectionAuthenticationType.S3Local]:
+    "Local/dev credential chain — no stored credentials.",
+  [DataConnectionAuthenticationType.AzureSasToken]:
+    "A shared access signature token you provide.",
+  [DataConnectionAuthenticationType.AzureWorkloadIdentity]:
+    "Keyless: the proxy federates into an Azure AD app registration.",
+};
+
 function FieldErrors({ errors, name }: { errors?: string[]; name: string }) {
   if (!errors?.length) return null;
   return (
@@ -65,6 +84,39 @@ function FieldErrors({ errors, name }: { errors?: string[]; name: string }) {
         </Text>
       ))}
     </>
+  );
+}
+
+/**
+ * Labelled field wrapper: renders the label, a gray description of what the
+ * field does, the control, and any server-side validation errors.
+ */
+function Field({
+  label,
+  name,
+  description,
+  errors,
+  children,
+}: {
+  label: string;
+  name: string;
+  description?: React.ReactNode;
+  errors?: string[];
+  children: React.ReactNode;
+}) {
+  return (
+    <Flex direction="column" gap="1">
+      <Text size="3" weight="medium">
+        {label}
+      </Text>
+      {description && (
+        <Text size="1" color="gray">
+          {description}
+        </Text>
+      )}
+      {children}
+      <FieldErrors name={name} errors={errors} />
+    </Flex>
   );
 }
 
@@ -124,17 +176,19 @@ export function DataConnectionForm({
       ? auth.client_id
       : "";
 
-  const secretHint =
-    mode === "edit" ? "Leave blank to keep the current value." : undefined;
+  // Secret fields are never pre-filled; on edit, blank means "keep current".
+  const withSecretHint = (base: string) =>
+    mode === "edit" ? `${base} Leave blank to keep the current value.` : base;
 
   return (
     <Form action={formAction}>
       <Flex direction="column" gap="4">
-        {/* Connection ID */}
-        <Flex direction="column" gap="1">
-          <Text size="3" weight="medium">
-            Connection ID
-          </Text>
+        <Field
+          label="Connection ID"
+          name="data_connection_id"
+          description="Unique identifier used in URLs and as the storage key. Lowercase letters, numbers, and hyphens only; cannot be changed after creation."
+          errors={state.fieldErrors?.data_connection_id}
+        >
           <input
             type="text"
             name="data_connection_id"
@@ -153,17 +207,14 @@ export function DataConnectionForm({
                 : {}),
             }}
           />
-          <FieldErrors
-            name="data_connection_id"
-            errors={state.fieldErrors?.data_connection_id}
-          />
-        </Flex>
+        </Field>
 
-        {/* Name */}
-        <Flex direction="column" gap="1">
-          <Text size="3" weight="medium">
-            Name
-          </Text>
+        <Field
+          label="Name"
+          name="name"
+          description="Human-readable label shown in admin lists and the product mirror picker."
+          errors={state.fieldErrors?.name}
+        >
           <input
             type="text"
             name="name"
@@ -173,14 +224,14 @@ export function DataConnectionForm({
             }
             style={fieldStyle}
           />
-          <FieldErrors name="name" errors={state.fieldErrors?.name} />
-        </Flex>
+        </Field>
 
-        {/* Prefix Template */}
-        <Flex direction="column" gap="1">
-          <Text size="3" weight="medium">
-            Prefix Template
-          </Text>
+        <Field
+          label="Prefix Template"
+          name="prefix_template"
+          description="Template for the object-key prefix each product receives within the bucket/container. {{repository.account_id}} and {{repository.repository_id}} are substituted when a product attaches this connection."
+          errors={state.fieldErrors?.prefix_template}
+        >
           <input
             type="text"
             name="prefix_template"
@@ -191,17 +242,13 @@ export function DataConnectionForm({
             }
             style={fieldStyle}
           />
-          <FieldErrors
-            name="prefix_template"
-            errors={state.fieldErrors?.prefix_template}
-          />
-        </Flex>
+        </Field>
 
-        {/* Read Only */}
-        <Flex direction="column" gap="1">
-          <Text size="3" weight="medium">
-            Read Only
-          </Text>
+        <Field
+          label="Read Only"
+          name="read_only"
+          description="Prevents products from writing or modifying data through this connection — browse and download only."
+        >
           <Flex align="center" gap="2" asChild>
             <label>
               <Checkbox
@@ -211,13 +258,14 @@ export function DataConnectionForm({
               <Text size="2">Connection is read-only</Text>
             </label>
           </Flex>
-        </Flex>
+        </Field>
 
-        {/* Allowed Visibilities */}
-        <Flex direction="column" gap="1">
-          <Text size="3" weight="medium">
-            Allowed Visibilities
-          </Text>
+        <Field
+          label="Allowed Visibilities"
+          name="allowed_visibilities"
+          description="Product visibilities permitted to use this connection. (Not currently enforced.)"
+          errors={state.fieldErrors?.allowed_visibilities}
+        >
           <Flex direction="column" gap="2">
             {Object.values(ProductVisibility).map((visibility) => (
               <Flex align="center" gap="2" asChild key={visibility}>
@@ -235,17 +283,14 @@ export function DataConnectionForm({
               </Flex>
             ))}
           </Flex>
-          <FieldErrors
-            name="allowed_visibilities"
-            errors={state.fieldErrors?.allowed_visibilities}
-          />
-        </Flex>
+        </Field>
 
-        {/* Required Flag */}
-        <Flex direction="column" gap="1">
-          <Text size="3" weight="medium">
-            Required Flag
-          </Text>
+        <Field
+          label="Required Flag"
+          name="required_flag"
+          description="Account flag a user must have for their products to use this connection. Choose None for no restriction. (Not currently enforced.)"
+          errors={state.fieldErrors?.required_flag}
+        >
           <select
             name="required_flag"
             defaultValue={
@@ -262,17 +307,14 @@ export function DataConnectionForm({
               </option>
             ))}
           </select>
-          <FieldErrors
-            name="required_flag"
-            errors={state.fieldErrors?.required_flag}
-          />
-        </Flex>
+        </Field>
 
-        {/* Provider */}
-        <Flex direction="column" gap="1">
-          <Text size="3" weight="medium">
-            Provider
-          </Text>
+        <Field
+          label="Provider"
+          name="provider"
+          description="Storage backend type. Determines the connection and authentication fields shown below."
+          errors={state.fieldErrors?.provider}
+        >
           <select
             name="provider"
             value={provider}
@@ -285,16 +327,17 @@ export function DataConnectionForm({
               </option>
             ))}
           </select>
-          <FieldErrors name="provider" errors={state.fieldErrors?.provider} />
-        </Flex>
+        </Field>
 
         {/* Provider-specific fields */}
         {provider === DataProvider.S3 && (
           <>
-            <Flex direction="column" gap="1">
-              <Text size="3" weight="medium">
-                Bucket
-              </Text>
+            <Field
+              label="Bucket"
+              name="bucket"
+              description="Name of the S3 bucket that stores the data."
+              errors={state.fieldErrors?.bucket}
+            >
               <input
                 type="text"
                 name="bucket"
@@ -306,13 +349,14 @@ export function DataConnectionForm({
                 }
                 style={fieldStyle}
               />
-              <FieldErrors name="bucket" errors={state.fieldErrors?.bucket} />
-            </Flex>
+            </Field>
 
-            <Flex direction="column" gap="1">
-              <Text size="3" weight="medium">
-                Base Prefix
-              </Text>
+            <Field
+              label="Base Prefix"
+              name="base_prefix"
+              description="Optional key prefix prepended to every object path in the bucket (a shared root folder). Leave blank for the bucket root."
+              errors={state.fieldErrors?.base_prefix}
+            >
               <input
                 type="text"
                 name="base_prefix"
@@ -324,16 +368,14 @@ export function DataConnectionForm({
                 }
                 style={fieldStyle}
               />
-              <FieldErrors
-                name="base_prefix"
-                errors={state.fieldErrors?.base_prefix}
-              />
-            </Flex>
+            </Field>
 
-            <Flex direction="column" gap="1">
-              <Text size="3" weight="medium">
-                Region
-              </Text>
+            <Field
+              label="Region"
+              name="region"
+              description="AWS region the bucket is hosted in."
+              errors={state.fieldErrors?.region}
+            >
               <select
                 name="region"
                 defaultValue={
@@ -353,17 +395,18 @@ export function DataConnectionForm({
                   </option>
                 ))}
               </select>
-              <FieldErrors name="region" errors={state.fieldErrors?.region} />
-            </Flex>
+            </Field>
           </>
         )}
 
         {provider === DataProvider.Azure && (
           <>
-            <Flex direction="column" gap="1">
-              <Text size="3" weight="medium">
-                Account Name
-              </Text>
+            <Field
+              label="Account Name"
+              name="account_name"
+              description="Azure Storage account name."
+              errors={state.fieldErrors?.account_name}
+            >
               <input
                 type="text"
                 name="account_name"
@@ -375,16 +418,14 @@ export function DataConnectionForm({
                 }
                 style={fieldStyle}
               />
-              <FieldErrors
-                name="account_name"
-                errors={state.fieldErrors?.account_name}
-              />
-            </Flex>
+            </Field>
 
-            <Flex direction="column" gap="1">
-              <Text size="3" weight="medium">
-                Container Name
-              </Text>
+            <Field
+              label="Container Name"
+              name="container_name"
+              description="Azure Blob Storage container name."
+              errors={state.fieldErrors?.container_name}
+            >
               <input
                 type="text"
                 name="container_name"
@@ -396,16 +437,14 @@ export function DataConnectionForm({
                 }
                 style={fieldStyle}
               />
-              <FieldErrors
-                name="container_name"
-                errors={state.fieldErrors?.container_name}
-              />
-            </Flex>
+            </Field>
 
-            <Flex direction="column" gap="1">
-              <Text size="3" weight="medium">
-                Base Prefix
-              </Text>
+            <Field
+              label="Base Prefix"
+              name="base_prefix"
+              description="Optional key prefix prepended to every object path in the container. Leave blank for the container root."
+              errors={state.fieldErrors?.base_prefix}
+            >
               <input
                 type="text"
                 name="base_prefix"
@@ -417,16 +456,14 @@ export function DataConnectionForm({
                 }
                 style={fieldStyle}
               />
-              <FieldErrors
-                name="base_prefix"
-                errors={state.fieldErrors?.base_prefix}
-              />
-            </Flex>
+            </Field>
 
-            <Flex direction="column" gap="1">
-              <Text size="3" weight="medium">
-                Region
-              </Text>
+            <Field
+              label="Region"
+              name="region"
+              description="Azure region the storage account is hosted in."
+              errors={state.fieldErrors?.region}
+            >
               <select
                 name="region"
                 defaultValue={
@@ -446,16 +483,19 @@ export function DataConnectionForm({
                   </option>
                 ))}
               </select>
-              <FieldErrors name="region" errors={state.fieldErrors?.region} />
-            </Flex>
+            </Field>
           </>
         )}
 
-        {/* Authentication Type */}
-        <Flex direction="column" gap="1">
-          <Text size="3" weight="medium">
-            Authentication Type
-          </Text>
+        <Field
+          label="Authentication Type"
+          name="auth_type"
+          description={
+            (authType && AUTH_TYPE_DESCRIPTIONS[authType as DataConnectionAuthenticationType]) ||
+            "How the data proxy authenticates to this backend when serving the product's data. Choose None for unsigned (public) access."
+          }
+          errors={state.fieldErrors?.auth_type}
+        >
           <select
             name="auth_type"
             value={authType}
@@ -469,16 +509,19 @@ export function DataConnectionForm({
               </option>
             ))}
           </select>
-          <FieldErrors name="auth_type" errors={state.fieldErrors?.auth_type} />
-        </Flex>
+        </Field>
 
         {/* Auth-specific fields */}
         {authType === DataConnectionAuthenticationType.S3AccessKey && (
           <>
-            <Flex direction="column" gap="1">
-              <Text size="3" weight="medium">
-                Access Key ID
-              </Text>
+            <Field
+              label="Access Key ID"
+              name="access_key_id"
+              description={withSecretHint(
+                "AWS access key ID for static-credential access."
+              )}
+              errors={state.fieldErrors?.access_key_id}
+            >
               <input
                 type="text"
                 name="access_key_id"
@@ -487,21 +530,16 @@ export function DataConnectionForm({
                 defaultValue={(state.data.get("access_key_id") as string) || ""}
                 style={fieldStyle}
               />
-              {secretHint && (
-                <Text size="1" color="gray">
-                  {secretHint}
-                </Text>
-              )}
-              <FieldErrors
-                name="access_key_id"
-                errors={state.fieldErrors?.access_key_id}
-              />
-            </Flex>
+            </Field>
 
-            <Flex direction="column" gap="1">
-              <Text size="3" weight="medium">
-                Secret Access Key
-              </Text>
+            <Field
+              label="Secret Access Key"
+              name="secret_access_key"
+              description={withSecretHint(
+                "AWS secret access key paired with the access key ID. Never shown after saving."
+              )}
+              errors={state.fieldErrors?.secret_access_key}
+            >
               <input
                 type="password"
                 name="secret_access_key"
@@ -512,24 +550,19 @@ export function DataConnectionForm({
                 }
                 style={fieldStyle}
               />
-              {secretHint && (
-                <Text size="1" color="gray">
-                  {secretHint}
-                </Text>
-              )}
-              <FieldErrors
-                name="secret_access_key"
-                errors={state.fieldErrors?.secret_access_key}
-              />
-            </Flex>
+            </Field>
           </>
         )}
 
         {authType === DataConnectionAuthenticationType.AzureSasToken && (
-          <Flex direction="column" gap="1">
-            <Text size="3" weight="medium">
-              SAS Token
-            </Text>
+          <Field
+            label="SAS Token"
+            name="sas_token"
+            description={withSecretHint(
+              "Azure shared access signature granting access to the container. Never shown after saving."
+            )}
+            errors={state.fieldErrors?.sas_token}
+          >
             <input
               type="password"
               name="sas_token"
@@ -538,23 +571,16 @@ export function DataConnectionForm({
               defaultValue={(state.data.get("sas_token") as string) || ""}
               style={fieldStyle}
             />
-            {secretHint && (
-              <Text size="1" color="gray">
-                {secretHint}
-              </Text>
-            )}
-            <FieldErrors
-              name="sas_token"
-              errors={state.fieldErrors?.sas_token}
-            />
-          </Flex>
+          </Field>
         )}
 
         {authType === DataConnectionAuthenticationType.S3WebIdentityRole && (
-          <Flex direction="column" gap="1">
-            <Text size="3" weight="medium">
-              Role ARN
-            </Text>
+          <Field
+            label="Role ARN"
+            name="role_arn"
+            description="IAM role the proxy assumes via AssumeRoleWithWebIdentity (keyless federation). This is an ARN, not a secret."
+            errors={state.fieldErrors?.role_arn}
+          >
             <input
               type="text"
               name="role_arn"
@@ -565,20 +591,17 @@ export function DataConnectionForm({
               }
               style={fieldStyle}
             />
-            <Text size="1" color="gray">
-              The proxy assumes this role via AssumeRoleWithWebIdentity. Not a
-              secret.
-            </Text>
-            <FieldErrors name="role_arn" errors={state.fieldErrors?.role_arn} />
-          </Flex>
+          </Field>
         )}
 
         {authType === DataConnectionAuthenticationType.AzureWorkloadIdentity && (
           <>
-            <Flex direction="column" gap="1">
-              <Text size="3" weight="medium">
-                Tenant ID
-              </Text>
+            <Field
+              label="Tenant ID"
+              name="tenant_id"
+              description="Azure AD tenant (directory) ID used for workload-identity federation."
+              errors={state.fieldErrors?.tenant_id}
+            >
               <input
                 type="text"
                 name="tenant_id"
@@ -589,16 +612,14 @@ export function DataConnectionForm({
                 }
                 style={fieldStyle}
               />
-              <FieldErrors
-                name="tenant_id"
-                errors={state.fieldErrors?.tenant_id}
-              />
-            </Flex>
+            </Field>
 
-            <Flex direction="column" gap="1">
-              <Text size="3" weight="medium">
-                Client ID
-              </Text>
+            <Field
+              label="Client ID"
+              name="client_id"
+              description="App registration (client) ID that holds the federated identity credential."
+              errors={state.fieldErrors?.client_id}
+            >
               <input
                 type="text"
                 name="client_id"
@@ -609,11 +630,7 @@ export function DataConnectionForm({
                 }
                 style={fieldStyle}
               />
-              <FieldErrors
-                name="client_id"
-                errors={state.fieldErrors?.client_id}
-              />
-            </Flex>
+            </Field>
           </>
         )}
 

--- a/src/components/features/data-connections/DataConnectionForm.tsx
+++ b/src/components/features/data-connections/DataConnectionForm.tsx
@@ -1,0 +1,621 @@
+"use client";
+
+import React, { useState, useActionState } from "react";
+import { Button, Text, Flex, Checkbox } from "@radix-ui/themes";
+import Form from "next/form";
+import { useRouter } from "next/navigation";
+import {
+  DataConnection,
+  DataProvider,
+  DataConnectionAuthenticationType,
+  S3Regions,
+  AzureRegions,
+  ProductVisibility,
+  AccountFlags,
+} from "@/types";
+import {
+  createDataConnection,
+  updateDataConnection,
+} from "@/lib/actions/data-connections";
+
+interface DataConnectionFormProps {
+  dataConnection?: DataConnection;
+  mode: "create" | "edit";
+}
+
+const fieldStyle: React.CSSProperties = {
+  fontFamily: "var(--code-font-family)",
+  width: "100%",
+  padding: "8px 12px",
+  borderRadius: "0",
+  border: "1px solid var(--gray-6)",
+  fontSize: "16px",
+  lineHeight: "1.5",
+  boxSizing: "border-box",
+};
+
+// Storage providers limited to those with a `details` schema (S3, Azure).
+const providerOptions: Array<{ value: DataProvider; label: string }> = [
+  { value: DataProvider.S3, label: "S3" },
+  { value: DataProvider.Azure, label: "Azure" },
+];
+
+const s3AuthTypes = [
+  DataConnectionAuthenticationType.S3ECSTaskRole,
+  DataConnectionAuthenticationType.S3AccessKey,
+  DataConnectionAuthenticationType.S3WebIdentityRole,
+  DataConnectionAuthenticationType.S3Local,
+];
+
+const azureAuthTypes = [
+  DataConnectionAuthenticationType.AzureSasToken,
+  DataConnectionAuthenticationType.AzureWorkloadIdentity,
+];
+
+const AUTH_TYPE_LABELS: Record<DataConnectionAuthenticationType, string> = {
+  [DataConnectionAuthenticationType.S3AccessKey]: "Access Key",
+  [DataConnectionAuthenticationType.S3WebIdentityRole]:
+    "Web Identity Role (federated)",
+  [DataConnectionAuthenticationType.S3ECSTaskRole]: "ECS Task Role",
+  [DataConnectionAuthenticationType.S3Local]: "Local",
+  [DataConnectionAuthenticationType.AzureSasToken]: "SAS Token",
+  [DataConnectionAuthenticationType.AzureWorkloadIdentity]:
+    "Workload Identity (federated)",
+  [DataConnectionAuthenticationType.GcpWorkloadIdentity]:
+    "Workload Identity (federated)",
+};
+
+function FieldErrors({ errors, name }: { errors?: string[]; name: string }) {
+  if (!errors?.length) return null;
+  return (
+    <>
+      {errors.map((error, index) => (
+        <Text size="1" color="red" key={`${name}-${index}`}>
+          {error}
+        </Text>
+      ))}
+    </>
+  );
+}
+
+export function DataConnectionForm({
+  dataConnection,
+  mode,
+}: DataConnectionFormProps) {
+  const router = useRouter();
+  const action = mode === "create" ? createDataConnection : updateDataConnection;
+
+  const [state, formAction, pending] = useActionState(action, {
+    message: "",
+    data: new FormData(),
+    fieldErrors: {},
+    success: false,
+  });
+
+  // Navigate client-side after a successful submission that asks for it, so the
+  // shared admin layout is refetched with the current session.
+  React.useEffect(() => {
+    if (state.success && state.redirectTo) {
+      router.refresh();
+      router.push(state.redirectTo);
+    }
+  }, [state.success, state.redirectTo, router]);
+
+  const [provider, setProvider] = useState<string>(
+    dataConnection?.details.provider || DataProvider.S3
+  );
+
+  const [authType, setAuthType] = useState<string>(
+    dataConnection?.authentication?.type || ""
+  );
+
+  // Reset auth type when provider changes; auth options are provider-specific.
+  const handleProviderChange = (value: string) => {
+    setProvider(value);
+    setAuthType("");
+  };
+
+  const authOptions =
+    provider === DataProvider.S3 ? s3AuthTypes : azureAuthTypes;
+
+  // Pre-fill non-secret authentication fields from the existing connection.
+  // Secrets (access keys, SAS tokens) are intentionally never rendered.
+  const auth = dataConnection?.authentication;
+  const initialRoleArn =
+    auth?.type === DataConnectionAuthenticationType.S3WebIdentityRole
+      ? auth.role_arn
+      : "";
+  const initialTenantId =
+    auth?.type === DataConnectionAuthenticationType.AzureWorkloadIdentity
+      ? auth.tenant_id
+      : "";
+  const initialClientId =
+    auth?.type === DataConnectionAuthenticationType.AzureWorkloadIdentity
+      ? auth.client_id
+      : "";
+
+  const secretHint =
+    mode === "edit" ? "Leave blank to keep the current value." : undefined;
+
+  return (
+    <Form action={formAction}>
+      <Flex direction="column" gap="4">
+        {/* Connection ID */}
+        <Flex direction="column" gap="1">
+          <Text size="3" weight="medium">
+            Connection ID
+          </Text>
+          <input
+            type="text"
+            name="data_connection_id"
+            required
+            placeholder="my-data-connection"
+            readOnly={mode === "edit"}
+            defaultValue={
+              (state.data.get("data_connection_id") as string) ||
+              dataConnection?.data_connection_id ||
+              ""
+            }
+            style={{
+              ...fieldStyle,
+              ...(mode === "edit"
+                ? { backgroundColor: "var(--gray-3)", cursor: "not-allowed" }
+                : {}),
+            }}
+          />
+          <FieldErrors
+            name="data_connection_id"
+            errors={state.fieldErrors?.data_connection_id}
+          />
+        </Flex>
+
+        {/* Name */}
+        <Flex direction="column" gap="1">
+          <Text size="3" weight="medium">
+            Name
+          </Text>
+          <input
+            type="text"
+            name="name"
+            required
+            defaultValue={
+              (state.data.get("name") as string) || dataConnection?.name || ""
+            }
+            style={fieldStyle}
+          />
+          <FieldErrors name="name" errors={state.fieldErrors?.name} />
+        </Flex>
+
+        {/* Prefix Template */}
+        <Flex direction="column" gap="1">
+          <Text size="3" weight="medium">
+            Prefix Template
+          </Text>
+          <input
+            type="text"
+            name="prefix_template"
+            defaultValue={
+              (state.data.get("prefix_template") as string) ||
+              dataConnection?.prefix_template ||
+              "{{repository.account_id}}/{{repository.repository_id}}/"
+            }
+            style={fieldStyle}
+          />
+          <FieldErrors
+            name="prefix_template"
+            errors={state.fieldErrors?.prefix_template}
+          />
+        </Flex>
+
+        {/* Read Only */}
+        <Flex direction="column" gap="1">
+          <Text size="3" weight="medium">
+            Read Only
+          </Text>
+          <Flex align="center" gap="2" asChild>
+            <label>
+              <Checkbox
+                name="read_only"
+                defaultChecked={dataConnection?.read_only || false}
+              />
+              <Text size="2">Connection is read-only</Text>
+            </label>
+          </Flex>
+        </Flex>
+
+        {/* Allowed Visibilities */}
+        <Flex direction="column" gap="1">
+          <Text size="3" weight="medium">
+            Allowed Visibilities
+          </Text>
+          <Flex direction="column" gap="2">
+            {Object.values(ProductVisibility).map((visibility) => (
+              <Flex align="center" gap="2" asChild key={visibility}>
+                <label>
+                  <Checkbox
+                    name={`visibility_${visibility}`}
+                    defaultChecked={
+                      dataConnection?.allowed_visibilities?.includes(
+                        visibility
+                      ) || false
+                    }
+                  />
+                  <Text size="2">{visibility}</Text>
+                </label>
+              </Flex>
+            ))}
+          </Flex>
+          <FieldErrors
+            name="allowed_visibilities"
+            errors={state.fieldErrors?.allowed_visibilities}
+          />
+        </Flex>
+
+        {/* Required Flag */}
+        <Flex direction="column" gap="1">
+          <Text size="3" weight="medium">
+            Required Flag
+          </Text>
+          <select
+            name="required_flag"
+            defaultValue={
+              (state.data.get("required_flag") as string) ||
+              dataConnection?.required_flag ||
+              ""
+            }
+            style={fieldStyle}
+          >
+            <option value="">None</option>
+            {Object.values(AccountFlags).map((flag) => (
+              <option key={flag} value={flag}>
+                {flag}
+              </option>
+            ))}
+          </select>
+          <FieldErrors
+            name="required_flag"
+            errors={state.fieldErrors?.required_flag}
+          />
+        </Flex>
+
+        {/* Provider */}
+        <Flex direction="column" gap="1">
+          <Text size="3" weight="medium">
+            Provider
+          </Text>
+          <select
+            name="provider"
+            value={provider}
+            onChange={(e) => handleProviderChange(e.target.value)}
+            style={fieldStyle}
+          >
+            {providerOptions.map((p) => (
+              <option key={p.value} value={p.value}>
+                {p.label}
+              </option>
+            ))}
+          </select>
+          <FieldErrors name="provider" errors={state.fieldErrors?.provider} />
+        </Flex>
+
+        {/* Provider-specific fields */}
+        {provider === DataProvider.S3 && (
+          <>
+            <Flex direction="column" gap="1">
+              <Text size="3" weight="medium">
+                Bucket
+              </Text>
+              <input
+                type="text"
+                name="bucket"
+                defaultValue={
+                  (state.data.get("bucket") as string) ||
+                  (dataConnection?.details.provider === DataProvider.S3
+                    ? dataConnection.details.bucket
+                    : "")
+                }
+                style={fieldStyle}
+              />
+              <FieldErrors name="bucket" errors={state.fieldErrors?.bucket} />
+            </Flex>
+
+            <Flex direction="column" gap="1">
+              <Text size="3" weight="medium">
+                Base Prefix
+              </Text>
+              <input
+                type="text"
+                name="base_prefix"
+                defaultValue={
+                  (state.data.get("base_prefix") as string) ||
+                  (dataConnection?.details.provider === DataProvider.S3
+                    ? dataConnection.details.base_prefix
+                    : "")
+                }
+                style={fieldStyle}
+              />
+              <FieldErrors
+                name="base_prefix"
+                errors={state.fieldErrors?.base_prefix}
+              />
+            </Flex>
+
+            <Flex direction="column" gap="1">
+              <Text size="3" weight="medium">
+                Region
+              </Text>
+              <select
+                name="region"
+                defaultValue={
+                  (state.data.get("region") as string) ||
+                  (dataConnection?.details.provider === DataProvider.S3
+                    ? dataConnection.details.region
+                    : "")
+                }
+                style={fieldStyle}
+              >
+                <option value="" disabled>
+                  Select a region
+                </option>
+                {Object.values(S3Regions).map((region) => (
+                  <option key={region} value={region}>
+                    {region}
+                  </option>
+                ))}
+              </select>
+              <FieldErrors name="region" errors={state.fieldErrors?.region} />
+            </Flex>
+          </>
+        )}
+
+        {provider === DataProvider.Azure && (
+          <>
+            <Flex direction="column" gap="1">
+              <Text size="3" weight="medium">
+                Account Name
+              </Text>
+              <input
+                type="text"
+                name="account_name"
+                defaultValue={
+                  (state.data.get("account_name") as string) ||
+                  (dataConnection?.details.provider === DataProvider.Azure
+                    ? dataConnection.details.account_name
+                    : "")
+                }
+                style={fieldStyle}
+              />
+              <FieldErrors
+                name="account_name"
+                errors={state.fieldErrors?.account_name}
+              />
+            </Flex>
+
+            <Flex direction="column" gap="1">
+              <Text size="3" weight="medium">
+                Container Name
+              </Text>
+              <input
+                type="text"
+                name="container_name"
+                defaultValue={
+                  (state.data.get("container_name") as string) ||
+                  (dataConnection?.details.provider === DataProvider.Azure
+                    ? dataConnection.details.container_name
+                    : "")
+                }
+                style={fieldStyle}
+              />
+              <FieldErrors
+                name="container_name"
+                errors={state.fieldErrors?.container_name}
+              />
+            </Flex>
+
+            <Flex direction="column" gap="1">
+              <Text size="3" weight="medium">
+                Base Prefix
+              </Text>
+              <input
+                type="text"
+                name="base_prefix"
+                defaultValue={
+                  (state.data.get("base_prefix") as string) ||
+                  (dataConnection?.details.provider === DataProvider.Azure
+                    ? dataConnection.details.base_prefix
+                    : "")
+                }
+                style={fieldStyle}
+              />
+              <FieldErrors
+                name="base_prefix"
+                errors={state.fieldErrors?.base_prefix}
+              />
+            </Flex>
+
+            <Flex direction="column" gap="1">
+              <Text size="3" weight="medium">
+                Region
+              </Text>
+              <select
+                name="region"
+                defaultValue={
+                  (state.data.get("region") as string) ||
+                  (dataConnection?.details.provider === DataProvider.Azure
+                    ? dataConnection.details.region
+                    : "")
+                }
+                style={fieldStyle}
+              >
+                <option value="" disabled>
+                  Select a region
+                </option>
+                {Object.values(AzureRegions).map((region) => (
+                  <option key={region} value={region}>
+                    {region}
+                  </option>
+                ))}
+              </select>
+              <FieldErrors name="region" errors={state.fieldErrors?.region} />
+            </Flex>
+          </>
+        )}
+
+        {/* Authentication Type */}
+        <Flex direction="column" gap="1">
+          <Text size="3" weight="medium">
+            Authentication Type
+          </Text>
+          <select
+            name="auth_type"
+            value={authType}
+            onChange={(e) => setAuthType(e.target.value)}
+            style={fieldStyle}
+          >
+            <option value="">None (unsigned)</option>
+            {authOptions.map((type) => (
+              <option key={type} value={type}>
+                {AUTH_TYPE_LABELS[type]}
+              </option>
+            ))}
+          </select>
+          <FieldErrors name="auth_type" errors={state.fieldErrors?.auth_type} />
+        </Flex>
+
+        {/* Auth-specific fields */}
+        {authType === DataConnectionAuthenticationType.S3AccessKey && (
+          <>
+            <Flex direction="column" gap="1">
+              <Text size="3" weight="medium">
+                Access Key ID
+              </Text>
+              <input
+                type="text"
+                name="access_key_id"
+                autoComplete="off"
+                required={mode === "create"}
+                defaultValue={(state.data.get("access_key_id") as string) || ""}
+                style={fieldStyle}
+              />
+              {secretHint && (
+                <Text size="1" color="gray">
+                  {secretHint}
+                </Text>
+              )}
+              <FieldErrors
+                name="access_key_id"
+                errors={state.fieldErrors?.access_key_id}
+              />
+            </Flex>
+
+            <Flex direction="column" gap="1">
+              <Text size="3" weight="medium">
+                Secret Access Key
+              </Text>
+              <input
+                type="password"
+                name="secret_access_key"
+                autoComplete="new-password"
+                required={mode === "create"}
+                defaultValue={
+                  (state.data.get("secret_access_key") as string) || ""
+                }
+                style={fieldStyle}
+              />
+              {secretHint && (
+                <Text size="1" color="gray">
+                  {secretHint}
+                </Text>
+              )}
+              <FieldErrors
+                name="secret_access_key"
+                errors={state.fieldErrors?.secret_access_key}
+              />
+            </Flex>
+          </>
+        )}
+
+        {authType === DataConnectionAuthenticationType.S3WebIdentityRole && (
+          <Flex direction="column" gap="1">
+            <Text size="3" weight="medium">
+              Role ARN
+            </Text>
+            <input
+              type="text"
+              name="role_arn"
+              required
+              placeholder="arn:aws:iam::123456789012:role/my-role"
+              defaultValue={
+                (state.data.get("role_arn") as string) || initialRoleArn
+              }
+              style={fieldStyle}
+            />
+            <Text size="1" color="gray">
+              The proxy assumes this role via AssumeRoleWithWebIdentity. Not a
+              secret.
+            </Text>
+            <FieldErrors name="role_arn" errors={state.fieldErrors?.role_arn} />
+          </Flex>
+        )}
+
+        {authType === DataConnectionAuthenticationType.AzureWorkloadIdentity && (
+          <>
+            <Flex direction="column" gap="1">
+              <Text size="3" weight="medium">
+                Tenant ID
+              </Text>
+              <input
+                type="text"
+                name="tenant_id"
+                required
+                placeholder="00000000-0000-0000-0000-000000000000"
+                defaultValue={
+                  (state.data.get("tenant_id") as string) || initialTenantId
+                }
+                style={fieldStyle}
+              />
+              <FieldErrors
+                name="tenant_id"
+                errors={state.fieldErrors?.tenant_id}
+              />
+            </Flex>
+
+            <Flex direction="column" gap="1">
+              <Text size="3" weight="medium">
+                Client ID
+              </Text>
+              <input
+                type="text"
+                name="client_id"
+                required
+                placeholder="00000000-0000-0000-0000-000000000000"
+                defaultValue={
+                  (state.data.get("client_id") as string) || initialClientId
+                }
+                style={fieldStyle}
+              />
+              <FieldErrors
+                name="client_id"
+                errors={state.fieldErrors?.client_id}
+              />
+            </Flex>
+          </>
+        )}
+
+        {/* Submit */}
+        <Flex mt="4" justify="end">
+          <Flex direction="column" gap="2" align="end">
+            <Button size="3" type="submit" disabled={pending} loading={pending}>
+              {mode === "create" ? "Create Connection" : "Update Connection"}
+            </Button>
+            {state?.message && (
+              <Text size="1" color={state.success ? "green" : "red"}>
+                {state.message}
+              </Text>
+            )}
+          </Flex>
+        </Flex>
+      </Flex>
+    </Form>
+  );
+}

--- a/src/components/features/data-connections/DataConnectionForm.tsx
+++ b/src/components/features/data-connections/DataConnectionForm.tsx
@@ -24,10 +24,11 @@ interface DataConnectionFormProps {
   mode: "create" | "edit";
 }
 
-// Storage providers limited to those with a `details` schema (S3, Azure).
+// Storage providers limited to those with a `details` schema (S3, Azure, GCP).
 const providerOptions: Array<{ value: DataProvider; label: string }> = [
-  { value: DataProvider.S3, label: "S3" },
+  { value: DataProvider.S3, label: "S3 / S3-compatible (R2, MinIO)" },
   { value: DataProvider.Azure, label: "Azure" },
+  { value: DataProvider.GCP, label: "GCP (GCS)" },
 ];
 
 const s3AuthTypes = [
@@ -41,6 +42,14 @@ const azureAuthTypes = [
   DataConnectionAuthenticationType.AzureSasToken,
   DataConnectionAuthenticationType.AzureWorkloadIdentity,
 ];
+
+const gcpAuthTypes = [DataConnectionAuthenticationType.GcpWorkloadIdentity];
+
+const authTypesByProvider: Record<string, DataConnectionAuthenticationType[]> = {
+  [DataProvider.S3]: s3AuthTypes,
+  [DataProvider.Azure]: azureAuthTypes,
+  [DataProvider.GCP]: gcpAuthTypes,
+};
 
 const AUTH_TYPE_LABELS: Record<DataConnectionAuthenticationType, string> = {
   [DataConnectionAuthenticationType.S3AccessKey]: "Access Key",
@@ -72,6 +81,8 @@ const AUTH_TYPE_DESCRIPTIONS: Partial<
     "A shared access signature token you provide.",
   [DataConnectionAuthenticationType.AzureWorkloadIdentity]:
     "Keyless: the proxy federates into an Azure AD app registration.",
+  [DataConnectionAuthenticationType.GcpWorkloadIdentity]:
+    "Keyless: the proxy federates into a GCP service account via Workload Identity.",
 };
 
 function FieldErrors({ errors, name }: { errors?: string[]; name: string }) {
@@ -157,8 +168,7 @@ export function DataConnectionForm({
     setAuthType("");
   };
 
-  const authOptions =
-    provider === DataProvider.S3 ? s3AuthTypes : azureAuthTypes;
+  const authOptions = authTypesByProvider[provider] ?? s3AuthTypes;
 
   // Pre-fill non-secret authentication fields from the existing connection.
   // Secrets (access keys, SAS tokens) are intentionally never rendered.
@@ -174,6 +184,14 @@ export function DataConnectionForm({
   const initialClientId =
     auth?.type === DataConnectionAuthenticationType.AzureWorkloadIdentity
       ? auth.client_id
+      : "";
+  const initialWorkloadIdentityProvider =
+    auth?.type === DataConnectionAuthenticationType.GcpWorkloadIdentity
+      ? auth.workload_identity_provider
+      : "";
+  const initialServiceAccount =
+    auth?.type === DataConnectionAuthenticationType.GcpWorkloadIdentity
+      ? auth.service_account
       : "";
 
   // Secret fields are never pre-filled; on edit, blank means "keep current".
@@ -373,7 +391,7 @@ export function DataConnectionForm({
             <Field
               label="Region"
               name="region"
-              description="AWS region the bucket is hosted in."
+              description="AWS region the bucket is hosted in. Use “auto” for S3-compatible backends like Cloudflare R2."
               errors={state.fieldErrors?.region}
             >
               <select
@@ -395,6 +413,68 @@ export function DataConnectionForm({
                   </option>
                 ))}
               </select>
+            </Field>
+
+            <Field
+              label="Endpoint"
+              name="endpoint"
+              description="Custom S3-compatible endpoint for non-AWS backends (Cloudflare R2, MinIO, Ceph). Leave blank for AWS S3."
+              errors={state.fieldErrors?.endpoint}
+            >
+              <input
+                type="text"
+                name="endpoint"
+                placeholder="https://<account>.r2.cloudflarestorage.com"
+                defaultValue={
+                  (state.data.get("endpoint") as string) ||
+                  (dataConnection?.details.provider === DataProvider.S3
+                    ? dataConnection.details.endpoint ?? ""
+                    : "")
+                }
+                style={fieldStyle}
+              />
+            </Field>
+          </>
+        )}
+
+        {provider === DataProvider.GCP && (
+          <>
+            <Field
+              label="Bucket"
+              name="bucket"
+              description="Name of the Google Cloud Storage bucket."
+              errors={state.fieldErrors?.bucket}
+            >
+              <input
+                type="text"
+                name="bucket"
+                defaultValue={
+                  (state.data.get("bucket") as string) ||
+                  (dataConnection?.details.provider === DataProvider.GCP
+                    ? dataConnection.details.bucket
+                    : "")
+                }
+                style={fieldStyle}
+              />
+            </Field>
+
+            <Field
+              label="Base Prefix"
+              name="base_prefix"
+              description="Optional key prefix prepended to every object path in the bucket. Leave blank for the bucket root."
+              errors={state.fieldErrors?.base_prefix}
+            >
+              <input
+                type="text"
+                name="base_prefix"
+                defaultValue={
+                  (state.data.get("base_prefix") as string) ||
+                  (dataConnection?.details.provider === DataProvider.GCP
+                    ? dataConnection.details.base_prefix
+                    : "")
+                }
+                style={fieldStyle}
+              />
             </Field>
           </>
         )}
@@ -627,6 +707,49 @@ export function DataConnectionForm({
                 placeholder="00000000-0000-0000-0000-000000000000"
                 defaultValue={
                   (state.data.get("client_id") as string) || initialClientId
+                }
+                style={fieldStyle}
+              />
+            </Field>
+          </>
+        )}
+
+        {authType ===
+          DataConnectionAuthenticationType.GcpWorkloadIdentity && (
+          <>
+            <Field
+              label="Workload Identity Provider"
+              name="workload_identity_provider"
+              description="Full GCP Workload Identity provider resource. Not a secret."
+              errors={state.fieldErrors?.workload_identity_provider}
+            >
+              <input
+                type="text"
+                name="workload_identity_provider"
+                required
+                placeholder="//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider"
+                defaultValue={
+                  (state.data.get("workload_identity_provider") as string) ||
+                  initialWorkloadIdentityProvider
+                }
+                style={fieldStyle}
+              />
+            </Field>
+
+            <Field
+              label="Service Account"
+              name="service_account"
+              description="Email of the GCP service account the proxy impersonates. Not a secret."
+              errors={state.fieldErrors?.service_account}
+            >
+              <input
+                type="text"
+                name="service_account"
+                required
+                placeholder="sa@my-project.iam.gserviceaccount.com"
+                defaultValue={
+                  (state.data.get("service_account") as string) ||
+                  initialServiceAccount
                 }
                 style={fieldStyle}
               />

--- a/src/components/features/data-connections/DataConnectionForm.tsx
+++ b/src/components/features/data-connections/DataConnectionForm.tsx
@@ -162,6 +162,24 @@ export function DataConnectionForm({
     dataConnection?.authentication?.type || ""
   );
 
+  // Controlled so the user's selections survive a re-render after a failed
+  // submit. React 19 resets uncontrolled form fields once the action returns;
+  // text inputs re-seed from `state.data`, but checkboxes can't (there's no way
+  // to tell "unchecked" from "absent"), so they must be controlled.
+  const [readOnly, setReadOnly] = useState<boolean>(
+    dataConnection?.read_only ?? false
+  );
+  const [visibilities, setVisibilities] = useState<Set<string>>(
+    () => new Set(dataConnection?.allowed_visibilities ?? [])
+  );
+  const toggleVisibility = (visibility: string, checked: boolean) =>
+    setVisibilities((prev) => {
+      const next = new Set(prev);
+      if (checked) next.add(visibility);
+      else next.delete(visibility);
+      return next;
+    });
+
   // Reset auth type when provider changes; auth options are provider-specific.
   const handleProviderChange = (value: string) => {
     setProvider(value);
@@ -271,7 +289,8 @@ export function DataConnectionForm({
             <label>
               <Checkbox
                 name="read_only"
-                defaultChecked={dataConnection?.read_only || false}
+                checked={readOnly}
+                onCheckedChange={(checked) => setReadOnly(checked === true)}
               />
               <Text size="2">Connection is read-only</Text>
             </label>
@@ -290,10 +309,9 @@ export function DataConnectionForm({
                 <label>
                   <Checkbox
                     name={`visibility_${visibility}`}
-                    defaultChecked={
-                      dataConnection?.allowed_visibilities?.includes(
-                        visibility
-                      ) || false
+                    checked={visibilities.has(visibility)}
+                    onCheckedChange={(checked) =>
+                      toggleVisibility(visibility, checked === true)
                     }
                   />
                   <Text size="2">{visibility}</Text>

--- a/src/components/features/data-connections/DataConnectionForm.tsx
+++ b/src/components/features/data-connections/DataConnectionForm.tsx
@@ -5,7 +5,6 @@ import { Button, Text, Flex, Checkbox } from "@radix-ui/themes";
 import Form from "next/form";
 import { useRouter } from "next/navigation";
 import {
-  DataConnection,
   DataProvider,
   DataConnectionAuthenticationType,
   S3Regions,
@@ -13,26 +12,17 @@ import {
   ProductVisibility,
   AccountFlags,
 } from "@/types";
+import { formFieldStyle as fieldStyle } from "@/components/core/DynamicForm";
 import {
   createDataConnection,
   updateDataConnection,
 } from "@/lib/actions/data-connections";
+import type { EditableDataConnection } from "./redact";
 
 interface DataConnectionFormProps {
-  dataConnection?: DataConnection;
+  dataConnection?: EditableDataConnection;
   mode: "create" | "edit";
 }
-
-const fieldStyle: React.CSSProperties = {
-  fontFamily: "var(--code-font-family)",
-  width: "100%",
-  padding: "8px 12px",
-  borderRadius: "0",
-  border: "1px solid var(--gray-6)",
-  fontSize: "16px",
-  lineHeight: "1.5",
-  boxSizing: "border-box",
-};
 
 // Storage providers limited to those with a `details` schema (S3, Azure).
 const providerOptions: Array<{ value: DataProvider; label: string }> = [
@@ -533,6 +523,31 @@ export function DataConnectionForm({
               />
             </Flex>
           </>
+        )}
+
+        {authType === DataConnectionAuthenticationType.AzureSasToken && (
+          <Flex direction="column" gap="1">
+            <Text size="3" weight="medium">
+              SAS Token
+            </Text>
+            <input
+              type="password"
+              name="sas_token"
+              autoComplete="new-password"
+              required={mode === "create"}
+              defaultValue={(state.data.get("sas_token") as string) || ""}
+              style={fieldStyle}
+            />
+            {secretHint && (
+              <Text size="1" color="gray">
+                {secretHint}
+              </Text>
+            )}
+            <FieldErrors
+              name="sas_token"
+              errors={state.fieldErrors?.sas_token}
+            />
+          </Flex>
         )}
 
         {authType === DataConnectionAuthenticationType.S3WebIdentityRole && (

--- a/src/components/features/data-connections/DeleteDataConnectionButton.tsx
+++ b/src/components/features/data-connections/DeleteDataConnectionButton.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import React, { useActionState } from "react";
+import { Button, Text, Flex, AlertDialog } from "@radix-ui/themes";
+import Form from "next/form";
+import { useRouter } from "next/navigation";
+import { deleteDataConnection } from "@/lib/actions/data-connections";
+
+interface DeleteDataConnectionButtonProps {
+  dataConnectionId: string;
+}
+
+export function DeleteDataConnectionButton({
+  dataConnectionId,
+}: DeleteDataConnectionButtonProps) {
+  const router = useRouter();
+  const [state, formAction, pending] = useActionState(deleteDataConnection, {
+    message: "",
+    data: new FormData(),
+    fieldErrors: {},
+    success: false,
+  });
+
+  // Navigate client-side back to the list once the deletion succeeds.
+  React.useEffect(() => {
+    if (state.success && state.redirectTo) {
+      router.refresh();
+      router.push(state.redirectTo);
+    }
+  }, [state.success, state.redirectTo, router]);
+
+  return (
+    <AlertDialog.Root>
+      <AlertDialog.Trigger>
+        <Button size="2" color="red" variant="soft">
+          Delete
+        </Button>
+      </AlertDialog.Trigger>
+      <AlertDialog.Content maxWidth="450px">
+        <AlertDialog.Title>Delete Data Connection</AlertDialog.Title>
+        <AlertDialog.Description>
+          Are you sure you want to delete this data connection? This action
+          cannot be undone. Products using this connection may be affected.
+        </AlertDialog.Description>
+        <Flex gap="3" mt="4" justify="end">
+          <AlertDialog.Cancel>
+            <Button variant="soft" color="gray">
+              Cancel
+            </Button>
+          </AlertDialog.Cancel>
+          <Form action={formAction}>
+            <input
+              type="hidden"
+              name="data_connection_id"
+              value={dataConnectionId}
+            />
+            {/*
+              Not wrapped in AlertDialog.Action: that closes the dialog on click,
+              which would unmount this button mid-submission. We close on success
+              by navigating away instead.
+            */}
+            <Button
+              type="submit"
+              color="red"
+              disabled={pending}
+              loading={pending}
+            >
+              Delete
+            </Button>
+          </Form>
+        </Flex>
+        {state.message && !state.success && (
+          <Text size="1" color="red" mt="2">
+            {state.message}
+          </Text>
+        )}
+      </AlertDialog.Content>
+    </AlertDialog.Root>
+  );
+}

--- a/src/components/features/data-connections/DeleteDataConnectionButton.tsx
+++ b/src/components/features/data-connections/DeleteDataConnectionButton.tsx
@@ -40,7 +40,8 @@ export function DeleteDataConnectionButton({
         <AlertDialog.Title>Delete Data Connection</AlertDialog.Title>
         <AlertDialog.Description>
           Are you sure you want to delete this data connection? This action
-          cannot be undone. Products using this connection may be affected.
+          cannot be undone. You cannot delete a connection while products are
+          using it — remove it from all products first.
         </AlertDialog.Description>
         <Flex gap="3" mt="4" justify="end">
           <AlertDialog.Cancel>

--- a/src/components/features/data-connections/DeleteDataConnectionButton.tsx
+++ b/src/components/features/data-connections/DeleteDataConnectionButton.tsx
@@ -40,9 +40,12 @@ export function DeleteDataConnectionButton({
         <AlertDialog.Title>Delete Data Connection</AlertDialog.Title>
         <AlertDialog.Description>
           Are you sure you want to delete this data connection? This action
-          cannot be undone. You cannot delete a connection while products are
-          using it — remove it from all products first.
+          cannot be undone.
         </AlertDialog.Description>
+        <Text as="p" size="1" color="gray" mt="2">
+          You cannot delete a connection while products are using it — remove it
+          from all products first.
+        </Text>
         <Flex gap="3" mt="4" justify="end">
           <AlertDialog.Cancel>
             <Button variant="soft" color="gray">

--- a/src/components/features/data-connections/DeleteDataConnectionButton.tsx
+++ b/src/components/features/data-connections/DeleteDataConnectionButton.tsx
@@ -8,11 +8,16 @@ import { deleteDataConnection } from "@/lib/actions/data-connections";
 
 interface DeleteDataConnectionButtonProps {
   dataConnectionId: string;
+  // Number of products still mirroring through this connection; deletion is
+  // blocked server-side while > 0, so we disable the confirm to match.
+  productsInUse: number;
 }
 
 export function DeleteDataConnectionButton({
   dataConnectionId,
+  productsInUse,
 }: DeleteDataConnectionButtonProps) {
+  const inUse = productsInUse > 0;
   const router = useRouter();
   const [state, formAction, pending] = useActionState(deleteDataConnection, {
     message: "",
@@ -42,10 +47,12 @@ export function DeleteDataConnectionButton({
           Are you sure you want to delete this data connection? This action
           cannot be undone.
         </AlertDialog.Description>
-        <Text as="p" size="1" color="gray" mt="2">
-          You cannot delete a connection while products are using it — remove it
-          from all products first.
-        </Text>
+        {inUse && (
+          <Text as="p" size="1" color="red" mt="2">
+            You cannot delete a connection while products are using it — remove
+            it from all products first.
+          </Text>
+        )}
         <Flex gap="3" mt="4" justify="end">
           <AlertDialog.Cancel>
             <Button variant="soft" color="gray">
@@ -66,7 +73,7 @@ export function DeleteDataConnectionButton({
             <Button
               type="submit"
               color="red"
-              disabled={pending}
+              disabled={pending || inUse}
               loading={pending}
             >
               Delete

--- a/src/components/features/data-connections/ProductMirrorsManager.tsx
+++ b/src/components/features/data-connections/ProductMirrorsManager.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { useActionState } from "react";
+import { Text, Table, Flex, Badge, Button, Heading, Code } from "@radix-ui/themes";
+import { Link1Icon } from "@radix-ui/react-icons";
+import Form from "next/form";
+import { DataConnection, Product } from "@/types";
+import {
+  addProductMirror,
+  removeProductMirror,
+  setPrimaryMirror,
+} from "@/lib/actions/product-mirrors";
+
+interface ProductMirrorsManagerProps {
+  product: Product;
+  availableConnections: DataConnection[];
+  isAdmin: boolean;
+}
+
+const emptyFormState = {
+  message: "",
+  data: new FormData(),
+  fieldErrors: {},
+  success: false,
+};
+
+export function ProductMirrorsManager({
+  product,
+  availableConnections,
+  isAdmin,
+}: ProductMirrorsManagerProps) {
+  const [addState, addAction, addPending] = useActionState(
+    addProductMirror,
+    emptyFormState
+  );
+  const [removeState, removeAction, removePending] = useActionState(
+    removeProductMirror,
+    emptyFormState
+  );
+  const [primaryState, primaryAction, primaryPending] = useActionState(
+    setPrimaryMirror,
+    emptyFormState
+  );
+
+  const mirrors = Object.entries(product.metadata.mirrors);
+
+  const usedConnectionIds = new Set(
+    mirrors.map(([, mirror]) => mirror.connection_id)
+  );
+  const unusedConnections = availableConnections.filter(
+    (conn) => !usedConnectionIds.has(conn.data_connection_id)
+  );
+
+  return (
+    <Flex direction="column" gap="4">
+      <Heading size="4">Data Connections</Heading>
+
+      {mirrors.length === 0 ? (
+        <Flex
+          direction="column"
+          align="center"
+          gap="2"
+          py="8"
+          style={{ userSelect: "none" }}
+        >
+          <Link1Icon width="48" height="48" color="var(--gray-8)" />
+          <Text size="4" weight="medium" color="gray">
+            No data connections
+          </Text>
+          <Text size="2" color="gray">
+            {isAdmin
+              ? "Add a data connection to this product."
+              : "No data connections have been configured for this product."}
+          </Text>
+        </Flex>
+      ) : (
+        <Table.Root>
+          <Table.Header>
+            <Table.Row>
+              <Table.ColumnHeaderCell>Connection</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Type</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Prefix</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Primary</Table.ColumnHeaderCell>
+              {isAdmin && (
+                <Table.ColumnHeaderCell>Actions</Table.ColumnHeaderCell>
+              )}
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {mirrors.map(([key, mirror]) => (
+              <Table.Row key={key}>
+                <Table.Cell>
+                  <Code size="2">{mirror.connection_id}</Code>
+                </Table.Cell>
+                <Table.Cell>
+                  <Badge
+                    color={mirror.storage_type === "s3" ? "orange" : "blue"}
+                  >
+                    {mirror.storage_type}
+                  </Badge>
+                </Table.Cell>
+                <Table.Cell>
+                  <Code size="2">{mirror.prefix}</Code>
+                </Table.Cell>
+                <Table.Cell>
+                  {mirror.is_primary ? (
+                    <Badge color="green">Primary</Badge>
+                  ) : isAdmin ? (
+                    <Form action={primaryAction} style={{ display: "inline" }}>
+                      <input
+                        type="hidden"
+                        name="account_id"
+                        value={product.account_id}
+                      />
+                      <input
+                        type="hidden"
+                        name="product_id"
+                        value={product.product_id}
+                      />
+                      <input type="hidden" name="mirror_key" value={key} />
+                      <Button
+                        type="submit"
+                        size="1"
+                        variant="soft"
+                        disabled={primaryPending}
+                        loading={primaryPending}
+                      >
+                        Set Primary
+                      </Button>
+                    </Form>
+                  ) : (
+                    <Text size="2" color="gray">
+                      -
+                    </Text>
+                  )}
+                </Table.Cell>
+                {isAdmin && (
+                  <Table.Cell>
+                    <Form action={removeAction} style={{ display: "inline" }}>
+                      <input
+                        type="hidden"
+                        name="account_id"
+                        value={product.account_id}
+                      />
+                      <input
+                        type="hidden"
+                        name="product_id"
+                        value={product.product_id}
+                      />
+                      <input type="hidden" name="mirror_key" value={key} />
+                      <Button
+                        type="submit"
+                        size="1"
+                        variant="soft"
+                        color="red"
+                        disabled={removePending}
+                        loading={removePending}
+                      >
+                        Remove
+                      </Button>
+                    </Form>
+                  </Table.Cell>
+                )}
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table.Root>
+      )}
+
+      {removeState.message && (
+        <Text size="2" color={removeState.success ? "green" : "red"}>
+          {removeState.message}
+        </Text>
+      )}
+      {primaryState.message && (
+        <Text size="2" color={primaryState.success ? "green" : "red"}>
+          {primaryState.message}
+        </Text>
+      )}
+
+      {isAdmin && unusedConnections.length > 0 && (
+        <Flex direction="column" gap="2">
+          <Text size="3" weight="medium">
+            Add Data Connection
+          </Text>
+          <Form action={addAction}>
+            <input
+              type="hidden"
+              name="account_id"
+              value={product.account_id}
+            />
+            <input
+              type="hidden"
+              name="product_id"
+              value={product.product_id}
+            />
+            <Flex gap="2" align="end">
+              <select
+                name="connection_id"
+                required
+                defaultValue=""
+                style={{
+                  fontFamily: "var(--code-font-family)",
+                  padding: "8px 12px",
+                  border: "1px solid var(--gray-6)",
+                  fontSize: "16px",
+                  lineHeight: "1.5",
+                  flex: 1,
+                }}
+              >
+                <option value="" disabled>
+                  Select a data connection...
+                </option>
+                {unusedConnections.map((conn) => (
+                  <option
+                    key={conn.data_connection_id}
+                    value={conn.data_connection_id}
+                  >
+                    {conn.name} ({conn.details.provider} - {conn.details.region})
+                  </option>
+                ))}
+              </select>
+              <Button
+                type="submit"
+                size="2"
+                disabled={addPending}
+                loading={addPending}
+              >
+                Add
+              </Button>
+            </Flex>
+          </Form>
+          {addState.message && (
+            <Text size="2" color={addState.success ? "green" : "red"}>
+              {addState.message}
+            </Text>
+          )}
+        </Flex>
+      )}
+    </Flex>
+  );
+}

--- a/src/components/features/data-connections/ProductMirrorsManager.tsx
+++ b/src/components/features/data-connections/ProductMirrorsManager.tsx
@@ -6,7 +6,7 @@ import { Link1Icon, ExternalLinkIcon } from "@radix-ui/react-icons";
 import Form from "next/form";
 import Link from "next/link";
 import { formFieldStyle } from "@/components/core/DynamicForm";
-import { Product } from "@/types";
+import { Product, ProductMirror } from "@/types";
 import {
   addProductMirror,
   removeProductMirror,
@@ -20,6 +20,19 @@ interface ProductMirrorsManagerProps {
   availableConnections: DataConnectionOption[];
   isAdmin: boolean;
 }
+
+// Distinct color per backend so GCS isn't confused with Azure. minio/ceph are
+// S3-compatible, hence orange like s3. Unknown types fall back to gray.
+const STORAGE_TYPE_COLOR: Record<
+  ProductMirror["storage_type"],
+  "orange" | "blue" | "green"
+> = {
+  s3: "orange",
+  minio: "orange",
+  ceph: "orange",
+  azure: "blue",
+  gcs: "green",
+};
 
 const emptyFormState = {
   message: "",
@@ -112,9 +125,7 @@ export function ProductMirrorsManager({
                   </Flex>
                 </Table.Cell>
                 <Table.Cell>
-                  <Badge
-                    color={mirror.storage_type === "s3" ? "orange" : "blue"}
-                  >
+                  <Badge color={STORAGE_TYPE_COLOR[mirror.storage_type]}>
                     {mirror.storage_type}
                   </Badge>
                 </Table.Cell>

--- a/src/components/features/data-connections/ProductMirrorsManager.tsx
+++ b/src/components/features/data-connections/ProductMirrorsManager.tsx
@@ -4,16 +4,18 @@ import { useActionState } from "react";
 import { Text, Table, Flex, Badge, Button, Heading, Code } from "@radix-ui/themes";
 import { Link1Icon } from "@radix-ui/react-icons";
 import Form from "next/form";
-import { DataConnection, Product } from "@/types";
+import { formFieldStyle } from "@/components/core/DynamicForm";
+import { Product } from "@/types";
 import {
   addProductMirror,
   removeProductMirror,
   setPrimaryMirror,
 } from "@/lib/actions/product-mirrors";
+import type { DataConnectionOption } from "./redact";
 
 interface ProductMirrorsManagerProps {
   product: Product;
-  availableConnections: DataConnection[];
+  availableConnections: DataConnectionOption[];
   isAdmin: boolean;
 }
 
@@ -199,14 +201,7 @@ export function ProductMirrorsManager({
                 name="connection_id"
                 required
                 defaultValue=""
-                style={{
-                  fontFamily: "var(--code-font-family)",
-                  padding: "8px 12px",
-                  border: "1px solid var(--gray-6)",
-                  fontSize: "16px",
-                  lineHeight: "1.5",
-                  flex: 1,
-                }}
+                style={{ ...formFieldStyle, flex: 1 }}
               >
                 <option value="" disabled>
                   Select a data connection...
@@ -216,7 +211,7 @@ export function ProductMirrorsManager({
                     key={conn.data_connection_id}
                     value={conn.data_connection_id}
                   >
-                    {conn.name} ({conn.details.provider} - {conn.details.region})
+                    {conn.name} ({conn.provider} - {conn.region})
                   </option>
                 ))}
               </select>

--- a/src/components/features/data-connections/ProductMirrorsManager.tsx
+++ b/src/components/features/data-connections/ProductMirrorsManager.tsx
@@ -239,7 +239,8 @@ export function ProductMirrorsManager({
                     key={conn.data_connection_id}
                     value={conn.data_connection_id}
                   >
-                    {conn.name} ({conn.provider} - {conn.region})
+                    {conn.name} ({conn.provider}
+                    {conn.region ? ` - ${conn.region}` : ""})
                   </option>
                 ))}
               </select>

--- a/src/components/features/data-connections/ProductMirrorsManager.tsx
+++ b/src/components/features/data-connections/ProductMirrorsManager.tsx
@@ -2,8 +2,9 @@
 
 import { useActionState } from "react";
 import { Text, Table, Flex, Badge, Button, Heading, Code } from "@radix-ui/themes";
-import { Link1Icon } from "@radix-ui/react-icons";
+import { Link1Icon, ExternalLinkIcon } from "@radix-ui/react-icons";
 import Form from "next/form";
+import Link from "next/link";
 import { formFieldStyle } from "@/components/core/DynamicForm";
 import { Product } from "@/types";
 import {
@@ -11,6 +12,7 @@ import {
   removeProductMirror,
   setPrimaryMirror,
 } from "@/lib/actions/product-mirrors";
+import { adminDataConnectionEditUrl } from "@/lib/urls";
 import type { DataConnectionOption } from "./redact";
 
 interface ProductMirrorsManagerProps {
@@ -92,7 +94,22 @@ export function ProductMirrorsManager({
             {mirrors.map(([key, mirror]) => (
               <Table.Row key={key}>
                 <Table.Cell>
-                  <Code size="2">{mirror.connection_id}</Code>
+                  <Flex align="center" gap="2">
+                    <Code size="2">{mirror.connection_id}</Code>
+                    {isAdmin && (
+                      <Link
+                        href={adminDataConnectionEditUrl(mirror.connection_id)}
+                        aria-label={`Manage ${mirror.connection_id} in the admin data connections view`}
+                        title="Manage in admin"
+                        style={{
+                          display: "inline-flex",
+                          color: "var(--accent-11)",
+                        }}
+                      >
+                        <ExternalLinkIcon />
+                      </Link>
+                    )}
+                  </Flex>
                 </Table.Cell>
                 <Table.Cell>
                   <Badge

--- a/src/components/features/data-connections/index.ts
+++ b/src/components/features/data-connections/index.ts
@@ -1,0 +1,3 @@
+export { DataConnectionForm } from "./DataConnectionForm";
+export { DeleteDataConnectionButton } from "./DeleteDataConnectionButton";
+export { ProductMirrorsManager } from "./ProductMirrorsManager";

--- a/src/components/features/data-connections/redact.ts
+++ b/src/components/features/data-connections/redact.ts
@@ -1,0 +1,93 @@
+import {
+  DataConnection,
+  DataConnectionAuthentication,
+  DataConnectionAuthenticationType,
+} from "@/types";
+
+/**
+ * Authentication with the secret fields removed. Server components must never
+ * pass raw `DataConnection.authentication` (which holds access keys / SAS
+ * tokens) into a client component: React serializes every prop into the RSC
+ * payload sent to the browser, regardless of which fields the component renders.
+ * These redacted shapes keep only the non-secret, admin-editable config (role
+ * ARNs, workload-identity IDs) plus the discriminating `type`.
+ */
+export type RedactedAuthentication =
+  | { type: DataConnectionAuthenticationType.S3AccessKey }
+  | { type: DataConnectionAuthenticationType.AzureSasToken }
+  | { type: DataConnectionAuthenticationType.S3ECSTaskRole }
+  | { type: DataConnectionAuthenticationType.S3Local }
+  | { type: DataConnectionAuthenticationType.S3WebIdentityRole; role_arn: string }
+  | {
+      type: DataConnectionAuthenticationType.GcpWorkloadIdentity;
+      workload_identity_provider: string;
+      service_account: string;
+    }
+  | {
+      type: DataConnectionAuthenticationType.AzureWorkloadIdentity;
+      tenant_id: string;
+      client_id: string;
+    };
+
+/** A `DataConnection` safe to hand to a client component (no secrets). */
+export type EditableDataConnection = Omit<DataConnection, "authentication"> & {
+  authentication?: RedactedAuthentication;
+};
+
+function redactAuthentication(
+  auth: DataConnectionAuthentication
+): RedactedAuthentication {
+  switch (auth.type) {
+    case DataConnectionAuthenticationType.S3WebIdentityRole:
+      return { type: auth.type, role_arn: auth.role_arn };
+    case DataConnectionAuthenticationType.GcpWorkloadIdentity:
+      return {
+        type: auth.type,
+        workload_identity_provider: auth.workload_identity_provider,
+        service_account: auth.service_account,
+      };
+    case DataConnectionAuthenticationType.AzureWorkloadIdentity:
+      return {
+        type: auth.type,
+        tenant_id: auth.tenant_id,
+        client_id: auth.client_id,
+      };
+    case DataConnectionAuthenticationType.S3AccessKey:
+    case DataConnectionAuthenticationType.AzureSasToken:
+    case DataConnectionAuthenticationType.S3ECSTaskRole:
+    case DataConnectionAuthenticationType.S3Local:
+      return { type: auth.type };
+  }
+}
+
+/** Strip secrets from a connection before passing it to the edit form. */
+export function toEditableDataConnection(
+  dataConnection: DataConnection
+): EditableDataConnection {
+  const { authentication, ...rest } = dataConnection;
+  return {
+    ...rest,
+    authentication: authentication
+      ? redactAuthentication(authentication)
+      : undefined,
+  };
+}
+
+/** Minimal, secret-free connection shape for the product mirror picker. */
+export interface DataConnectionOption {
+  data_connection_id: string;
+  name: string;
+  provider: string;
+  region: string;
+}
+
+export function toDataConnectionOption(
+  dataConnection: DataConnection
+): DataConnectionOption {
+  return {
+    data_connection_id: dataConnection.data_connection_id,
+    name: dataConnection.name,
+    provider: dataConnection.details.provider,
+    region: dataConnection.details.region,
+  };
+}

--- a/src/components/features/data-connections/redact.ts
+++ b/src/components/features/data-connections/redact.ts
@@ -84,10 +84,12 @@ export interface DataConnectionOption {
 export function toDataConnectionOption(
   dataConnection: DataConnection
 ): DataConnectionOption {
+  const details = dataConnection.details;
   return {
     data_connection_id: dataConnection.data_connection_id,
     name: dataConnection.name,
-    provider: dataConnection.details.provider,
-    region: dataConnection.details.region,
+    provider: details.provider,
+    // GCS connections carry no region.
+    region: "region" in details ? details.region : "",
   };
 }

--- a/src/components/features/settings/SettingsLayout.tsx
+++ b/src/components/features/settings/SettingsLayout.tsx
@@ -42,7 +42,13 @@ export function SettingsLayout({ children, menuItems }: SettingsLayoutProps) {
         >
           <Flex direction="column" gap="1">
             {filteredMenuItems.map((item) => {
-              const isActive = !item.external && pathname === item.href;
+              // Active when on the item's page or any of its sub-routes (e.g.
+              // a tool's create/edit pages). The "/" guard avoids matching
+              // sibling routes that merely share a prefix.
+              const isActive =
+                !item.external &&
+                (pathname === item.href ||
+                  pathname.startsWith(item.href + "/"));
               const baseStyle: CSSProperties = {
                 display: "flex",
                 alignItems: "center",

--- a/src/lib/actions/data-connections.test.ts
+++ b/src/lib/actions/data-connections.test.ts
@@ -3,7 +3,7 @@ import {
   updateDataConnection,
   deleteDataConnection,
 } from "./data-connections";
-import { dataConnectionsTable } from "../clients";
+import { dataConnectionsTable, productsTable } from "../clients";
 import { getPageSession } from "../api/utils";
 import { isAuthorized } from "../api/authz";
 import {
@@ -18,6 +18,9 @@ jest.mock("../clients", () => ({
     create: jest.fn(),
     update: jest.fn(),
     delete: jest.fn(),
+  },
+  productsTable: {
+    listProductsByConnectionId: jest.fn(),
   },
 }));
 
@@ -34,6 +37,7 @@ jest.mock("next/cache", () => ({
 }));
 
 const mockTable = dataConnectionsTable as jest.Mocked<typeof dataConnectionsTable>;
+const mockProductsTable = productsTable as jest.Mocked<typeof productsTable>;
 const mockGetPageSession = getPageSession as jest.MockedFunction<
   typeof getPageSession
 >;
@@ -87,6 +91,7 @@ beforeEach(() => {
   mockTable.fetchById.mockResolvedValue(null);
   mockTable.create.mockImplementation(async (dc) => dc);
   mockTable.update.mockImplementation(async (dc) => dc);
+  mockProductsTable.listProductsByConnectionId.mockResolvedValue([]);
 });
 
 describe("createDataConnection", () => {
@@ -452,6 +457,26 @@ describe("deleteDataConnection", () => {
 
     expect(result.success).toBe(false);
     expect(result.message).toContain("not found");
+    expect(mockTable.delete).not.toHaveBeenCalled();
+  });
+
+  test("blocks deletion while products still reference the connection", async () => {
+    mockTable.fetchById.mockResolvedValue({
+      data_connection_id: "my-connection",
+    } as DataConnection);
+    mockProductsTable.listProductsByConnectionId.mockResolvedValue([
+      { account_id: "acct", product_id: "prod" },
+    ] as Awaited<
+      ReturnType<typeof productsTable.listProductsByConnectionId>
+    >);
+
+    const result = await deleteDataConnection(
+      FORM_STATE,
+      formDataFor({ data_connection_id: "my-connection" })
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("still use this connection");
     expect(mockTable.delete).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/actions/data-connections.test.ts
+++ b/src/lib/actions/data-connections.test.ts
@@ -1,0 +1,394 @@
+import {
+  createDataConnection,
+  updateDataConnection,
+  deleteDataConnection,
+} from "./data-connections";
+import { dataConnectionsTable } from "../clients";
+import { getPageSession } from "../api/utils";
+import { isAuthorized } from "../api/authz";
+import {
+  DataConnection,
+  DataConnectionAuthenticationType,
+  DataProvider,
+} from "@/types";
+
+jest.mock("../clients", () => ({
+  dataConnectionsTable: {
+    fetchById: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+jest.mock("../api/utils", () => ({
+  getPageSession: jest.fn(),
+}));
+
+jest.mock("../api/authz", () => ({
+  isAuthorized: jest.fn(),
+}));
+
+jest.mock("next/cache", () => ({
+  revalidatePath: jest.fn(),
+}));
+
+const mockTable = dataConnectionsTable as jest.Mocked<typeof dataConnectionsTable>;
+const mockGetPageSession = getPageSession as jest.MockedFunction<
+  typeof getPageSession
+>;
+const mockIsAuthorized = isAuthorized as jest.MockedFunction<
+  typeof isAuthorized
+>;
+
+const FORM_STATE = {
+  message: "",
+  data: new FormData(),
+  fieldErrors: {},
+  success: false,
+};
+
+function formDataFor(fields: Record<string, string>): FormData {
+  const fd = new FormData();
+  for (const [key, value] of Object.entries(fields)) {
+    fd.set(key, value);
+  }
+  return fd;
+}
+
+const baseS3Fields = {
+  data_connection_id: "my-connection",
+  name: "My Connection",
+  prefix_template: "{{repository.account_id}}/{{repository.repository_id}}/",
+  provider: DataProvider.S3,
+  bucket: "my-bucket",
+  base_prefix: "",
+  region: "us-east-1",
+  visibility_public: "on",
+};
+
+const baseAzureFields = {
+  data_connection_id: "azure-connection",
+  name: "Azure Connection",
+  provider: DataProvider.Azure,
+  account_name: "myaccount",
+  container_name: "mycontainer",
+  base_prefix: "",
+  region: "westeurope",
+  visibility_public: "on",
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetPageSession.mockResolvedValue({
+    identity_id: "id-1",
+  } as Awaited<ReturnType<typeof getPageSession>>);
+  mockIsAuthorized.mockReturnValue(true);
+  mockTable.fetchById.mockResolvedValue(null);
+  mockTable.create.mockImplementation(async (dc) => dc);
+  mockTable.update.mockImplementation(async (dc) => dc);
+});
+
+describe("createDataConnection", () => {
+  test("rejects an unauthenticated caller before any write", async () => {
+    mockGetPageSession.mockResolvedValue(null);
+
+    const result = await createDataConnection(
+      FORM_STATE,
+      formDataFor({
+        ...baseS3Fields,
+        auth_type: DataConnectionAuthenticationType.S3AccessKey,
+        access_key_id: "AKIA",
+        secret_access_key: "secret",
+      })
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe("Unauthenticated");
+    expect(mockTable.create).not.toHaveBeenCalled();
+  });
+
+  test("rejects an unauthorized caller before any write", async () => {
+    mockIsAuthorized.mockReturnValue(false);
+
+    const result = await createDataConnection(
+      FORM_STATE,
+      formDataFor({
+        ...baseS3Fields,
+        auth_type: DataConnectionAuthenticationType.S3AccessKey,
+        access_key_id: "AKIA",
+        secret_access_key: "secret",
+      })
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("Unauthorized");
+    expect(mockTable.create).not.toHaveBeenCalled();
+  });
+
+  test("creates an S3 access-key connection and redirects to the list", async () => {
+    const result = await createDataConnection(
+      FORM_STATE,
+      formDataFor({
+        ...baseS3Fields,
+        read_only: "on",
+        auth_type: DataConnectionAuthenticationType.S3AccessKey,
+        access_key_id: "AKIA",
+        secret_access_key: "secret",
+      })
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.redirectTo).toBe("/admin/data-connections");
+    expect(mockTable.create).toHaveBeenCalledTimes(1);
+    const created = mockTable.create.mock.calls[0][0];
+    expect(created.read_only).toBe(true);
+    expect(created.allowed_visibilities).toEqual(["public"]);
+    expect(created.details).toMatchObject({
+      provider: DataProvider.S3,
+      bucket: "my-bucket",
+      region: "us-east-1",
+    });
+    expect(created.authentication).toEqual({
+      type: DataConnectionAuthenticationType.S3AccessKey,
+      access_key_id: "AKIA",
+      secret_access_key: "secret",
+    });
+  });
+
+  test("creates an S3 web-identity-role connection with a valid ARN", async () => {
+    const result = await createDataConnection(
+      FORM_STATE,
+      formDataFor({
+        ...baseS3Fields,
+        auth_type: DataConnectionAuthenticationType.S3WebIdentityRole,
+        role_arn: "arn:aws:iam::123456789012:role/my-role",
+      })
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockTable.create.mock.calls[0][0].authentication).toEqual({
+      type: DataConnectionAuthenticationType.S3WebIdentityRole,
+      role_arn: "arn:aws:iam::123456789012:role/my-role",
+    });
+  });
+
+  test("reports a leaf-level field error for an invalid role ARN", async () => {
+    const result = await createDataConnection(
+      FORM_STATE,
+      formDataFor({
+        ...baseS3Fields,
+        auth_type: DataConnectionAuthenticationType.S3WebIdentityRole,
+        role_arn: "not-an-arn",
+      })
+    );
+
+    expect(result.success).toBe(false);
+    // Keyed by leaf name so it renders next to the role_arn input, not under
+    // a nested "authentication" key.
+    expect(result.fieldErrors.role_arn).toBeDefined();
+    expect(mockTable.create).not.toHaveBeenCalled();
+  });
+
+  test("creates an Azure SAS-token connection", async () => {
+    const result = await createDataConnection(
+      FORM_STATE,
+      formDataFor({
+        ...baseAzureFields,
+        auth_type: DataConnectionAuthenticationType.AzureSasToken,
+        sas_token: "sv=2021-token",
+      })
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockTable.create.mock.calls[0][0].authentication).toEqual({
+      type: DataConnectionAuthenticationType.AzureSasToken,
+      sas_token: "sv=2021-token",
+    });
+  });
+
+  test("rejects a SAS-token connection submitted with a blank token", async () => {
+    const result = await createDataConnection(
+      FORM_STATE,
+      formDataFor({
+        ...baseAzureFields,
+        auth_type: DataConnectionAuthenticationType.AzureSasToken,
+        sas_token: "",
+      })
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.fieldErrors.sas_token).toBeDefined();
+    expect(mockTable.create).not.toHaveBeenCalled();
+  });
+
+  test("creates an Azure workload-identity connection with UUIDs", async () => {
+    const result = await createDataConnection(
+      FORM_STATE,
+      formDataFor({
+        ...baseAzureFields,
+        auth_type: DataConnectionAuthenticationType.AzureWorkloadIdentity,
+        tenant_id: "11111111-1111-1111-1111-111111111111",
+        client_id: "22222222-2222-2222-2222-222222222222",
+      })
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockTable.create.mock.calls[0][0].authentication).toMatchObject({
+      type: DataConnectionAuthenticationType.AzureWorkloadIdentity,
+      tenant_id: "11111111-1111-1111-1111-111111111111",
+    });
+  });
+
+  test("rejects an existing connection ID", async () => {
+    mockTable.fetchById.mockResolvedValue({
+      data_connection_id: "my-connection",
+    } as DataConnection);
+
+    const result = await createDataConnection(
+      FORM_STATE,
+      formDataFor({
+        ...baseS3Fields,
+        auth_type: DataConnectionAuthenticationType.S3ECSTaskRole,
+      })
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.fieldErrors.data_connection_id).toBeDefined();
+    expect(mockTable.create).not.toHaveBeenCalled();
+  });
+
+  test("translates a conditional-put race into a duplicate-ID error", async () => {
+    const conditionalFailure = Object.assign(new Error("conditional"), {
+      name: "ConditionalCheckFailedException",
+    });
+    mockTable.create.mockRejectedValue(conditionalFailure);
+
+    const result = await createDataConnection(
+      FORM_STATE,
+      formDataFor({
+        ...baseS3Fields,
+        auth_type: DataConnectionAuthenticationType.S3Local,
+      })
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.fieldErrors.data_connection_id).toBeDefined();
+  });
+});
+
+describe("updateDataConnection", () => {
+  const existingAccessKey: DataConnection = {
+    data_connection_id: "my-connection",
+    name: "Old name",
+    read_only: false,
+    allowed_visibilities: [],
+    details: {
+      provider: DataProvider.S3,
+      bucket: "my-bucket",
+      base_prefix: "",
+      region: "us-east-1",
+    },
+    authentication: {
+      type: DataConnectionAuthenticationType.S3AccessKey,
+      access_key_id: "OLD_KEY",
+      secret_access_key: "OLD_SECRET",
+    },
+  } as DataConnection;
+
+  test("preserves stored secrets when secret fields are left blank", async () => {
+    mockTable.fetchById.mockResolvedValue(existingAccessKey);
+
+    const result = await updateDataConnection(
+      FORM_STATE,
+      formDataFor({
+        ...baseS3Fields,
+        name: "New name",
+        auth_type: DataConnectionAuthenticationType.S3AccessKey,
+        access_key_id: "",
+        secret_access_key: "",
+      })
+    );
+
+    expect(result.success).toBe(true);
+    const updated = mockTable.update.mock.calls[0][0];
+    expect(updated.authentication).toEqual({
+      type: DataConnectionAuthenticationType.S3AccessKey,
+      access_key_id: "OLD_KEY",
+      secret_access_key: "OLD_SECRET",
+    });
+  });
+
+  test("does not reuse an old secret when the auth type changes", async () => {
+    // Existing connection used a web-identity role; switching to access-key with
+    // blank fields must error, not silently resurrect a mismatched secret.
+    mockTable.fetchById.mockResolvedValue({
+      ...existingAccessKey,
+      authentication: {
+        type: DataConnectionAuthenticationType.S3WebIdentityRole,
+        role_arn: "arn:aws:iam::123456789012:role/my-role",
+      },
+    } as DataConnection);
+
+    const result = await updateDataConnection(
+      FORM_STATE,
+      formDataFor({
+        ...baseS3Fields,
+        auth_type: DataConnectionAuthenticationType.S3AccessKey,
+        access_key_id: "",
+        secret_access_key: "",
+      })
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.fieldErrors.access_key_id).toBeDefined();
+    expect(result.fieldErrors.secret_access_key).toBeDefined();
+    expect(mockTable.update).not.toHaveBeenCalled();
+  });
+
+  test("reports not found for a missing connection", async () => {
+    mockTable.fetchById.mockResolvedValue(null);
+
+    const result = await updateDataConnection(
+      FORM_STATE,
+      formDataFor({
+        ...baseS3Fields,
+        auth_type: DataConnectionAuthenticationType.S3Local,
+      })
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("not found");
+    expect(mockTable.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("deleteDataConnection", () => {
+  test("deletes an existing connection and redirects to the list", async () => {
+    mockTable.fetchById.mockResolvedValue({
+      data_connection_id: "my-connection",
+    } as DataConnection);
+
+    const result = await deleteDataConnection(
+      FORM_STATE,
+      formDataFor({ data_connection_id: "my-connection" })
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.redirectTo).toBe("/admin/data-connections");
+    expect(mockTable.delete).toHaveBeenCalledWith("my-connection");
+  });
+
+  test("reports not found without deleting", async () => {
+    mockTable.fetchById.mockResolvedValue(null);
+
+    const result = await deleteDataConnection(
+      FORM_STATE,
+      formDataFor({ data_connection_id: "ghost" })
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("not found");
+    expect(mockTable.delete).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/actions/data-connections.test.ts
+++ b/src/lib/actions/data-connections.test.ts
@@ -240,6 +240,69 @@ describe("createDataConnection", () => {
     });
   });
 
+  test("creates an R2 (S3-compatible) connection with a custom endpoint", async () => {
+    const result = await createDataConnection(
+      FORM_STATE,
+      formDataFor({
+        ...baseS3Fields,
+        region: "auto",
+        endpoint: "https://abc123.r2.cloudflarestorage.com",
+        auth_type: DataConnectionAuthenticationType.S3AccessKey,
+        access_key_id: "AKIA",
+        secret_access_key: "secret",
+      })
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockTable.create.mock.calls[0][0].details).toMatchObject({
+      provider: DataProvider.S3,
+      region: "auto",
+      endpoint: "https://abc123.r2.cloudflarestorage.com",
+    });
+  });
+
+  test("omits endpoint for a plain AWS S3 connection", async () => {
+    await createDataConnection(
+      FORM_STATE,
+      formDataFor({
+        ...baseS3Fields,
+        auth_type: DataConnectionAuthenticationType.S3ECSTaskRole,
+      })
+    );
+
+    expect(
+      "endpoint" in mockTable.create.mock.calls[0][0].details
+    ).toBe(false);
+  });
+
+  test("creates a GCP (GCS) connection with workload-identity auth", async () => {
+    const result = await createDataConnection(
+      FORM_STATE,
+      formDataFor({
+        data_connection_id: "gcs-connection",
+        name: "GCS Connection",
+        provider: DataProvider.GCP,
+        bucket: "my-gcs-bucket",
+        base_prefix: "",
+        visibility_public: "on",
+        auth_type: DataConnectionAuthenticationType.GcpWorkloadIdentity,
+        workload_identity_provider:
+          "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/p/providers/pr",
+        service_account: "sa@my-project.iam.gserviceaccount.com",
+      })
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockTable.create.mock.calls[0][0].details).toMatchObject({
+      provider: DataProvider.GCP,
+      bucket: "my-gcs-bucket",
+    });
+    expect(mockTable.create.mock.calls[0][0].authentication).toMatchObject({
+      type: DataConnectionAuthenticationType.GcpWorkloadIdentity,
+      service_account: "sa@my-project.iam.gserviceaccount.com",
+    });
+  });
+
   test("rejects an existing connection ID", async () => {
     mockTable.fetchById.mockResolvedValue({
       data_connection_id: "my-connection",

--- a/src/lib/actions/data-connections.test.ts
+++ b/src/lib/actions/data-connections.test.ts
@@ -429,6 +429,25 @@ describe("updateDataConnection", () => {
     expect(result.message).toContain("not found");
     expect(mockTable.update).not.toHaveBeenCalled();
   });
+
+  test("translates a concurrent delete into a clear error", async () => {
+    mockTable.fetchById.mockResolvedValue(existingAccessKey);
+    const conditionalFailure = Object.assign(new Error("conditional"), {
+      name: "ConditionalCheckFailedException",
+    });
+    mockTable.update.mockRejectedValueOnce(conditionalFailure);
+
+    const result = await updateDataConnection(
+      FORM_STATE,
+      formDataFor({
+        ...baseS3Fields,
+        auth_type: DataConnectionAuthenticationType.S3Local,
+      })
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("deleted concurrently");
+  });
 });
 
 describe("deleteDataConnection", () => {

--- a/src/lib/actions/data-connections.ts
+++ b/src/lib/actions/data-connections.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { z } from "zod";
 import { LOGGER } from "@/lib/logging";
 import {
   Actions,
@@ -37,7 +38,17 @@ export async function createDataConnection(
     const validated = DataConnectionSchema.safeParse(dataConnection);
     if (!validated.success) {
       return {
-        fieldErrors: validated.error.flatten().fieldErrors,
+        fieldErrors: fieldErrorsFromZod(validated.error),
+        data: formData,
+        message: "Invalid form data",
+        success: false,
+      };
+    }
+
+    const secretErrors = missingSecretErrors(validated.data.authentication);
+    if (Object.keys(secretErrors).length > 0) {
+      return {
+        fieldErrors: secretErrors,
         data: formData,
         message: "Invalid form data",
         success: false,
@@ -69,7 +80,28 @@ export async function createDataConnection(
       };
     }
 
-    await dataConnectionsTable.create(validated.data);
+    try {
+      // create() does a conditional put; this also rejects a concurrent
+      // create that slipped past the existence check above.
+      await dataConnectionsTable.create(validated.data);
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.name === "ConditionalCheckFailedException"
+      ) {
+        return {
+          fieldErrors: {
+            data_connection_id: [
+              "A data connection with this ID already exists",
+            ],
+          },
+          data: formData,
+          message: "Data connection ID already exists",
+          success: false,
+        };
+      }
+      throw error;
+    }
 
     LOGGER.info("Successfully created data connection", {
       operation: "createDataConnection",
@@ -154,7 +186,17 @@ export async function updateDataConnection(
     const validated = DataConnectionSchema.safeParse(dataConnection);
     if (!validated.success) {
       return {
-        fieldErrors: validated.error.flatten().fieldErrors,
+        fieldErrors: fieldErrorsFromZod(validated.error),
+        data: formData,
+        message: "Invalid form data",
+        success: false,
+      };
+    }
+
+    const secretErrors = missingSecretErrors(validated.data.authentication);
+    if (Object.keys(secretErrors).length > 0) {
+      return {
+        fieldErrors: secretErrors,
         data: formData,
         message: "Invalid form data",
         success: false,
@@ -269,6 +311,24 @@ export async function deleteDataConnection(
 }
 
 /**
+ * Maps Zod issues to form-field errors keyed by the field's *leaf* name (e.g.
+ * `role_arn`, `region`), not the top-level object key. `ZodError.flatten()` only
+ * keys top-level fields, so nested `details.*` / `authentication.*` errors would
+ * otherwise never render next to their inputs.
+ */
+function fieldErrorsFromZod(error: z.ZodError): Record<string, string[]> {
+  const fieldErrors: Record<string, string[]> = {};
+  for (const issue of error.issues) {
+    const stringSegments = issue.path.filter(
+      (segment): segment is string => typeof segment === "string"
+    );
+    const key = stringSegments[stringSegments.length - 1] ?? "form";
+    (fieldErrors[key] ??= []).push(issue.message);
+  }
+  return fieldErrors;
+}
+
+/**
  * Maps the data connection form fields to a `DataConnection`-shaped object for
  * validation. `existing` (edit only) supplies the stored secret values when the
  * corresponding form field is left blank, so editing non-secret fields does not
@@ -355,14 +415,8 @@ function buildAuthenticationFromForm(
         type: DataConnectionAuthenticationType.S3WebIdentityRole,
         role_arn: formData.get("role_arn") as string,
       };
-    case DataConnectionAuthenticationType.GcpWorkloadIdentity:
-      return {
-        type: DataConnectionAuthenticationType.GcpWorkloadIdentity,
-        workload_identity_provider: formData.get(
-          "workload_identity_provider"
-        ) as string,
-        service_account: formData.get("service_account") as string,
-      };
+    // GcpWorkloadIdentity is intentionally omitted: there is no GCP `details`
+    // schema, so the form never offers it and it can't form a valid connection.
     case DataConnectionAuthenticationType.AzureWorkloadIdentity:
       return {
         type: DataConnectionAuthenticationType.AzureWorkloadIdentity,
@@ -387,4 +441,34 @@ function buildAuthenticationFromForm(
     default:
       return undefined;
   }
+}
+
+/**
+ * The auth schemas accept empty secret strings, and the form leaves secret
+ * fields blank on edit (to keep the stored value). This guards the remaining
+ * gap: selecting a secret-based auth type but providing no secret — on create,
+ * or when switching auth type on edit (where there is no stored value to reuse).
+ */
+function missingSecretErrors(
+  authentication: DataConnection["authentication"]
+): Record<string, string[]> {
+  const errors: Record<string, string[]> = {};
+  if (!authentication) return errors;
+
+  if (authentication.type === DataConnectionAuthenticationType.S3AccessKey) {
+    if (!authentication.access_key_id) {
+      errors.access_key_id = ["Access Key ID is required"];
+    }
+    if (!authentication.secret_access_key) {
+      errors.secret_access_key = ["Secret Access Key is required"];
+    }
+  } else if (
+    authentication.type === DataConnectionAuthenticationType.AzureSasToken
+  ) {
+    if (!authentication.sas_token) {
+      errors.sas_token = ["SAS Token is required"];
+    }
+  }
+
+  return errors;
 }

--- a/src/lib/actions/data-connections.ts
+++ b/src/lib/actions/data-connections.ts
@@ -45,16 +45,6 @@ export async function createDataConnection(
       };
     }
 
-    const secretErrors = missingSecretErrors(validated.data.authentication);
-    if (Object.keys(secretErrors).length > 0) {
-      return {
-        fieldErrors: secretErrors,
-        data: formData,
-        message: "Invalid form data",
-        success: false,
-      };
-    }
-
     if (!isAuthorized(session, validated.data, Actions.CreateDataConnection)) {
       return {
         fieldErrors: {},
@@ -187,16 +177,6 @@ export async function updateDataConnection(
     if (!validated.success) {
       return {
         fieldErrors: fieldErrorsFromZod(validated.error),
-        data: formData,
-        message: "Invalid form data",
-        success: false,
-      };
-    }
-
-    const secretErrors = missingSecretErrors(validated.data.authentication);
-    if (Object.keys(secretErrors).length > 0) {
-      return {
-        fieldErrors: secretErrors,
         data: formData,
         message: "Invalid form data",
         success: false,
@@ -493,34 +473,4 @@ function buildAuthenticationFromForm(
     default:
       return undefined;
   }
-}
-
-/**
- * The auth schemas accept empty secret strings, and the form leaves secret
- * fields blank on edit (to keep the stored value). This guards the remaining
- * gap: selecting a secret-based auth type but providing no secret — on create,
- * or when switching auth type on edit (where there is no stored value to reuse).
- */
-function missingSecretErrors(
-  authentication: DataConnection["authentication"]
-): Record<string, string[]> {
-  const errors: Record<string, string[]> = {};
-  if (!authentication) return errors;
-
-  if (authentication.type === DataConnectionAuthenticationType.S3AccessKey) {
-    if (!authentication.access_key_id) {
-      errors.access_key_id = ["Access Key ID is required"];
-    }
-    if (!authentication.secret_access_key) {
-      errors.secret_access_key = ["Secret Access Key is required"];
-    }
-  } else if (
-    authentication.type === DataConnectionAuthenticationType.AzureSasToken
-  ) {
-    if (!authentication.sas_token) {
-      errors.sas_token = ["SAS Token is required"];
-    }
-  }
-
-  return errors;
 }

--- a/src/lib/actions/data-connections.ts
+++ b/src/lib/actions/data-connections.ts
@@ -1,0 +1,390 @@
+"use server";
+
+import { LOGGER } from "@/lib/logging";
+import {
+  Actions,
+  DataConnectionSchema,
+  DataConnection,
+  DataProvider,
+  DataConnectionAuthenticationType,
+  ProductVisibility,
+} from "@/types";
+import { isAuthorized } from "../api/authz";
+import { getPageSession } from "../api/utils";
+import { dataConnectionsTable } from "../clients";
+import { FormState } from "@/components/core/DynamicForm";
+import { revalidatePath } from "next/cache";
+import { adminDataConnectionsUrl, adminDataConnectionEditUrl } from "@/lib/urls";
+
+export async function createDataConnection(
+  _prevState: FormState<DataConnection>,
+  formData: FormData
+): Promise<FormState<DataConnection>> {
+  const session = await getPageSession();
+
+  if (!session?.identity_id) {
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Unauthenticated",
+      success: false,
+    };
+  }
+
+  try {
+    const dataConnection = buildDataConnectionFromForm(formData);
+
+    const validated = DataConnectionSchema.safeParse(dataConnection);
+    if (!validated.success) {
+      return {
+        fieldErrors: validated.error.flatten().fieldErrors,
+        data: formData,
+        message: "Invalid form data",
+        success: false,
+      };
+    }
+
+    if (!isAuthorized(session, validated.data, Actions.CreateDataConnection)) {
+      return {
+        fieldErrors: {},
+        data: formData,
+        message: "Unauthorized to create data connections",
+        success: false,
+      };
+    }
+
+    const existing = await dataConnectionsTable.fetchById(
+      validated.data.data_connection_id
+    );
+    if (existing) {
+      return {
+        fieldErrors: {
+          data_connection_id: [
+            "A data connection with this ID already exists",
+          ],
+        },
+        data: formData,
+        message: "Data connection ID already exists",
+        success: false,
+      };
+    }
+
+    await dataConnectionsTable.create(validated.data);
+
+    LOGGER.info("Successfully created data connection", {
+      operation: "createDataConnection",
+      metadata: { data_connection_id: validated.data.data_connection_id },
+    });
+
+    revalidatePath(adminDataConnectionsUrl());
+
+    // Navigate client-side (see FormState.redirectTo) so the shared admin layout
+    // is refetched with the current session, rather than a server redirect()
+    // that leaves the client Router Cache stale.
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Data connection created successfully!",
+      success: true,
+      redirectTo: adminDataConnectionsUrl(),
+    };
+  } catch (error) {
+    LOGGER.error("Error creating data connection", {
+      operation: "createDataConnection",
+      error,
+    });
+
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Failed to create data connection. Please try again.",
+      success: false,
+    };
+  }
+}
+
+export async function updateDataConnection(
+  _prevState: FormState<DataConnection>,
+  formData: FormData
+): Promise<FormState<DataConnection>> {
+  const session = await getPageSession();
+
+  if (!session?.identity_id) {
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Unauthenticated",
+      success: false,
+    };
+  }
+
+  const dataConnectionId = formData.get("data_connection_id") as string;
+  if (!dataConnectionId) {
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Data connection ID is required",
+      success: false,
+    };
+  }
+
+  try {
+    const existing = await dataConnectionsTable.fetchById(dataConnectionId);
+    if (!existing) {
+      return {
+        fieldErrors: {},
+        data: formData,
+        message: "Data connection not found",
+        success: false,
+      };
+    }
+
+    if (!isAuthorized(session, existing, Actions.PutDataConnection)) {
+      return {
+        fieldErrors: {},
+        data: formData,
+        message: "Unauthorized to update data connections",
+        success: false,
+      };
+    }
+
+    // `existing` lets blank secret fields fall back to the stored credentials,
+    // so an admin can edit other fields without re-entering secrets.
+    const dataConnection = buildDataConnectionFromForm(formData, existing);
+    const validated = DataConnectionSchema.safeParse(dataConnection);
+    if (!validated.success) {
+      return {
+        fieldErrors: validated.error.flatten().fieldErrors,
+        data: formData,
+        message: "Invalid form data",
+        success: false,
+      };
+    }
+
+    await dataConnectionsTable.update(validated.data);
+
+    LOGGER.info("Successfully updated data connection", {
+      operation: "updateDataConnection",
+      metadata: { data_connection_id: dataConnectionId },
+    });
+
+    revalidatePath(adminDataConnectionsUrl());
+    revalidatePath(adminDataConnectionEditUrl(dataConnectionId));
+
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Data connection updated successfully!",
+      success: true,
+    };
+  } catch (error) {
+    LOGGER.error("Error updating data connection", {
+      operation: "updateDataConnection",
+      error,
+    });
+
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Failed to update data connection. Please try again.",
+      success: false,
+    };
+  }
+}
+
+export async function deleteDataConnection(
+  _prevState: FormState<unknown>,
+  formData: FormData
+): Promise<FormState<unknown>> {
+  const session = await getPageSession();
+
+  if (!session?.identity_id) {
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Unauthenticated",
+      success: false,
+    };
+  }
+
+  const dataConnectionId = formData.get("data_connection_id") as string;
+  if (!dataConnectionId) {
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Data connection ID is required",
+      success: false,
+    };
+  }
+
+  try {
+    const existing = await dataConnectionsTable.fetchById(dataConnectionId);
+    if (!existing) {
+      return {
+        fieldErrors: {},
+        data: formData,
+        message: "Data connection not found",
+        success: false,
+      };
+    }
+
+    if (!isAuthorized(session, existing, Actions.DeleteDataConnection)) {
+      return {
+        fieldErrors: {},
+        data: formData,
+        message: "Unauthorized to delete data connections",
+        success: false,
+      };
+    }
+
+    await dataConnectionsTable.delete(dataConnectionId);
+
+    LOGGER.info("Successfully deleted data connection", {
+      operation: "deleteDataConnection",
+      metadata: { data_connection_id: dataConnectionId },
+    });
+
+    revalidatePath(adminDataConnectionsUrl());
+
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Data connection deleted successfully!",
+      success: true,
+      redirectTo: adminDataConnectionsUrl(),
+    };
+  } catch (error) {
+    LOGGER.error("Error deleting data connection", {
+      operation: "deleteDataConnection",
+      error,
+    });
+
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Failed to delete data connection. Please try again.",
+      success: false,
+    };
+  }
+}
+
+/**
+ * Maps the data connection form fields to a `DataConnection`-shaped object for
+ * validation. `existing` (edit only) supplies the stored secret values when the
+ * corresponding form field is left blank, so editing non-secret fields does not
+ * wipe credentials the form deliberately never renders.
+ */
+function buildDataConnectionFromForm(
+  formData: FormData,
+  existing?: DataConnection
+): Record<string, unknown> {
+  const provider = formData.get("provider") as string;
+  const authType = formData.get("auth_type") as string;
+
+  const allowedVisibilities = Object.values(ProductVisibility).filter(
+    (visibility) => formData.get(`visibility_${visibility}`) === "on"
+  );
+
+  let details: Record<string, unknown>;
+  if (provider === DataProvider.S3) {
+    details = {
+      provider: DataProvider.S3,
+      bucket: formData.get("bucket") as string,
+      base_prefix: (formData.get("base_prefix") as string) || "",
+      region: formData.get("region") as string,
+    };
+  } else {
+    details = {
+      provider: DataProvider.Azure,
+      account_name: formData.get("account_name") as string,
+      container_name: formData.get("container_name") as string,
+      base_prefix: (formData.get("base_prefix") as string) || "",
+      region: formData.get("region") as string,
+    };
+  }
+
+  const authentication = buildAuthenticationFromForm(
+    authType,
+    formData,
+    existing
+  );
+
+  const requiredFlag = formData.get("required_flag") as string;
+
+  return {
+    data_connection_id: formData.get("data_connection_id") as string,
+    name: formData.get("name") as string,
+    prefix_template: (formData.get("prefix_template") as string) || undefined,
+    read_only: formData.get("read_only") === "on",
+    allowed_visibilities: allowedVisibilities,
+    required_flag: requiredFlag || undefined,
+    details,
+    authentication,
+  };
+}
+
+function buildAuthenticationFromForm(
+  authType: string,
+  formData: FormData,
+  existing?: DataConnection
+): Record<string, unknown> | undefined {
+  // Reuse a stored secret only when the connection still uses the same auth type.
+  const previous =
+    existing?.authentication?.type === authType
+      ? existing.authentication
+      : undefined;
+
+  switch (authType) {
+    case DataConnectionAuthenticationType.S3AccessKey: {
+      const prev =
+        previous?.type === DataConnectionAuthenticationType.S3AccessKey
+          ? previous
+          : undefined;
+      return {
+        type: DataConnectionAuthenticationType.S3AccessKey,
+        access_key_id:
+          (formData.get("access_key_id") as string) || prev?.access_key_id || "",
+        secret_access_key:
+          (formData.get("secret_access_key") as string) ||
+          prev?.secret_access_key ||
+          "",
+      };
+    }
+    case DataConnectionAuthenticationType.S3WebIdentityRole:
+      return {
+        type: DataConnectionAuthenticationType.S3WebIdentityRole,
+        role_arn: formData.get("role_arn") as string,
+      };
+    case DataConnectionAuthenticationType.GcpWorkloadIdentity:
+      return {
+        type: DataConnectionAuthenticationType.GcpWorkloadIdentity,
+        workload_identity_provider: formData.get(
+          "workload_identity_provider"
+        ) as string,
+        service_account: formData.get("service_account") as string,
+      };
+    case DataConnectionAuthenticationType.AzureWorkloadIdentity:
+      return {
+        type: DataConnectionAuthenticationType.AzureWorkloadIdentity,
+        tenant_id: formData.get("tenant_id") as string,
+        client_id: formData.get("client_id") as string,
+      };
+    case DataConnectionAuthenticationType.AzureSasToken: {
+      const prev =
+        previous?.type === DataConnectionAuthenticationType.AzureSasToken
+          ? previous
+          : undefined;
+      return {
+        type: DataConnectionAuthenticationType.AzureSasToken,
+        sas_token:
+          (formData.get("sas_token") as string) || prev?.sas_token || "",
+      };
+    }
+    case DataConnectionAuthenticationType.S3ECSTaskRole:
+      return { type: DataConnectionAuthenticationType.S3ECSTaskRole };
+    case DataConnectionAuthenticationType.S3Local:
+      return { type: DataConnectionAuthenticationType.S3Local };
+    default:
+      return undefined;
+  }
+}

--- a/src/lib/actions/data-connections.ts
+++ b/src/lib/actions/data-connections.ts
@@ -203,7 +203,24 @@ export async function updateDataConnection(
       };
     }
 
-    await dataConnectionsTable.update(validated.data);
+    try {
+      // update() requires the row to still exist; a concurrent delete between
+      // the fetchById above and here would otherwise resurrect a partial ghost.
+      await dataConnectionsTable.update(validated.data);
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.name === "ConditionalCheckFailedException"
+      ) {
+        return {
+          fieldErrors: {},
+          data: formData,
+          message: "Data connection was deleted concurrently",
+          success: false,
+        };
+      }
+      throw error;
+    }
 
     LOGGER.info("Successfully updated data connection", {
       operation: "updateDataConnection",

--- a/src/lib/actions/data-connections.ts
+++ b/src/lib/actions/data-connections.ts
@@ -12,7 +12,7 @@ import {
 } from "@/types";
 import { isAuthorized } from "../api/authz";
 import { getPageSession } from "../api/utils";
-import { dataConnectionsTable } from "../clients";
+import { dataConnectionsTable, productsTable } from "../clients";
 import { FormState } from "@/components/core/DynamicForm";
 import { revalidatePath } from "next/cache";
 import { adminDataConnectionsUrl, adminDataConnectionEditUrl } from "@/lib/urls";
@@ -279,6 +279,20 @@ export async function deleteDataConnection(
       };
     }
 
+    // Refuse to delete a connection still referenced by product mirrors —
+    // deleting would leave those products with a dangling connection_id. The
+    // admin must detach it from each product first.
+    const dependents =
+      await productsTable.listProductsByConnectionId(dataConnectionId);
+    if (dependents.length > 0) {
+      return {
+        fieldErrors: {},
+        data: formData,
+        message: `Cannot delete: ${dependents.length} product(s) still use this connection. Remove it from them first.`,
+        success: false,
+      };
+    }
+
     await dataConnectionsTable.delete(dataConnectionId);
 
     LOGGER.info("Successfully deleted data connection", {
@@ -312,9 +326,14 @@ export async function deleteDataConnection(
 
 /**
  * Maps Zod issues to form-field errors keyed by the field's *leaf* name (e.g.
- * `role_arn`, `region`), not the top-level object key. `ZodError.flatten()` only
- * keys top-level fields, so nested `details.*` / `authentication.*` errors would
- * otherwise never render next to their inputs.
+ * `role_arn`, `region`), not the top-level object key — `ZodError.flatten()`
+ * only keys top-level fields, so nested `details.*` / `authentication.*` errors
+ * would otherwise never render next to their inputs.
+ *
+ * Keying by leaf (rather than the full dotted path) is deliberate: the form is a
+ * flat namespace where every `<input name>` is a unique leaf, so leaf keys map
+ * 1:1 to inputs and cannot collide. A dotted path (`details.region`) would be
+ * more "unique" but would no longer match the form's leaf-based lookups.
  */
 function fieldErrorsFromZod(error: z.ZodError): Record<string, string[]> {
   const fieldErrors: Record<string, string[]> = {};
@@ -323,7 +342,8 @@ function fieldErrorsFromZod(error: z.ZodError): Record<string, string[]> {
       (segment): segment is string => typeof segment === "string"
     );
     const key = stringSegments[stringSegments.length - 1] ?? "form";
-    (fieldErrors[key] ??= []).push(issue.message);
+    const messages = (fieldErrors[key] ??= []);
+    if (!messages.includes(issue.message)) messages.push(issue.message);
   }
   return fieldErrors;
 }

--- a/src/lib/actions/data-connections.ts
+++ b/src/lib/actions/data-connections.ts
@@ -347,11 +347,20 @@ function buildDataConnectionFromForm(
 
   let details: Record<string, unknown>;
   if (provider === DataProvider.S3) {
+    const endpoint = (formData.get("endpoint") as string) || undefined;
     details = {
       provider: DataProvider.S3,
       bucket: formData.get("bucket") as string,
       base_prefix: (formData.get("base_prefix") as string) || "",
       region: formData.get("region") as string,
+      // Omit when blank so AWS S3 connections have no endpoint field.
+      ...(endpoint ? { endpoint } : {}),
+    };
+  } else if (provider === DataProvider.GCP) {
+    details = {
+      provider: DataProvider.GCP,
+      bucket: formData.get("bucket") as string,
+      base_prefix: (formData.get("base_prefix") as string) || "",
     };
   } else {
     details = {
@@ -415,8 +424,14 @@ function buildAuthenticationFromForm(
         type: DataConnectionAuthenticationType.S3WebIdentityRole,
         role_arn: formData.get("role_arn") as string,
       };
-    // GcpWorkloadIdentity is intentionally omitted: there is no GCP `details`
-    // schema, so the form never offers it and it can't form a valid connection.
+    case DataConnectionAuthenticationType.GcpWorkloadIdentity:
+      return {
+        type: DataConnectionAuthenticationType.GcpWorkloadIdentity,
+        workload_identity_provider: formData.get(
+          "workload_identity_provider"
+        ) as string,
+        service_account: formData.get("service_account") as string,
+      };
     case DataConnectionAuthenticationType.AzureWorkloadIdentity:
       return {
         type: DataConnectionAuthenticationType.AzureWorkloadIdentity,

--- a/src/lib/actions/index.ts
+++ b/src/lib/actions/index.ts
@@ -1,5 +1,7 @@
 export * from "./account";
 export * from "./admin";
 export * from "./credentials";
+export * from "./data-connections";
 export * from "./memberships";
+export * from "./product-mirrors";
 export * from "./products";

--- a/src/lib/actions/product-mirrors.test.ts
+++ b/src/lib/actions/product-mirrors.test.ts
@@ -131,6 +131,27 @@ describe("addProductMirror", () => {
     });
   });
 
+  test("maps a GCP connection to the gcs storage type", async () => {
+    mockProductsTable.fetchById.mockResolvedValue(productWith({}, ""));
+    mockDataConnectionsTable.fetchById.mockResolvedValue({
+      data_connection_id: "conn-a",
+      prefix_template: "{{repository.account_id}}/{{repository.repository_id}}/",
+      details: { provider: "gcp" },
+    } as DataConnection);
+
+    await addProductMirror(
+      FORM_STATE,
+      formDataFor({
+        account_id: "acct",
+        product_id: "prod",
+        connection_id: "conn-a",
+      })
+    );
+
+    const updated = mockProductsTable.update.mock.calls[0][0];
+    expect(updated.metadata.mirrors["conn-a"].storage_type).toBe("gcs");
+  });
+
   test("a second mirror does not become primary", async () => {
     mockProductsTable.fetchById.mockResolvedValue(
       productWith(

--- a/src/lib/actions/product-mirrors.test.ts
+++ b/src/lib/actions/product-mirrors.test.ts
@@ -1,0 +1,280 @@
+import {
+  addProductMirror,
+  removeProductMirror,
+  setPrimaryMirror,
+} from "./product-mirrors";
+import { productsTable, dataConnectionsTable } from "../clients";
+import { getPageSession } from "../api/utils";
+import { isAdmin } from "../api/authz";
+import { DataConnection, Product, ProductMirror } from "@/types";
+
+jest.mock("../clients", () => ({
+  productsTable: {
+    fetchById: jest.fn(),
+    update: jest.fn(),
+  },
+  dataConnectionsTable: {
+    fetchById: jest.fn(),
+  },
+}));
+
+jest.mock("../api/utils", () => ({
+  getPageSession: jest.fn(),
+}));
+
+jest.mock("../api/authz", () => ({
+  isAdmin: jest.fn(),
+}));
+
+jest.mock("next/cache", () => ({
+  revalidatePath: jest.fn(),
+}));
+
+const mockProductsTable = productsTable as jest.Mocked<typeof productsTable>;
+const mockDataConnectionsTable = dataConnectionsTable as jest.Mocked<
+  typeof dataConnectionsTable
+>;
+const mockGetPageSession = getPageSession as jest.MockedFunction<
+  typeof getPageSession
+>;
+const mockIsAdmin = isAdmin as jest.MockedFunction<typeof isAdmin>;
+
+const FORM_STATE = {
+  message: "",
+  data: new FormData(),
+  fieldErrors: {},
+  success: false,
+};
+
+function formDataFor(fields: Record<string, string>): FormData {
+  const fd = new FormData();
+  for (const [key, value] of Object.entries(fields)) {
+    fd.set(key, value);
+  }
+  return fd;
+}
+
+function mirror(overrides: Partial<ProductMirror>): ProductMirror {
+  return {
+    storage_type: "s3",
+    connection_id: "conn",
+    prefix: "acct/prod/",
+    is_primary: false,
+    ...overrides,
+  };
+}
+
+function productWith(
+  mirrors: Record<string, ProductMirror>,
+  primary_mirror: string
+): Product {
+  return {
+    account_id: "acct",
+    product_id: "prod",
+    metadata: { mirrors, primary_mirror },
+  } as Product;
+}
+
+const s3Connection = {
+  data_connection_id: "conn-a",
+  prefix_template: "{{repository.account_id}}/{{repository.repository_id}}/",
+  details: { provider: "s3" },
+} as DataConnection;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetPageSession.mockResolvedValue({
+    identity_id: "id-1",
+  } as Awaited<ReturnType<typeof getPageSession>>);
+  mockIsAdmin.mockReturnValue(true);
+  mockProductsTable.update.mockImplementation(async (p) => p);
+  mockDataConnectionsTable.fetchById.mockResolvedValue(s3Connection);
+});
+
+describe("addProductMirror", () => {
+  test("rejects non-admins before any write", async () => {
+    mockIsAdmin.mockReturnValue(false);
+
+    const result = await addProductMirror(
+      FORM_STATE,
+      formDataFor({
+        account_id: "acct",
+        product_id: "prod",
+        connection_id: "conn-a",
+      })
+    );
+
+    expect(result.success).toBe(false);
+    expect(mockProductsTable.update).not.toHaveBeenCalled();
+  });
+
+  test("the first mirror becomes primary", async () => {
+    mockProductsTable.fetchById.mockResolvedValue(productWith({}, ""));
+
+    const result = await addProductMirror(
+      FORM_STATE,
+      formDataFor({
+        account_id: "acct",
+        product_id: "prod",
+        connection_id: "conn-a",
+      })
+    );
+
+    expect(result.success).toBe(true);
+    const updated = mockProductsTable.update.mock.calls[0][0];
+    expect(updated.metadata.primary_mirror).toBe("conn-a");
+    expect(updated.metadata.mirrors["conn-a"]).toMatchObject({
+      storage_type: "s3",
+      connection_id: "conn-a",
+      prefix: "acct/prod/",
+      is_primary: true,
+    });
+  });
+
+  test("a second mirror does not become primary", async () => {
+    mockProductsTable.fetchById.mockResolvedValue(
+      productWith(
+        { "conn-x": mirror({ connection_id: "conn-x", is_primary: true }) },
+        "conn-x"
+      )
+    );
+
+    await addProductMirror(
+      FORM_STATE,
+      formDataFor({
+        account_id: "acct",
+        product_id: "prod",
+        connection_id: "conn-a",
+      })
+    );
+
+    const updated = mockProductsTable.update.mock.calls[0][0];
+    expect(updated.metadata.primary_mirror).toBe("conn-x");
+    expect(updated.metadata.mirrors["conn-a"].is_primary).toBe(false);
+  });
+
+  test("rejects a duplicate connection", async () => {
+    mockProductsTable.fetchById.mockResolvedValue(
+      productWith({ "conn-a": mirror({ connection_id: "conn-a" }) }, "conn-a")
+    );
+
+    const result = await addProductMirror(
+      FORM_STATE,
+      formDataFor({
+        account_id: "acct",
+        product_id: "prod",
+        connection_id: "conn-a",
+      })
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("already associated");
+    expect(mockProductsTable.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("removeProductMirror", () => {
+  test("removing the primary promotes a remaining mirror", async () => {
+    mockProductsTable.fetchById.mockResolvedValue(
+      productWith(
+        {
+          "conn-a": mirror({ connection_id: "conn-a", is_primary: true }),
+          "conn-b": mirror({ connection_id: "conn-b", is_primary: false }),
+        },
+        "conn-a"
+      )
+    );
+
+    const result = await removeProductMirror(
+      FORM_STATE,
+      formDataFor({
+        account_id: "acct",
+        product_id: "prod",
+        mirror_key: "conn-a",
+      })
+    );
+
+    expect(result.success).toBe(true);
+    const updated = mockProductsTable.update.mock.calls[0][0];
+    expect(updated.metadata.mirrors["conn-a"]).toBeUndefined();
+    expect(updated.metadata.primary_mirror).toBe("conn-b");
+    expect(updated.metadata.mirrors["conn-b"].is_primary).toBe(true);
+  });
+
+  test("removing the last mirror clears the primary", async () => {
+    mockProductsTable.fetchById.mockResolvedValue(
+      productWith(
+        { "conn-a": mirror({ connection_id: "conn-a", is_primary: true }) },
+        "conn-a"
+      )
+    );
+
+    const result = await removeProductMirror(
+      FORM_STATE,
+      formDataFor({
+        account_id: "acct",
+        product_id: "prod",
+        mirror_key: "conn-a",
+      })
+    );
+
+    expect(result.success).toBe(true);
+    const updated = mockProductsTable.update.mock.calls[0][0];
+    expect(updated.metadata.mirrors).toEqual({});
+    expect(updated.metadata.primary_mirror).toBe("");
+  });
+
+  test("removing a non-primary leaves the primary untouched", async () => {
+    mockProductsTable.fetchById.mockResolvedValue(
+      productWith(
+        {
+          "conn-a": mirror({ connection_id: "conn-a", is_primary: true }),
+          "conn-b": mirror({ connection_id: "conn-b", is_primary: false }),
+        },
+        "conn-a"
+      )
+    );
+
+    await removeProductMirror(
+      FORM_STATE,
+      formDataFor({
+        account_id: "acct",
+        product_id: "prod",
+        mirror_key: "conn-b",
+      })
+    );
+
+    const updated = mockProductsTable.update.mock.calls[0][0];
+    expect(updated.metadata.primary_mirror).toBe("conn-a");
+    expect(updated.metadata.mirrors["conn-a"].is_primary).toBe(true);
+  });
+});
+
+describe("setPrimaryMirror", () => {
+  test("flips is_primary across all mirrors", async () => {
+    mockProductsTable.fetchById.mockResolvedValue(
+      productWith(
+        {
+          "conn-a": mirror({ connection_id: "conn-a", is_primary: true }),
+          "conn-b": mirror({ connection_id: "conn-b", is_primary: false }),
+        },
+        "conn-a"
+      )
+    );
+
+    const result = await setPrimaryMirror(
+      FORM_STATE,
+      formDataFor({
+        account_id: "acct",
+        product_id: "prod",
+        mirror_key: "conn-b",
+      })
+    );
+
+    expect(result.success).toBe(true);
+    const updated = mockProductsTable.update.mock.calls[0][0];
+    expect(updated.metadata.primary_mirror).toBe("conn-b");
+    expect(updated.metadata.mirrors["conn-a"].is_primary).toBe(false);
+    expect(updated.metadata.mirrors["conn-b"].is_primary).toBe(true);
+  });
+});

--- a/src/lib/actions/product-mirrors.test.ts
+++ b/src/lib/actions/product-mirrors.test.ts
@@ -131,6 +131,31 @@ describe("addProductMirror", () => {
     });
   });
 
+  test("passes the read updated_at as an optimistic lock and reports conflicts", async () => {
+    mockProductsTable.fetchById.mockResolvedValue({
+      ...productWith({}, ""),
+      updated_at: "2026-01-01T00:00:00.000Z",
+    });
+    const conflict = new Error("stale write");
+    conflict.name = "ConditionalCheckFailedException";
+    mockProductsTable.update.mockRejectedValueOnce(conflict);
+
+    const result = await addProductMirror(
+      FORM_STATE,
+      formDataFor({
+        account_id: "acct",
+        product_id: "prod",
+        connection_id: "conn-a",
+      })
+    );
+
+    expect(mockProductsTable.update.mock.calls[0][1]).toEqual({
+      expectedUpdatedAt: "2026-01-01T00:00:00.000Z",
+    });
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/modified by someone else/i);
+  });
+
   test("maps a GCP connection to the gcs storage type", async () => {
     mockProductsTable.fetchById.mockResolvedValue(productWith({}, ""));
     mockDataConnectionsTable.fetchById.mockResolvedValue({

--- a/src/lib/actions/product-mirrors.ts
+++ b/src/lib/actions/product-mirrors.ts
@@ -9,11 +9,19 @@ import { FormState } from "@/components/core/DynamicForm";
 import { revalidatePath } from "next/cache";
 import { editProductDataConnectionsUrl } from "@/lib/urls";
 
-// ponytail: these three actions fetch → mutate → productsTable.update() with no
-// optimistic lock, so two admins editing the same product's mirrors at once can
-// silently lose one update (last write wins). Admin-only and low-frequency, so
-// the race is left open. Upgrade path: thread a ConditionExpression on
-// updated_at through productsTable.update() for a compare-and-swap.
+// These three actions fetch → mutate → productsTable.update(). The update is an
+// optimistic compare-and-swap on the product's updated_at, so two admins editing
+// the same product's mirrors concurrently can't silently clobber each other —
+// the second write fails and the action reports a conflict instead.
+const CONCURRENT_EDIT_MESSAGE =
+  "This product was modified by someone else. Please reload and try again.";
+
+function isConcurrentEdit(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.name === "ConditionalCheckFailedException"
+  );
+}
 
 export async function addProductMirror(
   _prevState: FormState<unknown>,
@@ -115,7 +123,9 @@ export async function addProductMirror(
       },
     };
 
-    await productsTable.update(updatedProduct);
+    await productsTable.update(updatedProduct, {
+      expectedUpdatedAt: product.updated_at,
+    });
 
     LOGGER.info("Successfully added product mirror", {
       operation: "addProductMirror",
@@ -131,6 +141,14 @@ export async function addProductMirror(
       success: true,
     };
   } catch (error) {
+    if (isConcurrentEdit(error)) {
+      return {
+        fieldErrors: {},
+        data: formData,
+        message: CONCURRENT_EDIT_MESSAGE,
+        success: false,
+      };
+    }
     LOGGER.error("Error adding product mirror", {
       operation: "addProductMirror",
       error,
@@ -226,7 +244,9 @@ export async function removeProductMirror(
       },
     };
 
-    await productsTable.update(updatedProduct);
+    await productsTable.update(updatedProduct, {
+      expectedUpdatedAt: product.updated_at,
+    });
 
     LOGGER.info("Successfully removed product mirror", {
       operation: "removeProductMirror",
@@ -242,6 +262,14 @@ export async function removeProductMirror(
       success: true,
     };
   } catch (error) {
+    if (isConcurrentEdit(error)) {
+      return {
+        fieldErrors: {},
+        data: formData,
+        message: CONCURRENT_EDIT_MESSAGE,
+        success: false,
+      };
+    }
     LOGGER.error("Error removing product mirror", {
       operation: "removeProductMirror",
       error,
@@ -329,7 +357,9 @@ export async function setPrimaryMirror(
       },
     };
 
-    await productsTable.update(updatedProduct);
+    await productsTable.update(updatedProduct, {
+      expectedUpdatedAt: product.updated_at,
+    });
 
     LOGGER.info("Successfully set primary mirror", {
       operation: "setPrimaryMirror",
@@ -345,6 +375,14 @@ export async function setPrimaryMirror(
       success: true,
     };
   } catch (error) {
+    if (isConcurrentEdit(error)) {
+      return {
+        fieldErrors: {},
+        data: formData,
+        message: CONCURRENT_EDIT_MESSAGE,
+        success: false,
+      };
+    }
     LOGGER.error("Error setting primary mirror", {
       operation: "setPrimaryMirror",
       error,

--- a/src/lib/actions/product-mirrors.ts
+++ b/src/lib/actions/product-mirrors.ts
@@ -1,0 +1,345 @@
+"use server";
+
+import { LOGGER } from "@/lib/logging";
+import { isAdmin } from "../api/authz";
+import { getPageSession } from "../api/utils";
+import { productsTable, dataConnectionsTable } from "../clients";
+import { DataProvider, ProductMirror } from "@/types";
+import { FormState } from "@/components/core/DynamicForm";
+import { revalidatePath } from "next/cache";
+import { editProductDataConnectionsUrl } from "@/lib/urls";
+
+export async function addProductMirror(
+  _prevState: FormState<unknown>,
+  formData: FormData
+): Promise<FormState<unknown>> {
+  const session = await getPageSession();
+
+  if (!session?.identity_id) {
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Unauthenticated",
+      success: false,
+    };
+  }
+
+  if (!isAdmin(session)) {
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Only admins can manage product mirrors",
+      success: false,
+    };
+  }
+
+  const accountId = formData.get("account_id") as string;
+  const productId = formData.get("product_id") as string;
+  const connectionId = formData.get("connection_id") as string;
+
+  if (!accountId || !productId || !connectionId) {
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Missing required fields",
+      success: false,
+    };
+  }
+
+  try {
+    const product = await productsTable.fetchById(accountId, productId);
+    if (!product) {
+      return {
+        fieldErrors: {},
+        data: formData,
+        message: "Product not found",
+        success: false,
+      };
+    }
+
+    const connection = await dataConnectionsTable.fetchById(connectionId);
+    if (!connection) {
+      return {
+        fieldErrors: {},
+        data: formData,
+        message: "Data connection not found",
+        success: false,
+      };
+    }
+
+    if (product.metadata.mirrors[connectionId]) {
+      return {
+        fieldErrors: {},
+        data: formData,
+        message: "This data connection is already associated with this product",
+        success: false,
+      };
+    }
+
+    const prefix = connection.prefix_template
+      ? connection.prefix_template
+          .replace("{{repository.account_id}}", accountId)
+          .replace("{{repository.repository_id}}", productId)
+      : `${accountId}/${productId}/`;
+
+    const isFirst = Object.keys(product.metadata.mirrors).length === 0;
+
+    const mirror: ProductMirror = {
+      storage_type:
+        connection.details.provider === DataProvider.S3 ? "s3" : "azure",
+      connection_id: connectionId,
+      prefix,
+      is_primary: isFirst,
+    };
+
+    const updatedProduct = {
+      ...product,
+      metadata: {
+        ...product.metadata,
+        mirrors: { ...product.metadata.mirrors, [connectionId]: mirror },
+        primary_mirror: isFirst ? connectionId : product.metadata.primary_mirror,
+      },
+    };
+
+    await productsTable.update(updatedProduct);
+
+    LOGGER.info("Successfully added product mirror", {
+      operation: "addProductMirror",
+      metadata: { accountId, productId, connectionId },
+    });
+
+    revalidatePath(editProductDataConnectionsUrl(accountId, productId));
+
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Data connection added successfully!",
+      success: true,
+    };
+  } catch (error) {
+    LOGGER.error("Error adding product mirror", {
+      operation: "addProductMirror",
+      error,
+    });
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Failed to add data connection. Please try again.",
+      success: false,
+    };
+  }
+}
+
+export async function removeProductMirror(
+  _prevState: FormState<unknown>,
+  formData: FormData
+): Promise<FormState<unknown>> {
+  const session = await getPageSession();
+
+  if (!session?.identity_id) {
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Unauthenticated",
+      success: false,
+    };
+  }
+
+  if (!isAdmin(session)) {
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Only admins can manage product mirrors",
+      success: false,
+    };
+  }
+
+  const accountId = formData.get("account_id") as string;
+  const productId = formData.get("product_id") as string;
+  const mirrorKey = formData.get("mirror_key") as string;
+
+  if (!accountId || !productId || !mirrorKey) {
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Missing required fields",
+      success: false,
+    };
+  }
+
+  try {
+    const product = await productsTable.fetchById(accountId, productId);
+    if (!product) {
+      return {
+        fieldErrors: {},
+        data: formData,
+        message: "Product not found",
+        success: false,
+      };
+    }
+
+    if (!product.metadata.mirrors[mirrorKey]) {
+      return {
+        fieldErrors: {},
+        data: formData,
+        message: "Mirror not found",
+        success: false,
+      };
+    }
+
+    const remainingMirrors = { ...product.metadata.mirrors };
+    delete remainingMirrors[mirrorKey];
+
+    // If we removed the primary, promote the first remaining mirror (if any).
+    let primaryMirror = product.metadata.primary_mirror;
+    if (primaryMirror === mirrorKey) {
+      const [nextPrimary] = Object.keys(remainingMirrors);
+      primaryMirror = nextPrimary ?? "";
+      if (nextPrimary) {
+        remainingMirrors[nextPrimary] = {
+          ...remainingMirrors[nextPrimary],
+          is_primary: true,
+        };
+      }
+    }
+
+    const updatedProduct = {
+      ...product,
+      metadata: {
+        ...product.metadata,
+        mirrors: remainingMirrors,
+        primary_mirror: primaryMirror,
+      },
+    };
+
+    await productsTable.update(updatedProduct);
+
+    LOGGER.info("Successfully removed product mirror", {
+      operation: "removeProductMirror",
+      metadata: { accountId, productId, mirrorKey },
+    });
+
+    revalidatePath(editProductDataConnectionsUrl(accountId, productId));
+
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Data connection removed successfully!",
+      success: true,
+    };
+  } catch (error) {
+    LOGGER.error("Error removing product mirror", {
+      operation: "removeProductMirror",
+      error,
+    });
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Failed to remove data connection. Please try again.",
+      success: false,
+    };
+  }
+}
+
+export async function setPrimaryMirror(
+  _prevState: FormState<unknown>,
+  formData: FormData
+): Promise<FormState<unknown>> {
+  const session = await getPageSession();
+
+  if (!session?.identity_id) {
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Unauthenticated",
+      success: false,
+    };
+  }
+
+  if (!isAdmin(session)) {
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Only admins can manage product mirrors",
+      success: false,
+    };
+  }
+
+  const accountId = formData.get("account_id") as string;
+  const productId = formData.get("product_id") as string;
+  const mirrorKey = formData.get("mirror_key") as string;
+
+  if (!accountId || !productId || !mirrorKey) {
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Missing required fields",
+      success: false,
+    };
+  }
+
+  try {
+    const product = await productsTable.fetchById(accountId, productId);
+    if (!product) {
+      return {
+        fieldErrors: {},
+        data: formData,
+        message: "Product not found",
+        success: false,
+      };
+    }
+
+    if (!product.metadata.mirrors[mirrorKey]) {
+      return {
+        fieldErrors: {},
+        data: formData,
+        message: "Mirror not found",
+        success: false,
+      };
+    }
+
+    const updatedMirrors = { ...product.metadata.mirrors };
+    for (const key of Object.keys(updatedMirrors)) {
+      updatedMirrors[key] = {
+        ...updatedMirrors[key],
+        is_primary: key === mirrorKey,
+      };
+    }
+
+    const updatedProduct = {
+      ...product,
+      metadata: {
+        ...product.metadata,
+        mirrors: updatedMirrors,
+        primary_mirror: mirrorKey,
+      },
+    };
+
+    await productsTable.update(updatedProduct);
+
+    LOGGER.info("Successfully set primary mirror", {
+      operation: "setPrimaryMirror",
+      metadata: { accountId, productId, mirrorKey },
+    });
+
+    revalidatePath(editProductDataConnectionsUrl(accountId, productId));
+
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Primary mirror updated successfully!",
+      success: true,
+    };
+  } catch (error) {
+    LOGGER.error("Error setting primary mirror", {
+      operation: "setPrimaryMirror",
+      error,
+    });
+    return {
+      fieldErrors: {},
+      data: formData,
+      message: "Failed to update primary mirror. Please try again.",
+      success: false,
+    };
+  }
+}

--- a/src/lib/actions/product-mirrors.ts
+++ b/src/lib/actions/product-mirrors.ts
@@ -9,6 +9,12 @@ import { FormState } from "@/components/core/DynamicForm";
 import { revalidatePath } from "next/cache";
 import { editProductDataConnectionsUrl } from "@/lib/urls";
 
+// ponytail: these three actions fetch → mutate → productsTable.update() with no
+// optimistic lock, so two admins editing the same product's mirrors at once can
+// silently lose one update (last write wins). Admin-only and low-frequency, so
+// the race is left open. Upgrade path: thread a ConditionExpression on
+// updated_at through productsTable.update() for a compare-and-swap.
+
 export async function addProductMirror(
   _prevState: FormState<unknown>,
   formData: FormData
@@ -78,8 +84,8 @@ export async function addProductMirror(
 
     const prefix = connection.prefix_template
       ? connection.prefix_template
-          .replace("{{repository.account_id}}", accountId)
-          .replace("{{repository.repository_id}}", productId)
+          .replaceAll("{{repository.account_id}}", accountId)
+          .replaceAll("{{repository.repository_id}}", productId)
       : `${accountId}/${productId}/`;
 
     const isFirst = Object.keys(product.metadata.mirrors).length === 0;

--- a/src/lib/actions/product-mirrors.ts
+++ b/src/lib/actions/product-mirrors.ts
@@ -84,9 +84,17 @@ export async function addProductMirror(
 
     const isFirst = Object.keys(product.metadata.mirrors).length === 0;
 
+    const storageTypeByProvider: Record<
+      DataProvider,
+      ProductMirror["storage_type"]
+    > = {
+      [DataProvider.S3]: "s3",
+      [DataProvider.Azure]: "azure",
+      [DataProvider.GCP]: "gcs",
+    };
+
     const mirror: ProductMirror = {
-      storage_type:
-        connection.details.provider === DataProvider.S3 ? "s3" : "azure",
+      storage_type: storageTypeByProvider[connection.details.provider],
       connection_id: connectionId,
       prefix,
       is_primary: isFirst,

--- a/src/lib/clients/database/data-connections.ts
+++ b/src/lib/clients/database/data-connections.ts
@@ -8,6 +8,7 @@ import {
   ScanCommand,
   PutCommand,
   UpdateCommand,
+  DeleteCommand,
 } from "@aws-sdk/lib-dynamodb";
 import { marshall } from "@aws-sdk/util-dynamodb";
 import { BaseTable } from "./base";
@@ -105,6 +106,22 @@ export class DataConnectionsTable extends BaseTable {
       this.logError("update", error, {
         dataConnectionId: dataConnection.data_connection_id,
       });
+      throw error;
+    }
+  }
+
+  async delete(dataConnectionId: string): Promise<void> {
+    try {
+      await this.client.send(
+        new DeleteCommand({
+          TableName: this.table,
+          Key: {
+            data_connection_id: dataConnectionId,
+          },
+        })
+      );
+    } catch (error) {
+      this.logError("delete", error, { dataConnectionId });
       throw error;
     }
   }

--- a/src/lib/clients/database/data-connections.ts
+++ b/src/lib/clients/database/data-connections.ts
@@ -68,6 +68,9 @@ export class DataConnectionsTable extends BaseTable {
         new PutCommand({
           TableName: this.table,
           Item: dataConnection,
+          // Guard against a concurrent create racing the caller's existence
+          // check and silently overwriting a live connection.
+          ConditionExpression: "attribute_not_exists(data_connection_id)",
         })
       );
       return dataConnection;
@@ -81,23 +84,53 @@ export class DataConnectionsTable extends BaseTable {
 
   async update(dataConnection: DataConnection): Promise<DataConnection> {
     try {
+      // `name` is a DynamoDB reserved word, so it must be aliased. Optional
+      // fields that are `undefined` are REMOVEd rather than SET: the document
+      // client strips undefined values (removeUndefinedValues), which would
+      // otherwise leave the SET expression referencing a missing value.
+      const names: Record<string, string> = { "#name": "name" };
+      const values: Record<string, unknown> = {
+        ":name": dataConnection.name,
+        ":read_only": dataConnection.read_only,
+        ":allowed_visibilities": dataConnection.allowed_visibilities,
+        ":details": dataConnection.details,
+      };
+      const setClauses = [
+        "#name = :name",
+        "read_only = :read_only",
+        "allowed_visibilities = :allowed_visibilities",
+        "details = :details",
+      ];
+      const removeClauses: string[] = [];
+
+      const optionalFields: Array<[string, unknown]> = [
+        ["prefix_template", dataConnection.prefix_template],
+        ["required_flag", dataConnection.required_flag],
+        ["authentication", dataConnection.authentication],
+      ];
+      for (const [field, value] of optionalFields) {
+        if (value === undefined) {
+          removeClauses.push(field);
+        } else {
+          setClauses.push(`${field} = :${field}`);
+          values[`:${field}`] = value;
+        }
+      }
+
+      let updateExpression = `SET ${setClauses.join(", ")}`;
+      if (removeClauses.length > 0) {
+        updateExpression += ` REMOVE ${removeClauses.join(", ")}`;
+      }
+
       const result = await this.client.send(
         new UpdateCommand({
           TableName: this.table,
           Key: {
             data_connection_id: dataConnection.data_connection_id,
           },
-          UpdateExpression:
-            "SET name = :name, prefix_template = :prefix_template, read_only = :read_only, allowed_visibilities = :allowed_visibilities, required_flag = :required_flag, details = :details, authentication = :authentication",
-          ExpressionAttributeValues: {
-            ":name": dataConnection.name,
-            ":prefix_template": dataConnection.prefix_template,
-            ":read_only": dataConnection.read_only,
-            ":allowed_visibilities": dataConnection.allowed_visibilities,
-            ":required_flag": dataConnection.required_flag,
-            ":details": dataConnection.details,
-            ":authentication": dataConnection.authentication,
-          },
+          UpdateExpression: updateExpression,
+          ExpressionAttributeNames: names,
+          ExpressionAttributeValues: values,
           ReturnValues: "ALL_NEW",
         })
       );

--- a/src/lib/clients/database/data-connections.ts
+++ b/src/lib/clients/database/data-connections.ts
@@ -47,15 +47,9 @@ export class DataConnectionsTable extends BaseTable {
           ConsistentRead: true,
         })
       );
-      // Copy before sorting: the response may be a shared, request-cached object,
-      // so we must not sort `result.Items` in place.
-      return (
-        [...(result.Items ?? [])]
-          .sort((a, b) =>
-            b.data_connection_id.localeCompare(a.data_connection_id)
-          )
-          .map((item) => item as DataConnection)
-      );
+      // Unsorted: callers order as they need (e.g. the admin page sorts by
+      // provider then name). Sorting here would express no useful intent.
+      return (result.Items ?? []) as DataConnection[];
     } catch (error) {
       this.logError("listAll", error);
       throw error;

--- a/src/lib/clients/database/data-connections.ts
+++ b/src/lib/clients/database/data-connections.ts
@@ -128,6 +128,9 @@ export class DataConnectionsTable extends BaseTable {
           Key: {
             data_connection_id: dataConnection.data_connection_id,
           },
+          // Guard against UpdateItem's upsert semantics resurrecting a row that
+          // was deleted concurrently (would otherwise write a partial ghost).
+          ConditionExpression: "attribute_exists(data_connection_id)",
           UpdateExpression: updateExpression,
           ExpressionAttributeNames: names,
           ExpressionAttributeValues: values,

--- a/src/lib/clients/database/products.ts
+++ b/src/lib/clients/database/products.ts
@@ -245,8 +245,26 @@ export class ProductsTable extends BaseTable {
     }
   }
 
-  async update(product: Product): Promise<Product> {
+  async update(
+    product: Product,
+    // Optimistic lock: when set, the write only lands if the row's stored
+    // updated_at still equals the value the caller read. A concurrent writer
+    // bumps updated_at, so the condition fails (ConditionalCheckFailedException)
+    // instead of silently clobbering their change. Omit it for last-write-wins.
+    opts?: { expectedUpdatedAt?: string }
+  ): Promise<Product> {
     try {
+      const values: Record<string, unknown> = {
+        ":title": product.title,
+        ":description": product.description,
+        ":updated_at": new Date().toISOString(),
+        ":visibility": product.visibility,
+        ":metadata": product.metadata,
+        ":search_text": this.buildSearchText(product),
+      };
+      if (opts?.expectedUpdatedAt) {
+        values[":expected_updated_at"] = opts.expectedUpdatedAt;
+      }
       const result = await this.client.send(
         new UpdateCommand({
           TableName: this.table,
@@ -256,14 +274,10 @@ export class ProductsTable extends BaseTable {
           },
           UpdateExpression:
             "SET title = :title, description = :description, updated_at = :updated_at, visibility = :visibility, metadata = :metadata, search_text = :search_text",
-          ExpressionAttributeValues: {
-            ":title": product.title,
-            ":description": product.description,
-            ":updated_at": new Date().toISOString(),
-            ":visibility": product.visibility,
-            ":metadata": product.metadata,
-            ":search_text": this.buildSearchText(product),
-          },
+          ...(opts?.expectedUpdatedAt
+            ? { ConditionExpression: "updated_at = :expected_updated_at" }
+            : {}),
+          ExpressionAttributeValues: values,
           ReturnValues: "ALL_NEW",
         })
       );

--- a/src/lib/clients/database/products.ts
+++ b/src/lib/clients/database/products.ts
@@ -103,6 +103,34 @@ export class ProductsTable extends BaseTable {
     return allProducts;
   }
 
+  /**
+   * Returns every product that mirrors data through the given data connection.
+   *
+   * There is no index on `metadata.mirrors[*].connection_id` (it lives inside a
+   * DynamoDB map), so this scans the whole table and filters app-side. It
+   * matches on each mirror's `connection_id` field rather than the map key, so
+   * it is robust to legacy mirrors keyed by region (e.g. "aws-us-east-1") rather
+   * than by connection id. Intended for low-traffic admin views; if product
+   * volume grows large, replace with a denormalized connection index + GSI.
+   */
+  async listProductsByConnectionId(connectionId: string): Promise<Product[]> {
+    const matches: Product[] = [];
+    let lastEvaluatedKey: any = undefined;
+
+    do {
+      const result = await this.list(1000, lastEvaluatedKey);
+      for (const product of result.products) {
+        const mirrors = Object.values(product.metadata?.mirrors ?? {});
+        if (mirrors.some((mirror) => mirror.connection_id === connectionId)) {
+          matches.push(product);
+        }
+      }
+      lastEvaluatedKey = result.lastEvaluatedKey;
+    } while (lastEvaluatedKey);
+
+    return matches;
+  }
+
   async listPublic(
     limit = 50,
     lastEvaluatedKey?: any,

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -15,6 +15,11 @@ export const newProductUrl = () => "/products/new";
 // Admin URLs
 export const adminUrl = () => "/admin";
 export const adminUserLookupUrl = () => "/admin/user-lookup";
+export const adminDataConnectionsUrl = () => "/admin/data-connections";
+export const adminDataConnectionCreateUrl = () =>
+  "/admin/data-connections/create";
+export const adminDataConnectionEditUrl = (data_connection_id: string) =>
+  `/admin/data-connections/${data_connection_id}`;
 
 // Auth URLs
 export const loginUrl = (returnTo?: string) => {
@@ -58,6 +63,10 @@ export const editProductMembershipsUrl = (
   account_id: string,
   product_id: string
 ) => `/edit/product/${account_id}/${product_id}/memberships`;
+export const editProductDataConnectionsUrl = (
+  account_id: string,
+  product_id: string
+) => `/edit/product/${account_id}/${product_id}/data-connections`;
 export const editProfileUrl = (account_id: string) =>
   `/edit/profile/${account_id}`;
 

--- a/src/types/data-connection.ts
+++ b/src/types/data-connection.ts
@@ -109,15 +109,15 @@ export const S3ECSTaskRoleAuthenticationSchema = z
 export const S3AccessKeyAuthenticationSchema = z
   .object({
     type: z.literal(DataConnectionAuthenticationType.S3AccessKey),
-    access_key_id: z.string(),
-    secret_access_key: z.string(),
+    access_key_id: z.string().min(1, "Access Key ID is required"),
+    secret_access_key: z.string().min(1, "Secret Access Key is required"),
   })
   .openapi("S3AccessKeyAuthentication");
 
 export const AzureSasTokenAuthenticationSchema = z
   .object({
     type: z.literal(DataConnectionAuthenticationType.AzureSasToken),
-    sas_token: z.string(),
+    sas_token: z.string().min(1, "SAS Token is required"),
   })
   .openapi("AzureSasTokenAuthentication");
 

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -4,8 +4,9 @@ import { AccountSchema } from "@/types/account";
 
 extendZodWithOpenApi(z);
 
-// Mirror configuration and status tracking
-// ProductMirror describes a storage mirror for a product, including config, sync status, and stats.
+// ProductMirror describes a storage mirror for a product: which data connection
+// backs it, the key prefix under which the product's objects live, and whether
+// it is the primary mirror.
 export const ProductMirrorSchema = z
   .object({
     storage_type: z.enum(["s3", "azure", "gcs", "minio", "ceph"]),


### PR DESCRIPTION
## What I'm changing

Adds a full **Data Connection admin** (browse / create / edit / delete) plus product-side mirror management. This reworks the closed #342 onto the admin menu from #350 and the data-connection model from #332 (now merged to `main`).

Admins can now:
- Manage data connections from **Admin → Data Connections**.
- Configure **S3, Azure, GCP (GCS),** and **S3-compatible backends (Cloudflare R2, MinIO, Ceph)**.
- See which products use a given connection, and jump from a product's mirrors straight to that connection's admin page.
- Attach/detach connections and set the primary mirror from a product's **Data Connections** tab.

Supersedes #342 · builds on #350 (admin menu) and #332 (model) · follow-up: #365 (enforce `required_flag`).

## How I did it

**Admin-menu integration (#350).** Registered "Data Connections" in the `ADMIN_TOOLS` registry, which drives both the `/admin` sidebar and the account-dropdown Admin submenu — no standalone admin layout. New routes live under `src/app/(app)/admin/data-connections/` (list / create / `[id]` edit).

**The form.** `DataConnectionForm` is a client form with provider- and auth-type-conditional fields (the shared `DynamicForm` can't express the discriminated `details`/`authentication` shapes). Every field carries an inline description, and the Authentication Type description changes with the selected mechanism:
- **S3** → ECS task role / access key / web-identity role / local, plus an optional **Endpoint** field + `auto` region for R2/MinIO/Ceph.
- **Azure** → SAS token / workload identity.
- **GCP** → workload identity (provider + service account).

**Server actions** (`data-connections.ts`, `product-mirrors.ts`). Each re-checks authorization (actions aren't covered by the layout gate), validates against the Zod schema, and maps Zod issues to **leaf** field names so nested `details.*` / `authentication.*` errors render next to their inputs. Navigation uses the `FormState.redirectTo` client-nav pattern (consistent with the rest of the app; avoids the stale Router Cache from a server `redirect()`).

**Security.** Storage secrets (access keys, SAS tokens) are never serialized to the client: a `redact` module strips them before any `DataConnection` is handed to a client component, and the edit form omits secret inputs (blank = keep existing on update).

**Data layer.** Added `DataConnectionsTable.delete`; fixed `update` (alias the reserved word `name`; `REMOVE` undefined optionals instead of referencing values the document client strips); `create` uses a conditional put so a concurrent create can't silently overwrite a live connection. Added `ProductsTable.listProductsByConnectionId` — a full scan + app-side filter (admin-scale; a denormalized index + GSI is the noted upgrade path) backing the "Products using this connection" panel.

**Mirrors.** `ProductMirrorsManager` (product edit tab) lets admins add/remove/set-primary; `addProductMirror` maps provider → `storage_type` (`gcp → gcs`), and the product file page now guards against an empty/stale `primary_mirror`.

The branch was hardened via a 5-agent review that caught secret leakage to the client, a broken DynamoDB `update`, a dropped SAS-token field, and a mirror-removal crash.

**Data Proxy impact.** No breaking changes to existing connection shapes. The S3 `endpoint` field is additive. **GCP Workload Identity federation is configurable here but not yet implemented in the proxy/multistore** (schema scaffolding, same status as Azure), so GCP connections won't be functional downstream until that lands; R2 via static keys is functional.

## How you can test it

1. As an **admin**, open **Admin → Data Connections** (or the account dropdown → Admin).
2. **Create** — try S3 (with and without an Endpoint for R2, region `auto`), Azure, and GCP. Switch provider/auth type and confirm the fields + descriptions update. Submit an invalid value (e.g. a malformed Role ARN) and confirm the error renders next to that field.
3. **Edit** — reopen a connection that has secrets: secret inputs are blank with a "leave blank to keep" hint, and saving without re-entering them preserves the stored values.
4. **Delete** — confirm the dialog and the redirect back to the list.
5. **Product → Data Connections tab** — add a connection, set it primary, remove it; as an admin, use the ↗ link next to a connection ID to open it in the admin.
6. **Connection edit page** — confirm the **Products using this connection** list (with a Primary badge).

Automated checks (all green): `npm run type-check`, `next lint`, and `npx jest src/lib/actions/data-connections.test.ts src/lib/actions/product-mirrors.test.ts` (27 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
