### PR TITLE
refactor(backfill): zero-downtime allowed_visibilities migration (additive backfill + separate cleanup)

### DIFF
--- a/scripts/backfill-allowed-visibilities.ts
+++ b/scripts/backfill-allowed-visibilities.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env tsx
 /**
- * Backfill script to migrate the legacy `allowed_data_modes` field to
- * `allowed_visibilities` on data-connections records, mapping legacy
- * values to ProductVisibility values along the way.
+ * Migrate the legacy `allowed_data_modes` field to `allowed_visibilities` on
+ * data-connections records, mapping legacy values to ProductVisibility values
+ * along the way.
  *
  * Value mapping:
  *   "open"         -> "public"
@@ -10,20 +10,37 @@
  *   "subscription" -> "restricted"
  * Values already conforming to ProductVisibility are passed through.
  *
- * For each record:
- *   - if it has `allowed_data_modes`, the values are mapped, deduped,
- *     written to `allowed_visibilities`, and `allowed_data_modes` is
- *     removed.
- *   - if it has only `allowed_visibilities`, it is skipped.
+ * ZERO-DOWNTIME, TWO-PHASE DESIGN
+ * -------------------------------
+ * `allowed_data_modes` and `allowed_visibilities` are read by two independently
+ * deployed services (this app and the data proxy). A single step that adds the
+ * new field and drops the old one would break whichever reader is still on the
+ * other version. So the migration is split so that both fields coexist for the
+ * whole rollout, and the destructive removal is deferred to the very end:
+ *
+ *   MODE=backfill (default) — ADDITIVE. Sets `allowed_visibilities` from the
+ *     mapped `allowed_data_modes` and leaves `allowed_data_modes` in place.
+ *     Guarded by `attribute_not_exists(allowed_visibilities)`, so it is
+ *     idempotent and never clobbers a value newer code already wrote.
+ *
+ *   MODE=cleanup — DESTRUCTIVE. Removes `allowed_data_modes` only. Guarded by
+ *     `attribute_exists(allowed_visibilities)`, so it never strips the legacy
+ *     field off a record that has no replacement. Run this ONLY after every
+ *     reader (app + data proxy) has been deployed reading `allowed_visibilities`.
+ *
+ * Rollout order: deploy read-both code (app + proxy) -> run backfill ->
+ * deploy read-new-only code (app + proxy) -> run cleanup. The backfill is safe
+ * to run before or after the code deploy because both fields remain present.
  *
  * Usage:
  *   npx tsx scripts/backfill-allowed-visibilities.ts <table-name>
  *
  * Examples:
  *   npx tsx scripts/backfill-allowed-visibilities.ts sc-dev-data-connections
- *   npx tsx scripts/backfill-allowed-visibilities.ts sc-prod-data-connections
+ *   MODE=cleanup npx tsx scripts/backfill-allowed-visibilities.ts sc-prod-data-connections
  *
  * Environment variables:
+ *   MODE        - "backfill" (default, additive) or "cleanup" (destructive)
  *   AWS_REGION  - AWS region (default: us-east-1)
  *   AWS_PROFILE - AWS profile to use (optional)
  *   DRY_RUN     - Set (to anything) to preview changes without writing
@@ -42,6 +59,8 @@ const LEGACY_TO_NEW: Record<string, string> = {
   subscription: "restricted",
 };
 
+type Mode = "backfill" | "cleanup";
+
 interface DataConnectionItem {
   data_connection_id: string;
   allowed_data_modes?: string[];
@@ -53,11 +72,16 @@ function mapValues(modes: string[]): string[] {
   return Array.from(new Set(mapped));
 }
 
-async function backfill(tableName: string, dryRun: boolean) {
+function isConditionalCheckFailed(err: unknown): boolean {
+  return err instanceof Error && err.name === "ConditionalCheckFailedException";
+}
+
+async function migrate(tableName: string, mode: Mode, dryRun: boolean) {
   const region = process.env.AWS_REGION || "us-east-1";
 
-  console.log(`Backfill allowed_visibilities for table: ${tableName}`);
-  console.log(`Region: ${region}`);
+  console.log(`Mode:    ${mode}`);
+  console.log(`Table:   ${tableName}`);
+  console.log(`Region:  ${region}`);
   console.log(`Dry run: ${dryRun}`);
   console.log("");
 
@@ -70,6 +94,9 @@ async function backfill(tableName: string, dryRun: boolean) {
   let scanned = 0;
   let updated = 0;
   let skipped = 0;
+  // Records that matched the field-presence pre-check but failed the write's
+  // ConditionExpression (e.g. already backfilled, or no new field to keep).
+  let guarded = 0;
   let errors = 0;
 
   do {
@@ -86,56 +113,104 @@ async function backfill(tableName: string, dryRun: boolean) {
     scanned += items.length;
 
     for (const item of items) {
+      // Both phases only ever touch records that still carry the legacy field.
+      // Once `allowed_data_modes` is gone, the record is fully migrated.
       if (item.allowed_data_modes === undefined) {
         skipped++;
         continue;
       }
 
-      const next = mapValues(item.allowed_data_modes);
+      if (mode === "backfill") {
+        // Mirror the live ConditionExpression in dry-run: only records missing
+        // the new field would actually be written.
+        if (item.allowed_visibilities !== undefined) {
+          guarded++;
+          continue;
+        }
+        const next = mapValues(item.allowed_data_modes);
 
-      if (dryRun) {
-        console.log(
-          `[DRY RUN] Would update ${item.data_connection_id}: allowed_data_modes=${JSON.stringify(item.allowed_data_modes)} -> allowed_visibilities=${JSON.stringify(next)}`
-        );
-        updated++;
-        continue;
-      }
+        if (dryRun) {
+          console.log(
+            `[DRY RUN] Would set ${item.data_connection_id}: allowed_visibilities=${JSON.stringify(next)} (allowed_data_modes left in place)`
+          );
+          updated++;
+          continue;
+        }
 
-      try {
-        await client.send(
-          new UpdateCommand({
-            TableName: tableName,
-            Key: { data_connection_id: item.data_connection_id },
-            UpdateExpression:
-              "SET allowed_visibilities = :allowed_visibilities REMOVE allowed_data_modes",
-            ExpressionAttributeValues: { ":allowed_visibilities": next },
-          })
-        );
-        updated++;
-      } catch (err) {
-        errors++;
-        console.error(`Error updating ${item.data_connection_id}:`, err);
+        try {
+          await client.send(
+            new UpdateCommand({
+              TableName: tableName,
+              Key: { data_connection_id: item.data_connection_id },
+              UpdateExpression: "SET allowed_visibilities = :allowed_visibilities",
+              ConditionExpression: "attribute_not_exists(allowed_visibilities)",
+              ExpressionAttributeValues: { ":allowed_visibilities": next },
+            })
+          );
+          updated++;
+        } catch (err) {
+          if (isConditionalCheckFailed(err)) {
+            // A concurrent writer populated allowed_visibilities first; leave it.
+            guarded++;
+            continue;
+          }
+          errors++;
+          console.error(`Error updating ${item.data_connection_id}:`, err);
+        }
+      } else {
+        // cleanup: never strip the legacy field off a record that has no
+        // replacement value yet.
+        if (item.allowed_visibilities === undefined) {
+          guarded++;
+          continue;
+        }
+
+        if (dryRun) {
+          console.log(
+            `[DRY RUN] Would remove allowed_data_modes from ${item.data_connection_id}`
+          );
+          updated++;
+          continue;
+        }
+
+        try {
+          await client.send(
+            new UpdateCommand({
+              TableName: tableName,
+              Key: { data_connection_id: item.data_connection_id },
+              UpdateExpression: "REMOVE allowed_data_modes",
+              ConditionExpression: "attribute_exists(allowed_visibilities)",
+            })
+          );
+          updated++;
+        } catch (err) {
+          if (isConditionalCheckFailed(err)) {
+            guarded++;
+            continue;
+          }
+          errors++;
+          console.error(`Error updating ${item.data_connection_id}:`, err);
+        }
       }
     }
 
     console.log(
-      `Progress: scanned=${scanned}, updated=${updated}, skipped=${skipped}, errors=${errors}`
+      `Progress: scanned=${scanned}, updated=${updated}, skipped=${skipped}, guarded=${guarded}, errors=${errors}`
     );
   } while (lastEvaluatedKey);
 
   console.log("");
-  console.log("Backfill complete.");
+  console.log(`${mode} complete.`);
   console.log(`  Total scanned: ${scanned}`);
   console.log(`  Updated:       ${updated}`);
-  console.log(`  Skipped:       ${skipped} (already migrated)`);
+  console.log(`  Skipped:       ${skipped} (no allowed_data_modes)`);
+  console.log(`  Guarded:       ${guarded} (condition not met)`);
   console.log(`  Errors:        ${errors}`);
 }
 
-const tableName = process.argv[2];
-
-if (!tableName) {
+function usage() {
   console.error(
-    "Usage: npx tsx scripts/backfill-allowed-visibilities.ts <table-name>"
+    "Usage: [MODE=backfill|cleanup] npx tsx scripts/backfill-allowed-visibilities.ts <table-name>"
   );
   console.error("");
   console.error("Examples:");
@@ -143,21 +218,38 @@ if (!tableName) {
     "  npx tsx scripts/backfill-allowed-visibilities.ts sc-dev-data-connections"
   );
   console.error(
-    "  npx tsx scripts/backfill-allowed-visibilities.ts sc-prod-data-connections"
+    "  MODE=cleanup npx tsx scripts/backfill-allowed-visibilities.ts sc-prod-data-connections"
   );
   console.error("");
   console.error("Environment variables:");
+  console.error(
+    "  MODE        - 'backfill' (default, additive) or 'cleanup' (destructive)"
+  );
   console.error("  AWS_REGION  - AWS region (default: us-east-1)");
   console.error("  AWS_PROFILE - AWS profile to use (optional)");
   console.error(
     "  DRY_RUN     - Set (to anything) to preview changes without writing"
   );
+}
+
+const tableName = process.argv[2];
+
+if (!tableName) {
+  usage();
+  process.exit(1);
+}
+
+const mode = (process.env.MODE || "backfill") as Mode;
+if (mode !== "backfill" && mode !== "cleanup") {
+  console.error(`Invalid MODE: ${mode} (expected "backfill" or "cleanup")`);
+  console.error("");
+  usage();
   process.exit(1);
 }
 
 const dryRun = process.env.DRY_RUN !== undefined;
 
-backfill(tableName, dryRun).catch((err) => {
-  console.error("Backfill failed:", err);
+migrate(tableName, mode, dryRun).catch((err) => {
+  console.error(`${mode} failed:`, err);
   process.exit(1);
 });


### PR DESCRIPTION
## What

Restructure `scripts/backfill-allowed-visibilities.ts` so the `allowed_data_modes` → `allowed_visibilities` migration can run with **zero downtime** across the two services that read these fields (this app and the data proxy in `data.source.coop`).

## Why

`allowed_data_modes` (legacy) and `allowed_visibilities` (new) are read by two **independently deployed** services. The previous script added the new field and removed the old one in a single atomic per-record `UpdateExpression` (`SET allowed_visibilities ... REMOVE allowed_data_modes`). That makes it unsafe in **both** deploy orderings:

- **Migration before code:** the instant `allowed_data_modes` is removed, any still-running reader on the old field sees nothing.
- **Code before migration:** new code reading only `allowed_visibilities` hits un-migrated records where the field doesn't exist yet.

There was no ordering of "run script + deploy" that avoided a gap, because the script flipped both fields at once while the two deploys can't land atomically.

## What changed

Split the one destructive step into two **non-destructive** phases, selected by a `MODE` env var, so both fields coexist for the whole rollout and the removal is deferred to the very end:

| `MODE` | Operation | Guard (`ConditionExpression`) | Notes |
|--------|-----------|-------------------------------|-------|
| `backfill` (default) | `SET allowed_visibilities` (additive — keeps `allowed_data_modes`) | `attribute_not_exists(allowed_visibilities)` | Idempotent; never clobbers a value newer code already wrote. |
| `cleanup` | `REMOVE allowed_data_modes` only | `attribute_exists(allowed_visibilities)` | Never strips the legacy field off a record with no replacement. Run only after all readers are on the new field. |

- `ConditionalCheckFailedException` is swallowed as a `guarded` skip (mirrors the existing `upsert` handling in `data-connections.ts`), so concurrent live writes during the backfill are safe.
- Dry-run replicates each phase's `ConditionExpression` for an accurate preview, and reports a new `guarded` counter.

## Rollout (zero-downtime)

1. **Expand** — deploy read-both / write-both code to **app + data proxy** (prefer `allowed_visibilities`, fall back to mapping `allowed_data_modes`).
2. **Backfill** — `npx tsx scripts/backfill-allowed-visibilities.ts sc-prod-data-connections` (additive; safe before or after the deploy since both fields remain present).
3. **Contract** — deploy read-new-only code to app + proxy.
4. **Cleanup** — `MODE=cleanup npx tsx scripts/backfill-allowed-visibilities.ts sc-prod-data-connections`.

## Testing

- `npm run type-check` — passes.
- `next lint` on the file — no warnings/errors.
- Recommend a `DRY_RUN=1` pass against `sc-dev-data-connections` for both modes before prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
