### PR TITLE
feat(products): deactivate products — form toggle, admin-only viewing, API 404s others

### DIFF
--- a/src/app/(app)/[account_id]/[product_id]/(product)/[[...path]]/layout.tsx
+++ b/src/app/(app)/[account_id]/[product_id]/(product)/[[...path]]/layout.tsx
@@ -19,7 +19,8 @@ import { isAuthorized } from "@/lib/api/authz";
 import { dataConnectionsTable, productsTable } from "@/lib/clients/database";
 import { productUrl } from "@/lib/urls";
 import { Actions } from "@/types/shared";
-import { Box, Card, Flex } from "@radix-ui/themes";
+import { Box, Callout, Card, Flex } from "@radix-ui/themes";
+import { ExclamationTriangleIcon } from "@radix-ui/react-icons";
 import { getPendingInvitation } from "@/lib/actions/memberships";
 import { ProductSchemaMetadata } from "@/components/features/products/ProductSchemaMetadata";
 import { getAuthorizedProduct } from "./data";
@@ -59,6 +60,21 @@ export default async function ProductLayout({
   return (
     <>
       <ProductSchemaMetadata product={product} />
+      {/* Deactivated products are visible only to admins (backend authz 404s
+          everyone else) — make that state unmistakable. */}
+      {product.disabled && (
+        <Box mt="4">
+          <Callout.Root color="amber" role="alert">
+            <Callout.Icon>
+              <ExclamationTriangleIcon />
+            </Callout.Icon>
+            <Callout.Text>
+              This product is deactivated. It is hidden from everyone except
+              administrators.
+            </Callout.Text>
+          </Callout.Root>
+        </Box>
+      )}
       {/* Show pending invitation banner if exists */}
       {pendingInvitation && (
         <PendingInvitationBanner

--- a/src/app/(app)/[account_id]/[product_id]/(product)/[[...path]]/page.test.tsx
+++ b/src/app/(app)/[account_id]/[product_id]/(product)/[[...path]]/page.test.tsx
@@ -79,6 +79,7 @@ import { readProxyCredentials } from "@/lib/services/proxy-credentials-read";
 import { getStorageClient } from "@/lib/clients/storage";
 import { ProductDataUnavailable } from "@/components/features/products/ProductDataUnavailable";
 import { DirectoryList } from "@/components/features/products/object-browser/DirectoryList";
+import { ProxyCredentialsGate } from "@/components/features/products/ProxyCredentialsGate";
 import { S3ServiceException } from "@aws-sdk/client-s3";
 
 describe("Product Page Metadata", () => {
@@ -270,6 +271,49 @@ describe("ProductPathPage proxy AccessDenied handling", () => {
         }),
       }),
     ).rejects.toThrow("proxy exploded");
+  });
+});
+
+describe("ProductPathPage authenticated-read gate for deactivated products", () => {
+  beforeEach(() => {
+    (getPageSession as jest.Mock).mockResolvedValue({ identity_id: "admin-1" });
+    (isAuthorized as jest.Mock).mockReturnValue(true);
+    // No cached proxy credentials — anonymous client.
+    (readProxyCredentials as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("routes a deactivated product through ProxyCredentialsGate regardless of visibility", async () => {
+    // A disabled product is reachable only by admins, and the proxy won't serve
+    // its data anonymously — even a *public* disabled product must mint signed
+    // credentials rather than attempt an anonymous read.
+    (productsTable.fetchById as jest.Mock).mockResolvedValue({
+      product_id: "test-product",
+      visibility: "public",
+      disabled: true,
+      metadata: { primary_mirror: "primary", mirrors: {} },
+      account: { account_id: "test-account", name: "Test Account" },
+    });
+    const listObjects = jest.fn();
+    (getStorageClient as jest.Mock).mockResolvedValue({
+      listObjects,
+      getObjectInfo: jest.fn(),
+    });
+
+    const element = await ProductPathPage({
+      params: Promise.resolve({
+        account_id: "test-account",
+        product_id: "test-product",
+        path: [],
+      }),
+    });
+
+    expect(element.type).toBe(ProxyCredentialsGate);
+    // Never attempted an anonymous listing.
+    expect(listObjects).not.toHaveBeenCalled();
   });
 });
 

--- a/src/app/(app)/[account_id]/[product_id]/(product)/[[...path]]/page.tsx
+++ b/src/app/(app)/[account_id]/[product_id]/(product)/[[...path]]/page.tsx
@@ -46,9 +46,16 @@ export default async function ProductPathPage({ params }: PageProps) {
   // product.
   const product = await getAuthorizedProduct(account_id, product_id);
 
+  // A deactivated (disabled) product is reachable here only by an admin — backend
+  // authz 404s everyone else — and the data proxy won't serve its objects to an
+  // anonymous reader. So read its data with signed credentials regardless of
+  // visibility, taking the same gate-and-mint path a restricted product takes.
+  const needsAuthenticatedRead =
+    product.visibility === "restricted" || product.disabled;
+
   // Read the user's cached proxy credentials once for this request: used both to
   // build the (signed-or-anonymous) storage client and, below, to decide whether
-  // a restricted product needs the credential gate. Build one storage client and
+  // the product needs the credential gate. Build one storage client and
   // reuse it for both the file-detection HEAD and the directory listing.
   const creds = await readProxyCredentials();
   // creds is already resolved here; `?? null` passes an explicit "none" so
@@ -120,7 +127,7 @@ export default async function ProductPathPage({ params }: PageProps) {
   // restricted product with no fresh cookie, an authenticated user is sent
   // through ProxyCredentialsGate, which mints (in an action) and refreshes the
   // page so this render then finds the credentials.
-  if (!creds && product.visibility === "restricted") {
+  if (!creds && needsAuthenticatedRead) {
     return <ProxyCredentialsGate />;
   }
 
@@ -151,7 +158,7 @@ export default async function ProductPathPage({ params }: PageProps) {
       prefix: s3Prefix,
     });
   } catch (error) {
-    if (isAccessDeniedError(error) && product.visibility === "restricted") {
+    if (isAccessDeniedError(error) && needsAuthenticatedRead) {
       LOGGER.warn("Proxy denied a signed read for an authorized viewer", {
         operation: "ProductPathPage",
         context: "directory listing",

--- a/src/app/api/v1/products/[account_id]/[repository_id]/route.test.ts
+++ b/src/app/api/v1/products/[account_id]/[repository_id]/route.test.ts
@@ -125,6 +125,30 @@ describe("/api/v1/products/[account_id]/[repository_id]", () => {
       });
     });
 
+    test("returns 404 (not 401) for a deactivated product when not permitted", async () => {
+      (productsTable.fetchById as jest.Mock).mockResolvedValue({
+        ...mockRepository,
+        disabled: true,
+      });
+
+      const request = new NextRequest(
+        "http://localhost/api/v1/products/test-account/test-repo"
+        // No Authorization header = not permitted to view
+      );
+      const response = await GET(request, {
+        params: Promise.resolve({
+          account_id: "test-account",
+          repository_id: "test-repo",
+        }),
+      });
+
+      expect(response.status).toBe(404);
+      const responseData = await response.json();
+      expect(responseData).toEqual({
+        error: "Repository with ID test-account/test-repo not found",
+      });
+    });
+
   });
 
   describe("org account authenticated via OIDC", () => {

--- a/src/app/api/v1/products/[account_id]/[repository_id]/route.ts
+++ b/src/app/api/v1/products/[account_id]/[repository_id]/route.ts
@@ -64,6 +64,17 @@ export async function GET(
       );
     }
     if (!isAuthorized(session, repository, Actions.GetRepository)) {
+      // A deactivated product should be indistinguishable from a missing one
+      // for anyone not permitted to view it: return 404 instead of a 401 that
+      // would leak its existence.
+      if (repository.disabled) {
+        return NextResponse.json(
+          {
+            error: `Repository with ID ${account_id}/${repository_id} not found`,
+          },
+          { status: StatusCodes.NOT_FOUND },
+        );
+      }
       // Distinguish the three ways this 401 happens: no session at all (the
       // OIDC token failed to verify or its subject didn't resolve — see the
       // authenticateWithOidcToken warnings) vs. a resolved session that simply

--- a/src/components/features/products/ProductCreationForm.tsx
+++ b/src/components/features/products/ProductCreationForm.tsx
@@ -121,6 +121,11 @@ export function ProductCreationForm({
     isEditMode ? product.visibility : allowedVisibilities[0]
   );
 
+  // Active/deactivated toggle (edit mode only — new products start active).
+  const [disabled, setDisabled] = useState<boolean>(
+    isEditMode ? product.disabled : false
+  );
+
   // The currently selected visibility must always be selectable, even if it
   // falls outside the connection's allowed set (e.g. legacy data drift).
   const visibilityOptions = allowedVisibilities.includes(visibility)
@@ -274,6 +279,27 @@ export function ProductCreationForm({
       value: visibility,
       onValueChange: (value) => setVisibility(value as ProductVisibility),
     },
+    // Activation toggle (edit mode only). Deactivating hides the product
+    // everywhere; only an admin can reactivate it afterwards.
+    ...(isEditMode
+      ? ([
+          {
+            label: "Status",
+            name: "disabled" as keyof Product,
+            type: "select",
+            required: true,
+            description:
+              "A deactivated product is inaccessible via the data.source.coop API and hidden from the source.coop UI for everyone except administrators. Reactivating it afterwards requires a Source Cooperative administrator.",
+            options: [
+              { value: "false", label: "Active" },
+              { value: "true", label: "Deactivated" },
+            ],
+            controlled: true,
+            value: String(disabled),
+            onValueChange: (value) => setDisabled(value === "true"),
+          },
+        ] as FormField<Product>[])
+      : []),
   ];
 
   return (

--- a/src/components/features/products/ProductCreationForm.tsx
+++ b/src/components/features/products/ProductCreationForm.tsx
@@ -269,7 +269,7 @@ export function ProductCreationForm({
       required: true,
       description: connectionMissing
         ? "This product's data connection could not be found, so its visibility can't be changed."
-        : "Your product's visibility",
+        : "Your product's visibility. The available options depend on the product's primary data connection.",
       options: visibilityOptions.map((value) => ({
         value,
         label: VISIBILITY_LABELS[value],
@@ -289,7 +289,7 @@ export function ProductCreationForm({
             type: "select",
             required: true,
             description:
-              "A deactivated product is inaccessible via the data.source.coop API and hidden from the source.coop UI for everyone except administrators. Reactivating it afterwards requires a Source Cooperative administrator.",
+              "A deactivated product is inaccessible via the data.source.coop API and hidden from the source.coop UI for everyone except administrators. This does not delete the product's data — it only makes it unavailable. Reactivating it afterwards requires a Source Cooperative administrator.",
             options: [
               { value: "false", label: "Active" },
               { value: "true", label: "Deactivated" },

--- a/src/lib/actions/products.test.ts
+++ b/src/lib/actions/products.test.ts
@@ -305,4 +305,32 @@ describe("updateProduct", () => {
     expect(dataConnectionsTable.fetchById).not.toHaveBeenCalled();
     expect(productsTable.update).toHaveBeenCalledTimes(1);
   });
+
+  test("deactivates a product when disabled=true is submitted", async () => {
+    (productsTable.fetchById as jest.Mock).mockResolvedValue(currentProduct());
+
+    const result = await updateProduct(
+      undefined,
+      buildUpdateFormData({ visibility: "public", disabled: "true" })
+    );
+
+    expect(result.success).toBe(true);
+    const updated = (productsTable.update as jest.Mock).mock.calls[0][0];
+    expect(updated.disabled).toBe(true);
+  });
+
+  test("reactivates a product when disabled=false is submitted", async () => {
+    (productsTable.fetchById as jest.Mock).mockResolvedValue(
+      currentProduct({ disabled: true })
+    );
+
+    const result = await updateProduct(
+      undefined,
+      buildUpdateFormData({ visibility: "public", disabled: "false" })
+    );
+
+    expect(result.success).toBe(true);
+    const updated = (productsTable.update as jest.Mock).mock.calls[0][0];
+    expect(updated.disabled).toBe(false);
+  });
 });

--- a/src/lib/actions/products.ts
+++ b/src/lib/actions/products.ts
@@ -322,6 +322,13 @@ export async function updateProduct(
     const title = formData.get("title") as string;
     const description = formData.get("description") as string;
     const visibility = formData.get("visibility") as ProductVisibility;
+    // Activation toggle. The select submits "true"/"false"; absent (e.g. an
+    // older form) leaves the current value untouched. Note: authorization above
+    // already blocks non-admins from updating an already-disabled product, so
+    // reactivation is admin-only — by design, disabled products are inaccessible.
+    const disabledRaw = formData.get("disabled");
+    const disabled =
+      disabledRaw === null ? currentProduct.disabled : disabledRaw === "true";
 
     // Enforce the connection's allowed visibilities when the visibility is
     // being changed. The edit form only offers permitted options, but the
@@ -372,6 +379,7 @@ export async function updateProduct(
       title: title || currentProduct.title,
       description: description || currentProduct.description,
       visibility: visibility || currentProduct.visibility,
+      disabled,
       updated_at: new Date().toISOString(),
     };
 

--- a/src/lib/clients/database/products.ts
+++ b/src/lib/clients/database/products.ts
@@ -261,6 +261,7 @@ export class ProductsTable extends BaseTable {
         ":visibility": product.visibility,
         ":metadata": product.metadata,
         ":search_text": this.buildSearchText(product),
+        ":disabled": product.disabled,
       };
       if (opts?.expectedUpdatedAt) {
         values[":expected_updated_at"] = opts.expectedUpdatedAt;
@@ -273,7 +274,7 @@ export class ProductsTable extends BaseTable {
             account_id: product.account_id,
           },
           UpdateExpression:
-            "SET title = :title, description = :description, updated_at = :updated_at, visibility = :visibility, metadata = :metadata, search_text = :search_text",
+            "SET title = :title, description = :description, updated_at = :updated_at, visibility = :visibility, metadata = :metadata, search_text = :search_text, disabled = :disabled",
           ...(opts?.expectedUpdatedAt
             ? { ConditionExpression: "updated_at = :expected_updated_at" }
             : {}),


### PR DESCRIPTION
## What

End-to-end support for **deactivating a product**, plus the access changes that make a deactivated product behave consistently everywhere: a deactivated product is **inaccessible via the `data.source.coop` API** and **hidden from the `source.coop` UI** for everyone except administrators.

Three parts:

1. **Deactivate from the product edit form** — a new *Status* selector (Active / Deactivated) shows the product's current activation state and lets an owner deactivate it. The field describes the consequences. The change is persisted through `updateProduct` and the products table's update expression.
2. **Admins can still view a deactivated product** — with a clear amber warning, reading its data through authenticated (signed) proxy credentials regardless of visibility.
3. **The API hides deactivated products** — `GET /api/v1/products/{account}/{repository}` returns `404` (not `401`) to anyone not permitted to view a deactivated product, so its existence isn't leaked.

## Why

The backend authz model already treats a disabled product as inaccessible to non-admins (`getRepository`/`listRepository`/`putRepository` in `authz.ts` short-circuit on `product.disabled`), and admins bypass that check. The pieces missing were: a way to actually flip the flag from the UI; a frontend that reads a deactivated product's data with credentials (the proxy refuses anonymous reads, so admins saw a broken page); and an API response that doesn't leak a deactivated product's existence with a `401`.

## Changes

**Deactivate from the form**
- **`ProductCreationForm.tsx`** — edit-mode-only *Status* selector (Active / Deactivated), controlled by a `disabled` state initialized from the product. Its description states that a deactivated product is inaccessible via the `data.source.coop` API and hidden from the `source.coop` UI for all but admins.
- **`actions/products.ts`** — `updateProduct` parses the submitted `disabled` value (absent ⇒ keep current) and includes it in the update.
- **`clients/database/products.ts`** — `update()` now writes `disabled` in the `SET` expression.
- **`actions/products.test.ts`** — new tests covering deactivate (`disabled=true`) and reactivate (`disabled=false`) persistence.

**Admin viewing (read side, frontend)**
- **`page.tsx`** — `needsAuthenticatedRead = visibility === "restricted" || product.disabled`, used for both the credential-gate decision and the AccessDenied fallback. A deactivated product mints signed proxy credentials and reads authenticated, regardless of visibility.
- **`layout.tsx`** — amber `role="alert"` Callout shown when `product.disabled`, on every product sub-path.
- **`page.test.tsx`** — deactivated *public* product with no creds routes to `ProxyCredentialsGate` and never attempts an anonymous listing.

**API hides deactivated products (read side, API)**
- **`api/v1/products/[account_id]/[repository_id]/route.ts`** — return `404` instead of `401` for a deactivated product when the caller isn't permitted, so it's indistinguishable from a missing product.
- **`route.test.ts`** — new test asserting the `404`.

## Authz note

Deactivation is **non-admin-irreversible by design**: existing authz already blocks non-admins from updating an *already-disabled* product, so once deactivated only an admin can reactivate it (admins bypass the `disabled` check). The form's help text calls this out.

## Verification

- `tsc --noEmit` ✅ (0 errors)
- lint clean on changed files (only pre-existing `any` warnings) ✅
- `products` action + DB client suites: 19/19 pass (incl. new deactivate/reactivate cases) ✅
- product page test suite passes (incl. admin-view case) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
