### PR TITLE
refactor(data-connections): remove unused field-less S3 auth types

### DIFF
--- a/fixtures/data-connections.json
+++ b/fixtures/data-connections.json
@@ -10,9 +10,6 @@
       "bucket": "dev.us-west-2.opendata.source.coop",
       "base_prefix": "",
       "region": "us-west-2"
-    },
-    "authentication": {
-      "type": "s3_ecs_task_role"
     }
   },
   {
@@ -26,9 +23,6 @@
       "bucket": "source-coop-data",
       "base_prefix": "",
       "region": "us-east-1"
-    },
-    "authentication": {
-      "type": "s3_local"
     }
   },
   {
@@ -79,9 +73,6 @@
       "bucket": "source-coop-subscription",
       "base_prefix": "premium/",
       "region": "eu-west-1"
-    },
-    "authentication": {
-      "type": "s3_ecs_task_role"
     }
   }
 ]

--- a/src/components/features/data-connections/DataConnectionForm.tsx
+++ b/src/components/features/data-connections/DataConnectionForm.tsx
@@ -32,10 +32,8 @@ const providerOptions: Array<{ value: DataProvider; label: string }> = [
 ];
 
 const s3AuthTypes = [
-  DataConnectionAuthenticationType.S3ECSTaskRole,
   DataConnectionAuthenticationType.S3AccessKey,
   DataConnectionAuthenticationType.S3WebIdentityRole,
-  DataConnectionAuthenticationType.S3Local,
 ];
 
 const azureAuthTypes = [
@@ -55,8 +53,6 @@ const AUTH_TYPE_LABELS: Record<DataConnectionAuthenticationType, string> = {
   [DataConnectionAuthenticationType.S3AccessKey]: "Access Key",
   [DataConnectionAuthenticationType.S3WebIdentityRole]:
     "Web Identity Role (federated)",
-  [DataConnectionAuthenticationType.S3ECSTaskRole]: "ECS Task Role",
-  [DataConnectionAuthenticationType.S3Local]: "Local",
   [DataConnectionAuthenticationType.AzureSasToken]: "SAS Token",
   [DataConnectionAuthenticationType.AzureWorkloadIdentity]:
     "Workload Identity (federated)",
@@ -69,14 +65,10 @@ const AUTH_TYPE_LABELS: Record<DataConnectionAuthenticationType, string> = {
 const AUTH_TYPE_DESCRIPTIONS: Partial<
   Record<DataConnectionAuthenticationType, string>
 > = {
-  [DataConnectionAuthenticationType.S3ECSTaskRole]:
-    "Use the proxy's ECS task role — no stored credentials.",
   [DataConnectionAuthenticationType.S3AccessKey]:
     "Static IAM access key and secret you provide.",
   [DataConnectionAuthenticationType.S3WebIdentityRole]:
     "Keyless: the proxy assumes a customer IAM role via web identity.",
-  [DataConnectionAuthenticationType.S3Local]:
-    "Local/dev credential chain — no stored credentials.",
   [DataConnectionAuthenticationType.AzureSasToken]:
     "A shared access signature token you provide.",
   [DataConnectionAuthenticationType.AzureWorkloadIdentity]:

--- a/src/components/features/data-connections/redact.ts
+++ b/src/components/features/data-connections/redact.ts
@@ -15,8 +15,6 @@ import {
 export type RedactedAuthentication =
   | { type: DataConnectionAuthenticationType.S3AccessKey }
   | { type: DataConnectionAuthenticationType.AzureSasToken }
-  | { type: DataConnectionAuthenticationType.S3ECSTaskRole }
-  | { type: DataConnectionAuthenticationType.S3Local }
   | { type: DataConnectionAuthenticationType.S3WebIdentityRole; role_arn: string }
   | {
       type: DataConnectionAuthenticationType.GcpWorkloadIdentity;
@@ -54,8 +52,6 @@ function redactAuthentication(
       };
     case DataConnectionAuthenticationType.S3AccessKey:
     case DataConnectionAuthenticationType.AzureSasToken:
-    case DataConnectionAuthenticationType.S3ECSTaskRole:
-    case DataConnectionAuthenticationType.S3Local:
       return { type: auth.type };
   }
 }

--- a/src/lib/actions/data-connections.test.ts
+++ b/src/lib/actions/data-connections.test.ts
@@ -271,7 +271,6 @@ describe("createDataConnection", () => {
       FORM_STATE,
       formDataFor({
         ...baseS3Fields,
-        auth_type: DataConnectionAuthenticationType.S3ECSTaskRole,
       })
     );
 
@@ -317,7 +316,6 @@ describe("createDataConnection", () => {
       FORM_STATE,
       formDataFor({
         ...baseS3Fields,
-        auth_type: DataConnectionAuthenticationType.S3ECSTaskRole,
       })
     );
 
@@ -336,7 +334,6 @@ describe("createDataConnection", () => {
       FORM_STATE,
       formDataFor({
         ...baseS3Fields,
-        auth_type: DataConnectionAuthenticationType.S3Local,
       })
     );
 
@@ -421,7 +418,6 @@ describe("updateDataConnection", () => {
       FORM_STATE,
       formDataFor({
         ...baseS3Fields,
-        auth_type: DataConnectionAuthenticationType.S3Local,
       })
     );
 
@@ -441,7 +437,6 @@ describe("updateDataConnection", () => {
       FORM_STATE,
       formDataFor({
         ...baseS3Fields,
-        auth_type: DataConnectionAuthenticationType.S3Local,
       })
     );
 

--- a/src/lib/actions/data-connections.ts
+++ b/src/lib/actions/data-connections.ts
@@ -466,10 +466,6 @@ function buildAuthenticationFromForm(
           (formData.get("sas_token") as string) || prev?.sas_token || "",
       };
     }
-    case DataConnectionAuthenticationType.S3ECSTaskRole:
-      return { type: DataConnectionAuthenticationType.S3ECSTaskRole };
-    case DataConnectionAuthenticationType.S3Local:
-      return { type: DataConnectionAuthenticationType.S3Local };
     default:
       return undefined;
   }

--- a/src/types/data-connection.ts
+++ b/src/types/data-connection.ts
@@ -90,21 +90,7 @@ export enum DataConnectionAuthenticationType {
    */
   AzureWorkloadIdentity = "azure_workload_identity",
   AzureSasToken = "az_sas_token",
-  S3ECSTaskRole = "s3_ecs_task_role",
-  S3Local = "s3_local",
 }
-
-export const S3LocalAuthenticationSchema = z
-  .object({
-    type: z.literal(DataConnectionAuthenticationType.S3Local),
-  })
-  .openapi("S3LocalAuthentication");
-
-export const S3ECSTaskRoleAuthenticationSchema = z
-  .object({
-    type: z.literal(DataConnectionAuthenticationType.S3ECSTaskRole),
-  })
-  .openapi("S3ECSTaskRoleAuthentication");
 
 export const S3AccessKeyAuthenticationSchema = z
   .object({
@@ -190,8 +176,6 @@ export const DataConnectionAuthenticationSchema = z
     GcpWorkloadIdentityAuthenticationSchema,
     AzureWorkloadIdentityAuthenticationSchema,
     AzureSasTokenAuthenticationSchema,
-    S3ECSTaskRoleAuthenticationSchema,
-    S3LocalAuthenticationSchema,
   ])
   .openapi("DataConnectionAuthentication");
 
@@ -266,8 +250,6 @@ const PROVIDER_AUTH_TYPES: Record<
   [DataProvider.S3]: [
     DataConnectionAuthenticationType.S3AccessKey,
     DataConnectionAuthenticationType.S3WebIdentityRole,
-    DataConnectionAuthenticationType.S3ECSTaskRole,
-    DataConnectionAuthenticationType.S3Local,
   ],
   [DataProvider.Azure]: [
     DataConnectionAuthenticationType.AzureWorkloadIdentity,
@@ -357,8 +339,6 @@ export function isSecretBearingAuth(
     case DataConnectionAuthenticationType.S3WebIdentityRole:
     case DataConnectionAuthenticationType.GcpWorkloadIdentity:
     case DataConnectionAuthenticationType.AzureWorkloadIdentity:
-    case DataConnectionAuthenticationType.S3ECSTaskRole:
-    case DataConnectionAuthenticationType.S3Local:
       return false;
     default:
       return true;


### PR DESCRIPTION
## What

Removes **both** field-less, no-credential S3 data-connection authentication types, which are no longer used:

- `s3_ecs_task_role` (`S3ECSTaskRole`) — "use the proxy's ECS task role"
- `s3_local` (`S3Local`) — "use the local/default AWS credential chain"

The default AWS credential chain already includes the ECS task role, so these overlapped; neither is referenced by anything that consumes connection auth.

## Changes

- **`src/types/data-connection.ts`** — drop both enum members, their `*AuthenticationSchema`s, their discriminated-union entries, the `S3` provider→auth pairings in `PROVIDER_AUTH_TYPES`, and the secret-less cases in `isSecretBearingAuth`.
- **`src/lib/actions/data-connections.ts`** — drop both `buildAuthenticationFromForm` cases.
- **`src/components/.../DataConnectionForm.tsx`** — drop the auth-type options, labels, and descriptions.
- **`src/components/.../redact.ts`** — drop the redaction union members and switch cases.
- **`fixtures/data-connections.json`** & **`src/lib/actions/data-connections.test.ts`** — the fixtures and tests that used these as field-less S3 auth now use **no authentication (unsigned)**.

## No capability lost

S3 still supports unsigned connections via the form's existing **"None (unsigned)"** option. The two remaining S3 auth types — access key and web identity role — both carry required fields, so nothing field-less is left to support.

## Verification

- `npm run type-check` ✅
- `npx jest src/lib/actions/data-connections.test.ts` — 20/20 ✅
- Full `jest` — 337/338; the one failure (`DropdownSection.integration.test.tsx`, a layout RTL test) is pre-existing and unrelated, confirmed failing on the un-modified tree.
- `npm run lint` — no new warnings in touched files ✅
- `git grep -i 's3_ecs_task_role\|s3_local'` — no references remain ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)