### PR TITLE
feat(admin-ui): trust-policy sub-pattern preview on the federated connection edit page

### DIFF
--- a/src/components/core/CopyToClipboard.tsx
+++ b/src/components/core/CopyToClipboard.tsx
@@ -23,6 +23,7 @@ export function CopyToClipboard({ text }: CopyToClipboardProps) {
   return (
     <Tooltip content="Copy to clipboard">
       <IconButton
+        type="button"
         size="1"
         variant="ghost"
         color={copied ? "green" : "gray"}

--- a/src/components/features/data-connections/DataConnectionForm.tsx
+++ b/src/components/features/data-connections/DataConnectionForm.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import React, { useState, useActionState } from "react";
-import { Button, Text, Flex, Checkbox } from "@radix-ui/themes";
+import { Button, Text, Flex, Checkbox, Code } from "@radix-ui/themes";
+import { CopyToClipboard } from "@/components/core/CopyToClipboard";
 import Form from "next/form";
 import { useRouter } from "next/navigation";
 import {
@@ -195,6 +196,8 @@ export function DataConnectionForm({
     auth?.type === DataConnectionAuthenticationType.S3WebIdentityRole
       ? auth.role_arn
       : "";
+  // OIDC subject the proxy presents; owners match it in their IAM trust policy.
+  const subPattern = `scv1:conn:${dataConnection?.data_connection_id ?? ""}:*`;
   const initialTenantId =
     auth?.type === DataConnectionAuthenticationType.AzureWorkloadIdentity
       ? auth.tenant_id
@@ -678,23 +681,52 @@ export function DataConnectionForm({
         )}
 
         {authType === DataConnectionAuthenticationType.S3WebIdentityRole && (
-          <Field
-            label="Role ARN"
-            name="role_arn"
-            description="IAM role the proxy assumes via AssumeRoleWithWebIdentity (keyless federation). This is an ARN, not a secret."
-            errors={state.fieldErrors?.role_arn}
-          >
-            <input
-              type="text"
+          <>
+            <Field
+              label="Role ARN"
               name="role_arn"
-              required
-              placeholder="arn:aws:iam::123456789012:role/my-role"
-              defaultValue={
-                (state.data.get("role_arn") as string) || initialRoleArn
-              }
-              style={fieldStyle}
-            />
-          </Field>
+              description="IAM role the proxy assumes via AssumeRoleWithWebIdentity (keyless federation). This is an ARN, not a secret."
+              errors={state.fieldErrors?.role_arn}
+            >
+              <input
+                type="text"
+                name="role_arn"
+                required
+                placeholder="arn:aws:iam::123456789012:role/my-role"
+                defaultValue={
+                  (state.data.get("role_arn") as string) || initialRoleArn
+                }
+                style={fieldStyle}
+              />
+            </Field>
+
+            {mode === "edit" && (
+              <Field
+                label="Trust-policy subject"
+                name="sub_pattern"
+                description={
+                  <>
+                    The proxy presents this OIDC subject when assuming the role.
+                    In the role&apos;s trust policy, add a{" "}
+                    <Text weight="medium">StringLike</Text> condition on{" "}
+                    <Text weight="medium">data.source.coop:sub</Text> matching
+                    it, alongside{" "}
+                    <Text weight="medium">
+                      data.source.coop:aud = source-coop-data-proxy
+                    </Text>
+                    .
+                  </>
+                }
+              >
+                <Flex align="center" gap="2">
+                  <Code size="2" variant="soft">
+                    {subPattern}
+                  </Code>
+                  <CopyToClipboard text={subPattern} />
+                </Flex>
+              </Field>
+            )}
+          </>
         )}
 
         {authType === DataConnectionAuthenticationType.AzureWorkloadIdentity && (


### PR DESCRIPTION
Closes #328. Draft — visual review pending.

## What
Adds the one missing piece from #328: the **OIDC subject pattern** on the federated (`S3WebIdentityRole`) connection's **edit page**, so an owner can author their IAM role's trust policy without guessing.

Below the Role ARN field (edit mode only), it's rendered as a `Code` chip with a copy button:

```
scv1:conn:<connection-id>:*   [copy]
```

with help text: *"The proxy presents this OIDC subject when assuming the role. In the role's trust policy, add a `StringLike` condition on `data.source.coop:sub` matching it, alongside `data.source.coop:aud = source-coop-data-proxy`."*

## Why edit-only
The pattern needs the finalized connection id, and authoring the AWS trust policy is a post-creation task. Showing it only when viewing a created connection also keeps the code purely derived from the stored id — **no form state, no `onChange`, no placeholder.**

## Why this shape
The proxy mints a fixed, product-grained subject `scv1:conn:{connection_id}:{account_id}/{product_id}`. A `StringLike` on `scv1:conn:{id}:*` is the simplest correct trust-policy condition allowing that connection's products; the customer's bucket/permission policy is the finer cap. Pairs with the onboarding IaC in #330.

## Implementation notes
- Reuses the existing `CopyToClipboard` component rather than a new control.
- Gives that component's `IconButton` `type="button"` — it had no type, so inside a `<Form>` it would default to `submit` and submit the form on copy. Correct everywhere it's used.
- No `subject_scope`/`cache_level` selector — dropped from the design (fixed subject; cache granularity derived from `owner`).

## Verification
- `npx tsc --noEmit` — clean
- `npm run lint` — clean (touched files)
- ⚠️ No RTL test: this form's `useActionState` can't render under jest here. **Visual check still pending** — hence draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)