### PR TITLE
fix(data-connections): admin form-reset, redirect, and prefix-template handling

### DIFF
--- a/src/components/features/data-connections/DataConnectionForm.tsx
+++ b/src/components/features/data-connections/DataConnectionForm.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import React, { useState, useActionState } from "react";
+import React, { useState, useActionState, startTransition } from "react";
 import { Button, Text, Flex, Checkbox, Code } from "@radix-ui/themes";
 import { CopyToClipboard } from "@/components/core/CopyToClipboard";
-import Form from "next/form";
 import { useRouter } from "next/navigation";
 import {
   DataProvider,
@@ -219,8 +218,20 @@ export function DataConnectionForm({
   const withSecretHint = (base: string) =>
     mode === "edit" ? `${base} Leave blank to keep the current value.` : base;
 
+  // Dispatch the action from onSubmit (in a transition) rather than via the
+  // form's `action` prop. React auto-resets a form after an `action` submit,
+  // and that reset snaps controlled <select>/checkbox fields (auth_type,
+  // provider, read_only, visibilities) back to their first option/default —
+  // here auth_type stuck on "None" after save (facebook/react#31695). This is
+  // the maintainer-recommended opt-out; mirrors the DynamicForm fix (#373).
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    startTransition(() => formAction(formData));
+  };
+
   return (
-    <Form action={formAction}>
+    <form onSubmit={handleSubmit}>
       <Flex direction="column" gap="4">
         <Field
           label="Connection ID"
@@ -826,6 +837,6 @@ export function DataConnectionForm({
           </Flex>
         </Flex>
       </Flex>
-    </Form>
+    </form>
   );
 }

--- a/src/components/features/data-connections/DataConnectionForm.tsx
+++ b/src/components/features/data-connections/DataConnectionForm.tsx
@@ -290,8 +290,13 @@ export function DataConnectionForm({
               // failed submit instead of reverting to the stored value.
               state.data.has("prefix_template")
                 ? (state.data.get("prefix_template") as string)
-                : (dataConnection?.prefix_template ??
-                  "{{repository.account_id}}/{{repository.repository_id}}/")
+                : mode === "create"
+                  ? // Creating: pre-fill the default so admins don't retype it.
+                    "{{repository.account_id}}/{{repository.repository_id}}/"
+                  : // Editing: show the stored value, empty if it was cleared.
+                    // Don't fall back to the default, or a cleared prefix would
+                    // reappear on reload.
+                    (dataConnection?.prefix_template ?? "")
             }
             style={fieldStyle}
           />

--- a/src/components/features/data-connections/DeleteDataConnectionButton.tsx
+++ b/src/components/features/data-connections/DeleteDataConnectionButton.tsx
@@ -26,10 +26,12 @@ export function DeleteDataConnectionButton({
     success: false,
   });
 
-  // Navigate client-side back to the list once the deletion succeeds.
+  // Navigate client-side back to the list once the deletion succeeds. No
+  // router.refresh() — that refetches the *current* (now-deleted) connection's
+  // page and 404s before the push lands. The list is already revalidatePath'd
+  // server-side, so the push fetches it fresh.
   React.useEffect(() => {
     if (state.success && state.redirectTo) {
-      router.refresh();
       router.push(state.redirectTo);
     }
   }, [state.success, state.redirectTo, router]);

--- a/src/lib/actions/data-connections.test.ts
+++ b/src/lib/actions/data-connections.test.ts
@@ -131,7 +131,7 @@ describe("createDataConnection", () => {
     expect(mockTable.create).not.toHaveBeenCalled();
   });
 
-  test("creates an S3 access-key connection and redirects to the list", async () => {
+  test("creates an S3 access-key connection and redirects to the new connection", async () => {
     const result = await createDataConnection(
       FORM_STATE,
       formDataFor({
@@ -144,7 +144,7 @@ describe("createDataConnection", () => {
     );
 
     expect(result.success).toBe(true);
-    expect(result.redirectTo).toBe("/admin/data-connections");
+    expect(result.redirectTo).toBe("/admin/data-connections/my-connection");
     expect(mockTable.create).toHaveBeenCalledTimes(1);
     const created = mockTable.create.mock.calls[0][0];
     expect(created.read_only).toBe(true);

--- a/src/lib/actions/data-connections.ts
+++ b/src/lib/actions/data-connections.ts
@@ -102,13 +102,14 @@ export async function createDataConnection(
 
     // Navigate client-side (see FormState.redirectTo) so the shared admin layout
     // is refetched with the current session, rather than a server redirect()
-    // that leaves the client Router Cache stale.
+    // that leaves the client Router Cache stale. Land on the new connection's
+    // page rather than back on the list.
     return {
       fieldErrors: {},
       data: formData,
       message: "Data connection created successfully!",
       success: true,
-      redirectTo: adminDataConnectionsUrl(),
+      redirectTo: adminDataConnectionEditUrl(validated.data.data_connection_id),
     };
   } catch (error) {
     LOGGER.error("Error creating data connection", {

--- a/src/lib/actions/product-mirrors.test.ts
+++ b/src/lib/actions/product-mirrors.test.ts
@@ -156,6 +156,26 @@ describe("addProductMirror", () => {
     expect(result.message).toMatch(/modified by someone else/i);
   });
 
+  test("an empty prefix template mirrors at the root (no prefix)", async () => {
+    mockProductsTable.fetchById.mockResolvedValue(productWith({}, ""));
+    mockDataConnectionsTable.fetchById.mockResolvedValue({
+      data_connection_id: "conn-a",
+      details: { provider: "s3" },
+    } as DataConnection);
+
+    await addProductMirror(
+      FORM_STATE,
+      formDataFor({
+        account_id: "acct",
+        product_id: "prod",
+        connection_id: "conn-a",
+      })
+    );
+
+    const updated = mockProductsTable.update.mock.calls[0][0];
+    expect(updated.metadata.mirrors["conn-a"].prefix).toBe("");
+  });
+
   test("maps a GCP connection to the gcs storage type", async () => {
     mockProductsTable.fetchById.mockResolvedValue(productWith({}, ""));
     mockDataConnectionsTable.fetchById.mockResolvedValue({

--- a/src/lib/actions/product-mirrors.ts
+++ b/src/lib/actions/product-mirrors.ts
@@ -4,7 +4,7 @@ import { LOGGER } from "@/lib/logging";
 import { isAdmin } from "../api/authz";
 import { getPageSession } from "../api/utils";
 import { productsTable, dataConnectionsTable } from "../clients";
-import { DataProvider, ProductMirror } from "@/types";
+import { DataProvider, ProductMirror, resolveMirrorPrefix } from "@/types";
 import { FormState } from "@/components/core/DynamicForm";
 import { revalidatePath } from "next/cache";
 import { editProductDataConnectionsUrl } from "@/lib/urls";
@@ -90,12 +90,11 @@ export async function addProductMirror(
       };
     }
 
-    // An empty/undefined template means "no prefix" — the product mirrors at
-    // the bucket root (base_prefix). It's the admin's responsibility to avoid
-    // collisions when several products share a root-mirrored connection.
-    const prefix = (connection.prefix_template ?? "")
-      .replaceAll("{{repository.account_id}}", accountId)
-      .replaceAll("{{repository.repository_id}}", productId);
+    const prefix = resolveMirrorPrefix(
+      connection.prefix_template,
+      accountId,
+      productId
+    );
 
     const isFirst = Object.keys(product.metadata.mirrors).length === 0;
 

--- a/src/lib/actions/product-mirrors.ts
+++ b/src/lib/actions/product-mirrors.ts
@@ -90,11 +90,12 @@ export async function addProductMirror(
       };
     }
 
-    const prefix = connection.prefix_template
-      ? connection.prefix_template
-          .replaceAll("{{repository.account_id}}", accountId)
-          .replaceAll("{{repository.repository_id}}", productId)
-      : `${accountId}/${productId}/`;
+    // An empty/undefined template means "no prefix" — the product mirrors at
+    // the bucket root (base_prefix). It's the admin's responsibility to avoid
+    // collisions when several products share a root-mirrored connection.
+    const prefix = (connection.prefix_template ?? "")
+      .replaceAll("{{repository.account_id}}", accountId)
+      .replaceAll("{{repository.repository_id}}", productId);
 
     const isFirst = Object.keys(product.metadata.mirrors).length === 0;
 

--- a/src/lib/actions/products.test.ts
+++ b/src/lib/actions/products.test.ts
@@ -82,7 +82,10 @@ describe("createProduct", () => {
 
   test("builds mirror metadata from the selected data connection", async () => {
     (dataConnectionsTable.fetchById as jest.Mock).mockResolvedValue(
-      connection()
+      connection({
+        prefix_template:
+          "{{repository.account_id}}/{{repository.repository_id}}/",
+      })
     );
 
     const result = await createProduct(undefined, buildFormData());
@@ -98,6 +101,17 @@ describe("createProduct", () => {
     });
     expect(result.success).toBe(true);
     expect(result.redirectTo).toBeDefined();
+  });
+
+  test("a connection without a prefix template mirrors at the root", async () => {
+    (dataConnectionsTable.fetchById as jest.Mock).mockResolvedValue(
+      connection()
+    );
+
+    await createProduct(undefined, buildFormData());
+
+    const created = (productsTable.create as jest.Mock).mock.calls[0][0];
+    expect(created.metadata.mirrors["conn-x"].prefix).toBe("");
   });
 
   test("rejects a visibility not allowed by the data connection", async () => {

--- a/src/lib/actions/products.ts
+++ b/src/lib/actions/products.ts
@@ -9,6 +9,7 @@ import {
   type ProductCreationRequest,
   type ProductMirror,
   type ProductVisibility,
+  resolveMirrorPrefix,
 } from "@/types";
 import { getPageSession, LOGGER } from "@/lib";
 import { FormState } from "@/components/core/DynamicForm";
@@ -239,7 +240,11 @@ export async function createProduct(
           storage_type:
             STORAGE_TYPE_BY_PROVIDER[dataConnection.details.provider],
           connection_id: dataConnection.data_connection_id,
-          prefix: `${validatedFields.data.account_id}/${validatedFields.data.product_id}/`,
+          prefix: resolveMirrorPrefix(
+            dataConnection.prefix_template,
+            validatedFields.data.account_id,
+            validatedFields.data.product_id
+          ),
           is_primary: true,
         },
       },

--- a/src/types/data-connection.ts
+++ b/src/types/data-connection.ts
@@ -342,6 +342,25 @@ export const DataConnectionSchema = DataConnectionObjectSchema.superRefine(
 export type DataConnection = z.infer<typeof DataConnectionSchema>;
 
 /**
+ * The object-key prefix a product mirror receives on this connection.
+ * Substitutes the repository tokens in `prefix_template`; an empty/undefined
+ * template means "no prefix" — the product mirrors at the bucket root.
+ *
+ * Single source of truth: both product creation (`createProduct`) and attaching
+ * a connection later (`addProductMirror`) call this, so the two paths can't
+ * diverge on how a prefix is computed.
+ */
+export function resolveMirrorPrefix(
+  prefixTemplate: string | undefined,
+  accountId: string,
+  productId: string
+): string {
+  return (prefixTemplate ?? "")
+    .replaceAll("{{repository.account_id}}", accountId)
+    .replaceAll("{{repository.repository_id}}", productId);
+}
+
+/**
  * Whether an authentication variant carries a usable secret — and so must never
  * be returned by the read API (`sanitizeDataConnection` strips it for everyone;
  * such secrets are write-only). The V2 federation variants (web identity /


### PR DESCRIPTION
Five related fixes to the data-connection admin.

## 1. Auth Type select reverts to "None" after save

`DataConnectionForm` submitted via `<Form action={formAction}>` (`next/form`). React auto-resets a `<form>` after an `action`-prop submission, and that reset snaps **controlled** `<select>`/checkbox fields back to their first option ([facebook/react#31695](https://github.com/facebook/react/issues/31695)). Since the controlled `authType` state is unchanged across the post-action render, reconciliation skips re-writing the DOM, so the Authentication Type select stuck on "None" until a reload.

Same class fixed in #373 for `DynamicForm`; this form is bespoke and was missed. Fix: dispatch from `onSubmit` in a `startTransition` (the [maintainer-recommended opt-out](https://github.com/facebook/react/issues/29034#issuecomment-2143595195)), drop `next/form`. Also covers the controlled `provider` select and `read_only`/visibility checkboxes.

### Swept all other forms

| Form | Controlled user-editable fields? | Verdict |
|------|----------------------------------|---------|
| **DataConnectionForm** | Yes (`auth_type`/`provider` selects, checkboxes) | **Fixed here** |
| `AccountFlagsForm` | checkboxes (via `DynamicForm`) | Covered by #373; redundant `useEffect` workaround left for separate cleanup |
| `MembershipsTable` | No — hidden constant only | Safe |
| `DeleteDataConnectionButton` | No — hidden constant only | Safe |
| `ProductMirrorsManager` | No — hidden constants + one *uncontrolled* picker | Safe |

## 2. Create lands on the list instead of the new connection

`createDataConnection` returned `redirectTo: adminDataConnectionsUrl()`. Now redirects to `adminDataConnectionEditUrl(id)` — the newly created connection.

## 3. Delete 404s

`DeleteDataConnectionButton` did `router.refresh()` then `router.push()`. `router.refresh()` refetched the **current** (just-deleted) connection's page, which 404s before the push to the list lands. Dropped the refresh; the list is already `revalidatePath`'d server-side, so the push fetches it fresh.

## 4. Cleared prefix template reappears on reload

The Prefix Template field fell back to the hardcoded default (`{{repository.account_id}}/{{repository.repository_id}}/`) whenever the stored value was empty. Clearing the field and saving *does* persist correctly (empty → `undefined` → DynamoDB `REMOVE`), but on reload the form re-seeded the default, so it looked like the clear was ignored.

Fix: pre-fill the default only when `mode === "create"`; in edit mode show the stored value (empty if cleared).

## 5. Empty prefix template still forced a per-product prefix

Even with the template cleared, attaching a connection to a product still produced a prefix: the mirror prefix fell back to `accountId/productId/` whenever `prefix_template` was empty, so "cleared" and "the default" were indistinguishable at the mirror layer — there was no way to mirror a product at the bucket root.

Worse, this logic was **duplicated and divergent** across two paths: `addProductMirror` (attach later) and `createProduct` (initial mirror at creation). The first round only fixed `addProductMirror`, which is why a *newly created* product still got a prefix while *re-adding* the same connection didn't.

Fix: extract `resolveMirrorPrefix()` as the single source of truth and call it from both paths. An empty/undefined template now means **no prefix** — the product mirrors at `base_prefix` (bucket root); a template substitutes as before. Tradeoff: admins owning a root-mirrored connection are responsible for avoiding cross-product collisions; the old fallback prevented that implicitly.

## Verification

- `data-connections.test.ts`: 20/20 pass (create-redirect assertion updated; delete still redirects to the list).
- `product-mirrors.test.ts`: 11/11 pass (added "an empty prefix template mirrors at the root").
- `products.test.ts`: pass (added "a connection without a prefix template mirrors at the root"; existing build-mirror test now exercises template substitution).
- `tsc --noEmit` clean.
- Component-level reset behavior verified by hand — `useActionState` (React 19) doesn't render under this repo's jest/jsdom setup (same constraint noted in #373).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
