### PR TITLE
fix(data-connection): enforce provider↔auth pairing, tighten ARN + GCP SA validation

### DIFF
--- a/src/app/(app)/edit/product/[account_id]/[product_id]/details/page.tsx
+++ b/src/app/(app)/edit/product/[account_id]/[product_id]/details/page.tsx
@@ -6,7 +6,7 @@ import {
   accountsTable,
   dataConnectionsTable,
 } from "@/lib/clients/database";
-import { DataConnection, DataConnectionSchema } from "@/types";
+import { DataConnection, DataConnectionObjectSchema } from "@/types";
 
 export async function generateMetadata({
   params,
@@ -41,7 +41,11 @@ export default async function DetailsPage({ params }: PageProps) {
     product.metadata.primary_mirror
   );
   const dataConnections: DataConnection[] = connection
-    ? [DataConnectionSchema.omit({ authentication: true }).parse(connection)]
+    ? [
+        DataConnectionObjectSchema.omit({ authentication: true }).parse(
+          connection
+        ),
+      ]
     : [];
 
   return (

--- a/src/app/(app)/products/new/page.tsx
+++ b/src/app/(app)/products/new/page.tsx
@@ -2,7 +2,7 @@ import { ProductCreationForm } from "@/components/features/products/ProductCreat
 import { accountsTable, getPageSession, membershipsTable } from "@/lib";
 import { isAuthorized } from "@/lib/api/authz";
 import { listUsableDataConnections } from "@/lib/data-connections";
-import { Actions, DataConnectionSchema, MembershipState } from "@/types";
+import { Actions, DataConnectionObjectSchema, MembershipState } from "@/types";
 import { Heading, Text } from "@radix-ui/themes";
 import { FormTitle } from "@/components/core";
 
@@ -49,7 +49,9 @@ export default async function NewProductPage() {
   // Strip credentials before handing connections to the client component.
   const dataConnections = (await listUsableDataConnections(session)).map(
     (connection) =>
-      DataConnectionSchema.omit({ authentication: true }).parse(connection)
+      DataConnectionObjectSchema.omit({ authentication: true }).parse(
+        connection
+      )
   );
 
   return (

--- a/src/app/api/openapi/route.ts
+++ b/src/app/api/openapi/route.ts
@@ -6,7 +6,7 @@ import { OpenApiGeneratorV3 } from "@asteasolutions/zod-to-openapi";
 import {
   APIKeyRequestSchema,
   APIKeySchema,
-  DataConnectionSchema,
+  DataConnectionObjectSchema,
   MembershipInvitationSchema,
   MembershipSchema,
   RedactedAPIKeySchema,
@@ -40,7 +40,7 @@ export async function GET(_req: NextRequest) {
     APIKeyRequestSchema,
     RedactedAPIKeySchema,
     MembershipInvitationSchema,
-    DataConnectionSchema,
+    DataConnectionObjectSchema,
   ]);
   if (!openapiSpecification["components"]) {
     openapiSpecification["components"] = {};

--- a/src/app/api/v1/data-connections/[data_connection_id]/route.ts
+++ b/src/app/api/v1/data-connections/[data_connection_id]/route.ts
@@ -27,11 +27,7 @@
  *         description: Internal server error
  */
 import { NextRequest, NextResponse } from "next/server";
-import {
-  Actions,
-  DataConnectionSchema,
-  DataConnectionObjectSchema,
-} from "@/types";
+import { Actions, DataConnectionSchema } from "@/types";
 import { StatusCodes } from "http-status-codes";
 import { isAdmin, isAuthorized } from "@/lib/api/authz";
 import { sanitizeDataConnection } from "@/lib/api/sanitize-data-connection";
@@ -63,18 +59,7 @@ export async function GET(
       );
     }
 
-    // Sanitize connection if user doesn't have permission to view credentials
-    if (
-      !isAuthorized(
-        session,
-        dataConnection,
-        Actions.ViewDataConnectionCredentials
-      )
-    ) {
-      dataConnection = DataConnectionObjectSchema.omit({
-        authentication: true,
-      }).parse(dataConnection);
-    }
+    // sanitizeDataConnection redacts authentication per the caller's permissions.
     const sanitized = sanitizeDataConnection(dataConnection, session);
 
     return NextResponse.json(sanitized, { status: StatusCodes.OK });

--- a/src/app/api/v1/data-connections/[data_connection_id]/route.ts
+++ b/src/app/api/v1/data-connections/[data_connection_id]/route.ts
@@ -27,7 +27,11 @@
  *         description: Internal server error
  */
 import { NextRequest, NextResponse } from "next/server";
-import { Actions, DataConnectionSchema } from "@/types";
+import {
+  Actions,
+  DataConnectionSchema,
+  DataConnectionObjectSchema,
+} from "@/types";
 import { StatusCodes } from "http-status-codes";
 import { isAdmin, isAuthorized } from "@/lib/api/authz";
 import { getApiSession } from "@/lib/api/utils";
@@ -66,7 +70,7 @@ export async function GET(
         Actions.ViewDataConnectionCredentials
       )
     ) {
-      dataConnection = DataConnectionSchema.omit({
+      dataConnection = DataConnectionObjectSchema.omit({
         authentication: true,
       }).parse(dataConnection);
     }

--- a/src/app/api/v1/data-connections/route.ts
+++ b/src/app/api/v1/data-connections/route.ts
@@ -18,11 +18,7 @@
  *         description: Internal server error
  */
 import { NextRequest, NextResponse } from "next/server";
-import {
-  Actions,
-  DataConnectionSchema,
-  DataConnectionObjectSchema,
-} from "@/types";
+import { Actions, DataConnectionSchema } from "@/types";
 import { StatusCodes } from "http-status-codes";
 import { isAuthorized } from "@/lib/api/authz";
 import { sanitizeDataConnection } from "@/lib/api/sanitize-data-connection";
@@ -38,15 +34,10 @@ export async function GET(request: NextRequest) {
     const filteredConnections = dataConnections.filter((dataConnection) =>
       isAuthorized(session, dataConnection, Actions.GetDataConnection)
     );
-    const sanitizedConnections = filteredConnections.map((connection) => {
-      const sanitized = sanitizeDataConnection(connection, session);
-      if (
-        isAuthorized(session, connection, Actions.ViewDataConnectionCredentials)
-      ) {
-        return DataConnectionSchema.parse(connection);
-      }
-      return sanitized;
-    });
+    // sanitizeDataConnection redacts authentication per the caller's permissions.
+    const sanitizedConnections = filteredConnections.map((connection) =>
+      sanitizeDataConnection(connection, session)
+    );
 
     return NextResponse.json(sanitizedConnections, { status: StatusCodes.OK });
   } catch (err: any) {

--- a/src/app/api/v1/data-connections/route.ts
+++ b/src/app/api/v1/data-connections/route.ts
@@ -18,7 +18,11 @@
  *         description: Internal server error
  */
 import { NextRequest, NextResponse } from "next/server";
-import { Actions, DataConnectionSchema, DataConnection } from "@/types";
+import {
+  Actions,
+  DataConnectionSchema,
+  DataConnectionObjectSchema,
+} from "@/types";
 import { StatusCodes } from "http-status-codes";
 import { isAuthorized } from "@/lib/api/authz";
 import { getApiSession } from "@/lib/api/utils";
@@ -34,7 +38,7 @@ export async function GET(request: NextRequest) {
       isAuthorized(session, dataConnection, Actions.GetDataConnection)
     );
     const sanitizedConnections = filteredConnections.map((connection) => {
-      const sanitized = DataConnectionSchema.omit({
+      const sanitized = DataConnectionObjectSchema.omit({
         authentication: true,
       }).parse(connection);
       if (

--- a/src/lib/api/sanitize-data-connection.ts
+++ b/src/lib/api/sanitize-data-connection.ts
@@ -1,6 +1,7 @@
 import {
   Actions,
   DataConnection,
+  DataConnectionObjectSchema,
   DataConnectionSchema,
   isSecretBearingAuth,
   UserSession,
@@ -40,5 +41,7 @@ export function sanitizeDataConnection(
     return DataConnectionSchema.parse(connection);
   }
 
-  return DataConnectionSchema.omit({ authentication: true }).parse(connection);
+  return DataConnectionObjectSchema.omit({ authentication: true }).parse(
+    connection
+  );
 }

--- a/src/types/data-connection.test.ts
+++ b/src/types/data-connection.test.ts
@@ -140,6 +140,11 @@ describe("DataConnection V2 workload-identity variants", () => {
       "not-an-arn",
       "arn:aws:s3:::some-bucket",
       "arn:aws:iam::abc:role/source-coop",
+      // role name with a space — invalid IAM character, must be rejected here
+      // rather than slipping through to an STS failure at call time
+      "arn:aws:iam::123456789012:role/foo bar",
+      // role name with an otherwise-invalid character
+      "arn:aws:iam::123456789012:role/source$coop",
     ]) {
       expect(() =>
         DataConnectionAuthenticationSchema.parse({
@@ -161,7 +166,12 @@ describe("DataConnection V2 workload-identity variants", () => {
   });
 
   test("rejects a service_account that is not a gserviceaccount.com email", () => {
-    for (const service_account of ["not-an-email", "user@gmail.com"]) {
+    for (const service_account of [
+      "not-an-email",
+      "user@gmail.com",
+      // missing the `.iam.` subdomain — not a valid user-managed SA format
+      "sa@project.gserviceaccount.com",
+    ]) {
       expect(() =>
         DataConnectionAuthenticationSchema.parse({
           type: "gcp_workload_identity",
@@ -273,5 +283,81 @@ describe("DataConnectionDetails (S3-compatible + GCP variants)", () => {
     expect(dc.authentication?.type).toBe(
       DataConnectionAuthenticationType.GcpWorkloadIdentity
     );
+  });
+});
+
+describe("DataConnection provider ↔ authentication cross-validation", () => {
+  const baseFields = {
+    data_connection_id: "conn-1",
+    name: "Conn",
+    read_only: false,
+    allowed_visibilities: [],
+  };
+  const s3Details = {
+    provider: "s3",
+    bucket: "example-bucket",
+    base_prefix: "",
+    region: "us-west-2",
+  };
+  const gcpDetails = { provider: "gcp", bucket: "example-bucket", base_prefix: "" };
+  const s3WebIdentityAuth = {
+    type: "s3_web_identity_role",
+    role_arn: "arn:aws:iam::123456789012:role/source-coop",
+  };
+  const gcpAuth = {
+    type: "gcp_workload_identity",
+    workload_identity_provider:
+      "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/p/providers/pr",
+    service_account: "sa@project.iam.gserviceaccount.com",
+  };
+
+  test("accepts an S3 provider paired with an S3 auth variant", () => {
+    const dc = DataConnectionSchema.parse({
+      ...baseFields,
+      details: s3Details,
+      authentication: s3WebIdentityAuth,
+    });
+    expect(dc.authentication?.type).toBe(
+      DataConnectionAuthenticationType.S3WebIdentityRole
+    );
+  });
+
+  test("accepts a GCP provider paired with the GCP auth variant", () => {
+    const dc = DataConnectionSchema.parse({
+      ...baseFields,
+      details: gcpDetails,
+      authentication: gcpAuth,
+    });
+    expect(dc.authentication?.type).toBe(
+      DataConnectionAuthenticationType.GcpWorkloadIdentity
+    );
+  });
+
+  test("rejects a GCP provider paired with an S3 auth variant", () => {
+    expect(() =>
+      DataConnectionSchema.parse({
+        ...baseFields,
+        details: gcpDetails,
+        authentication: s3WebIdentityAuth,
+      })
+    ).toThrow();
+  });
+
+  test("rejects an S3 provider paired with the GCP auth variant", () => {
+    expect(() =>
+      DataConnectionSchema.parse({
+        ...baseFields,
+        details: s3Details,
+        authentication: gcpAuth,
+      })
+    ).toThrow();
+  });
+
+  test("allows a connection with no authentication regardless of provider", () => {
+    const dc = DataConnectionSchema.parse({
+      ...baseFields,
+      details: gcpDetails,
+    });
+    expect(dc.authentication).toBeUndefined();
   });
 });

--- a/src/types/data-connection.ts
+++ b/src/types/data-connection.ts
@@ -124,9 +124,12 @@ export const AzureSasTokenAuthenticationSchema = z
 /**
  * IAM role ARN: `arn:{partition}:iam::{account}:role/{path}{name}`. The
  * partition class (`aws`, `aws-us-gov`, `aws-cn`) and an optional role path are
- * allowed so GovCloud/China and pathed roles are not rejected.
+ * allowed so GovCloud/China and pathed roles are not rejected. The role
+ * path/name segment is restricted to the characters AWS permits
+ * (`[A-Za-z0-9+=,.@_-]`, plus `/` for the path), so malformed ARNs are
+ * rejected here rather than at AWS STS call time.
  */
-const IAM_ROLE_ARN_REGEX = /^arn:aws[a-z-]*:iam::\d{12}:role\/.+$/;
+const IAM_ROLE_ARN_REGEX = /^arn:aws[a-z-]*:iam::\d{12}:role\/[A-Za-z0-9+=,.@/_-]+$/;
 
 /**
  * V2 federated S3 access. `role_arn` is the customer-owned IAM role the proxy
@@ -154,8 +157,12 @@ export const GcpWorkloadIdentityAuthenticationSchema = z
     workload_identity_provider: z
       .string()
       .startsWith("//iam.googleapis.com/projects/"),
-    /** Service account email the exchanged token impersonates for GCS. */
-    service_account: z.string().email().endsWith(".gserviceaccount.com"),
+    /**
+     * Service account email the exchanged token impersonates for GCS. User-
+     * managed service accounts (the kind used for WIF) always live under the
+     * `.iam.gserviceaccount.com` domain, e.g. `sa@project.iam.gserviceaccount.com`.
+     */
+    service_account: z.string().email().endsWith(".iam.gserviceaccount.com"),
   })
   .openapi("GcpWorkloadIdentityAuthentication");
 
@@ -245,7 +252,37 @@ export type DataConnectionDetails = z.infer<
   typeof DataConnnectionDetailsSchema
 >;
 
-export const DataConnectionSchema = z
+/**
+ * Authentication variants permitted for each provider. `authentication` is
+ * optional (omitted ⇒ unsigned), so this pairing is only checked when it is
+ * present. A discriminated union can't express this cross-field
+ * (`details.provider` ↔ `authentication.type`) constraint on its own, so it is
+ * enforced with a `superRefine` on the full connection.
+ */
+const PROVIDER_AUTH_TYPES: Record<
+  DataProvider,
+  readonly DataConnectionAuthenticationType[]
+> = {
+  [DataProvider.S3]: [
+    DataConnectionAuthenticationType.S3AccessKey,
+    DataConnectionAuthenticationType.S3WebIdentityRole,
+    DataConnectionAuthenticationType.S3ECSTaskRole,
+    DataConnectionAuthenticationType.S3Local,
+  ],
+  [DataProvider.Azure]: [
+    DataConnectionAuthenticationType.AzureWorkloadIdentity,
+    DataConnectionAuthenticationType.AzureSasToken,
+  ],
+  [DataProvider.GCP]: [DataConnectionAuthenticationType.GcpWorkloadIdentity],
+};
+
+/**
+ * The connection object shape. Exported separately from {@link DataConnectionSchema}
+ * because object-only operations (`.omit()`, OpenAPI registration) need the
+ * underlying `ZodObject`, which the cross-field `superRefine` below wraps into a
+ * `ZodEffects`.
+ */
+export const DataConnectionObjectSchema = z
   .object({
     data_connection_id: z
       .string()
@@ -264,5 +301,27 @@ export const DataConnectionSchema = z
     authentication: z.optional(DataConnectionAuthenticationSchema),
   })
   .openapi("DataConnection");
+
+/**
+ * Full data connection schema: the object shape plus the cross-field check that
+ * `authentication.type` is valid for `details.provider`. Use this for parsing/
+ * validating whole connections; use {@link DataConnectionObjectSchema} when you
+ * need `ZodObject` operations such as `.omit()`.
+ */
+export const DataConnectionSchema = DataConnectionObjectSchema.superRefine(
+  (connection, ctx) => {
+    const { authentication, details } = connection;
+    if (!authentication) return;
+    if (
+      !PROVIDER_AUTH_TYPES[details.provider].includes(authentication.type)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["authentication", "type"],
+        message: `Authentication type "${authentication.type}" is not valid for provider "${details.provider}"`,
+      });
+    }
+  }
+);
 
 export type DataConnection = z.infer<typeof DataConnectionSchema>;


### PR DESCRIPTION
Addresses the three non-blocking review nits flagged on #332 ([review comment](https://github.com/source-cooperative/source.coop/pull/332#issuecomment-4713144724)). All three were still present **verbatim on `main`** — the federation schema landed but the nits were never picked up.

## Fixes

1. **Provider ↔ auth-type cross-validation** (`src/types/data-connection.ts`)
   A discriminated union can't express a cross-field constraint, so a `provider: "gcp"` connection paired with `authentication: { type: "s3_web_identity_role" }` validated cleanly. Added a `superRefine` on the full connection, driven by a `PROVIDER_AUTH_TYPES` allow-map. It only runs when `authentication` is present (omitted ⇒ unsigned — unchanged).
   - The object schema is now exported separately as `DataConnectionObjectSchema` because `.omit()` and OpenAPI registration need the underlying `ZodObject` (the `superRefine` wraps it into a `ZodEffects`). The two `.omit({ authentication: true })` sanitization sites and the OpenAPI generator were updated accordingly; the `.parse()` paths (create/update) now get the cross-field check.

2. **`IAM_ROLE_ARN_REGEX` tightened**
   Replaced the permissive `.+` role-name tail with the characters AWS actually allows (`[A-Za-z0-9+=,.@/_-]+`), so a malformed ARN (e.g. a role name containing a space) is rejected at parse time instead of failing later at `AssumeRoleWithWebIdentity`.

3. **GCP `service_account` domain**
   Now requires `.iam.gserviceaccount.com` (the user-managed SA domain used for Workload Identity Federation) rather than just `.gserviceaccount.com`.

## Tests
`src/types/data-connection.test.ts` — new `provider ↔ authentication cross-validation` describe block (accepts valid pairings, rejects `gcp`+S3 and `s3`+GCP, allows no-auth), plus extended ARN (space / invalid char) and SA (missing `.iam.`) rejection cases.

Typecheck + the data-connection suite (27 tests) green. No fixtures violate the new pairing rule, so the mock loader is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)