### PR TITLE
feat(data-connection): derive federated cache_level from connection owner (#326)

### DIFF
--- a/src/lib/api/sanitize-data-connection.test.ts
+++ b/src/lib/api/sanitize-data-connection.test.ts
@@ -93,14 +93,27 @@ describe("sanitizeDataConnection", () => {
     ).toBeUndefined();
   });
 
-  test("keeps secret-less auth when the caller may view the config", () => {
+  test("keeps secret-less auth (with derived cache_level) when viewable", () => {
     const c = conn({
       allowed_visibilities: [ProductVisibility.Public],
       authentication: roleAuth as never,
     });
+    // Unowned ⇒ Source-managed shared connection ⇒ system-level caching.
     expect(
       sanitizeDataConnection(c, sessions["anonymous"]).authentication
-    ).toEqual(roleAuth);
+    ).toEqual({ ...roleAuth, cache_level: "system" });
+  });
+
+  test("derives cache_level=product for an owned federated connection", () => {
+    const c = conn({
+      allowed_visibilities: [ProductVisibility.Restricted],
+      owner: "acme",
+      authentication: roleAuth as never,
+    });
+    expect(sanitizeDataConnection(c, memberOfAcme).authentication).toEqual({
+      ...roleAuth,
+      cache_level: "product",
+    });
   });
 
   test("strips secret-less auth when the caller may NOT view the config", () => {

--- a/src/lib/api/sanitize-data-connection.ts
+++ b/src/lib/api/sanitize-data-connection.ts
@@ -1,12 +1,37 @@
 import {
   Actions,
   DataConnection,
+  DataConnectionAuthenticationType,
+  DataConnectionCacheLevel,
   DataConnectionObjectSchema,
   DataConnectionSchema,
   isSecretBearingAuth,
   UserSession,
 } from "@/types";
 import { canViewDataConnectionConfig, isAuthorized } from "./authz";
+
+/**
+ * The proxy's federated-credential cache granularity is derived, not stored:
+ * an unowned connection is the Source-managed shared one (~99% of products), so
+ * it caches one credential for the whole connection (`system`); an owned
+ * connection caches per-product (`product`, always safe). Attached to the
+ * federated `authentication` the proxy reads; a no-op for every other auth type.
+ */
+function withDerivedCacheLevel(connection: DataConnection): DataConnection {
+  const auth = connection.authentication;
+  if (auth?.type !== DataConnectionAuthenticationType.S3WebIdentityRole) {
+    return connection;
+  }
+  return {
+    ...connection,
+    authentication: {
+      ...auth,
+      cache_level: connection.owner
+        ? DataConnectionCacheLevel.Product
+        : DataConnectionCacheLevel.System,
+    },
+  };
+}
 
 /**
  * Redact a data connection's `authentication` for a read response.
@@ -28,7 +53,7 @@ export function sanitizeDataConnection(
   if (
     isAuthorized(principal, connection, Actions.ViewDataConnectionCredentials)
   ) {
-    return DataConnectionSchema.parse(connection);
+    return withDerivedCacheLevel(DataConnectionSchema.parse(connection));
   }
 
   const auth = connection.authentication;
@@ -38,7 +63,7 @@ export function sanitizeDataConnection(
     canViewDataConnectionConfig(principal, connection);
 
   if (keepSecretlessConfig) {
-    return DataConnectionSchema.parse(connection);
+    return withDerivedCacheLevel(DataConnectionSchema.parse(connection));
   }
 
   return DataConnectionObjectSchema.omit({ authentication: true }).parse(

--- a/src/types/data-connection.ts
+++ b/src/types/data-connection.ts
@@ -132,14 +132,34 @@ export const AzureSasTokenAuthenticationSchema = z
 const IAM_ROLE_ARN_REGEX = /^arn:aws[a-z-]*:iam::\d{12}:role\/[A-Za-z0-9+=,.@/_-]+$/;
 
 /**
+ * Granularity of the proxy's federated-credential cache for this connection —
+ * it keys the cache + single-flight lock, *not* the OIDC subject (which is
+ * always product-grained). Not stored: it's derived from connection ownership
+ * at exposure time (see `sanitizeDataConnection`) — unowned (Source-managed
+ * shared connection) ⇒ `system` (one cached credential); owned ⇒ `product`
+ * (per-product, always safe). `account` exists for a future customer that needs
+ * account-level caching with an account-scoped trust policy; nothing emits it
+ * yet.
+ */
+export enum DataConnectionCacheLevel {
+  Product = "product",
+  Account = "account",
+  System = "system",
+}
+
+/**
  * V2 federated S3 access. `role_arn` is the customer-owned IAM role the proxy
  * assumes via `AssumeRoleWithWebIdentity`. It is *not* a secret (it's an ARN),
  * so it can be surfaced to the proxy without exposing credentials.
+ *
+ * `cache_level` is optional here only so the wire type can carry the derived
+ * value; it is never stored (see {@link DataConnectionCacheLevel}).
  */
 export const S3WebIdentityRoleAuthenticationSchema = z
   .object({
     type: z.literal(DataConnectionAuthenticationType.S3WebIdentityRole),
     role_arn: z.string().regex(IAM_ROLE_ARN_REGEX, "Invalid IAM role ARN"),
+    cache_level: z.optional(z.nativeEnum(DataConnectionCacheLevel)),
   })
   .openapi("S3WebIdentityRoleAuthentication");
 


### PR DESCRIPTION
Closes #326. Completes the **schema** half of the federated-backend-auth epic (#325).

## What changed (vs the first revision of this PR)

The [2026-06-06 design pivot](https://github.com/source-cooperative/source.coop/issues/325#issuecomment-4640367748) called for a per-connection `cache_level` controlling the proxy's federated-credential cache granularity. The first cut stored it as a 3-value enum on the connection. But nothing app-side *reads* the value — it's pure pass-through to the proxy — and the only two cases that exist map exactly onto whether the connection has an `owner`. So instead of storing it (plus owning a UI selector, edit-preservation, and a migration), it's **derived at the proxy-exposure boundary**:

| connection | derived `cache_level` | why |
|---|---|---|
| **unowned** (Source-managed shared, ~99% of products) | `system` | one cached credential, zero regression |
| **owned** (customer) | `product` | per-product, always safe |

This matches the `owner` field's existing documented semantics (*"absent = unowned (e.g. Source Cooperative-managed)"*).

## Changes (3 files, +62/-4)

- `data-connection.ts` — `DataConnectionCacheLevel` enum (the proxy wire vocabulary); `cache_level` is **optional/wire-only** on `S3WebIdentityRoleAuthenticationSchema` and never stored.
- `sanitize-data-connection.ts` — `withDerivedCacheLevel` attaches the derived value to the federated `authentication` the proxy reads; no-op for every other auth type.
- `sanitize-data-connection.test.ts` — unowned ⇒ `system`, owned ⇒ `product`.

## Notes
- The proxy contract is unchanged — it still receives `cache_level` in the federated config, just derived instead of stored.
- `account` level is reserved for a future customer needing account-level caching with an account-scoped trust policy; nothing emits it yet (YAGNI).
- No admin-UI selector and no model changes — so #328 sheds the `cache_level` selector it would otherwise owe.
- **Even-lazier alternative not taken:** the proxy already receives `owner`, so it could derive this itself with zero app code. Kept it app-side so the policy lives in one place and the proxy stays a dumb cache.

## Verification
- `npx tsc --noEmit` — clean
- `jest` data-connection types + actions + sanitize + api routes — 60 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)