### PR TITLE
fix(forms): opt out of React's auto form-reset so controlled fields don't flash

### DIFF
--- a/src/components/core/DynamicForm.tsx
+++ b/src/components/core/DynamicForm.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import React, { useActionState } from "react";
+import React, { useActionState, startTransition } from "react";
 import { Button, Text, Flex } from "@radix-ui/themes";
-import Form from "next/form";
 import { useRouter } from "next/navigation";
 
 export interface FormField<T extends Record<string, any>> {
@@ -98,6 +97,21 @@ export function DynamicForm<T extends Record<string, any>>({
     }
   };
 
+  // Dispatch the action from onSubmit (in a transition) rather than via the
+  // form's `action` prop. React automatically resets a form after an `action`
+  // submission, and that reset incorrectly snaps controlled <select>/checkbox
+  // fields back to their first option/default for a frame before re-applying
+  // the controlled value (facebook/react#31695). Dispatching from onSubmit is
+  // the React-maintainer-recommended opt-out:
+  // https://github.com/facebook/react/issues/29034#issuecomment-2143595195
+  // Handling submit ourselves keeps controlled fields' values; `pending` from
+  // useActionState still tracks the in-flight action.
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    startTransition(() => formAction(formData));
+  };
+
   // Call onSuccess when form submission is successful
   React.useEffect(() => {
     if (state.success && onSuccess) {
@@ -117,7 +131,7 @@ export function DynamicForm<T extends Record<string, any>>({
   }, [state.success, state.redirectTo, router]);
 
   return (
-    <Form action={formAction} className={className}>
+    <form onSubmit={handleSubmit} className={className}>
       {/* Hidden fields */}
       {Object.entries(hiddenFields).map(([name, value]) => (
         <input key={name} type="hidden" name={name} value={value} />
@@ -273,6 +287,6 @@ export function DynamicForm<T extends Record<string, any>>({
           </Flex>
         )}
       </Flex>
-    </Form>
+    </form>
   );
 }


### PR DESCRIPTION
## What

Fixes the Status field flashing back to **"Active"** for a frame after you deactivate a product and save (it then settles on "Deactivated"). Fixes it at the form-engine level, so it also covers the Visibility select and any other controlled field in any `DynamicForm`.

## Why

React automatically resets a `<form>` after an `action`-prop submission (`useActionState`). That reset has a known bug: it snaps **controlled** `<select>`/checkbox fields back to their first option/default for a frame before re-applying the controlled value. So the Status select briefly showed its first option, "Active." The **uncontrolled** title/description fields reset to their just-submitted value, which is why they never flashed.

- [facebook/react #29034 — opt out of automatic form reset for Form Actions](https://github.com/facebook/react/issues/29034) (the maintainer's recommended `onSubmit` opt-out — what this PR uses)
- [facebook/react #31695 — controlled inputs reset by form submission](https://github.com/facebook/react/issues/31695)
- [vercel/next.js Discussion #81393 — controlled select loses value after submit with useActionState](https://github.com/vercel/next.js/discussions/81393)

## Change

**`DynamicForm.tsx`** — dispatch the action from `onSubmit` in a transition (`startTransition(() => formAction(formData))`) instead of via the form's `action` prop. That's the React-maintainer-recommended way to opt out of the automatic reset, so controlled fields keep their value. `pending` from `useActionState` still tracks the in-flight action. Drops `next/form` (only adds navigation/prefetch behavior these mutation forms don't use).

One engine-level change fixes the whole class — Status, Visibility, and every other controlled field across all `DynamicForm`-based forms.

## Notes

- Supersedes earlier attempts in this PR (a `router.refresh()` band-aid built on a wrong "client Router Cache" diagnosis, then making just the Status field uncontrolled). The `onSubmit` opt-out is the actual root-cause fix and is cleaner — it keeps fields controlled and fixes them all at once.
- `AccountFlagsForm` has a hand-rolled workaround for this same reset bug; it's now redundant and can be removed in a follow-up.
- Not unit-tested at the component level — `useActionState` (React 19) doesn't render under this repo's jest/jsdom setup. Action-layer tests are unaffected (36/36); the flash is verified by hand.

Follow-up to #372 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
