### PR TITLE
fix(api): return 200 on successful member invite

### DIFF
--- a/src/app/api/v1/accounts/[account_id]/members/route.test.ts
+++ b/src/app/api/v1/accounts/[account_id]/members/route.test.ts
@@ -1,0 +1,49 @@
+/** @jest-environment node */
+import { NextRequest } from "next/server";
+import { accountsTable, membershipsTable } from "@/lib/clients/database";
+import { getApiSession } from "@/lib/api/utils";
+import { isAuthorized } from "@/lib/api/authz";
+import { AccountType } from "@/types/account";
+import { MembershipRole } from "@/types";
+import { POST } from "./route";
+
+jest.mock("@/lib/clients/database", () => ({
+  accountsTable: { fetchById: jest.fn() },
+  membershipsTable: { create: jest.fn(), listByAccount: jest.fn() },
+}));
+jest.mock("@/lib/api/utils", () => ({ getApiSession: jest.fn() }));
+jest.mock("@/lib/api/authz", () => ({ isAuthorized: jest.fn() }));
+
+describe("POST /api/v1/accounts/[account_id]/members", () => {
+  afterEach(() => jest.resetAllMocks());
+
+  const validBody = { account_id: "invitee", role: MembershipRole.ReadData };
+
+  // Regression: a successful invite must return 200 with the created membership.
+  // The handler previously gated its only return on a `const success = false`,
+  // so a successful POST created the membership then fell through to undefined.
+  test("returns 200 and created membership on success", async () => {
+    (getApiSession as jest.Mock).mockResolvedValue({});
+    (accountsTable.fetchById as jest.Mock).mockResolvedValue({
+      account_id: "org",
+      type: AccountType.INDIVIDUAL,
+    });
+    (isAuthorized as jest.Mock).mockReturnValue(true);
+    (membershipsTable.listByAccount as jest.Mock).mockResolvedValue([]);
+    (membershipsTable.create as jest.Mock).mockImplementation((m) =>
+      Promise.resolve(m)
+    );
+
+    const req = {
+      json: () => Promise.resolve(validBody),
+    } as unknown as NextRequest;
+    const res = await POST(req, { params: Promise.resolve({ account_id: "org" }) });
+
+    expect(res?.status).toBe(200);
+    await expect(res?.json()).resolves.toMatchObject({
+      account_id: "invitee",
+      membership_account_id: "org",
+      state: "invited",
+    });
+  });
+});

--- a/src/app/api/v1/accounts/[account_id]/members/route.ts
+++ b/src/app/api/v1/accounts/[account_id]/members/route.ts
@@ -89,8 +89,6 @@ export async function POST(
         { status: StatusCodes.BAD_REQUEST }
       );
     }
-    let createdMembership: Membership | null = null;
-    const success = false;
     const membership: Membership = {
       ...membershipInvitation,
       membership_id: uuidv4(),
@@ -122,12 +120,10 @@ export async function POST(
         );
       }
     }
-    createdMembership = await membershipsTable.create(membership);
-    if (success) {
-      return NextResponse.json(createdMembership, {
-        status: StatusCodes.OK,
-      });
-    }
+    const createdMembership = await membershipsTable.create(membership);
+    return NextResponse.json(createdMembership, {
+      status: StatusCodes.OK,
+    });
   } catch (err: unknown) {
     const errorMessage =
       err instanceof Error ? err.message : "Internal server error";


### PR DESCRIPTION
## What

`POST /api/v1/accounts/{account_id}/members` gated its only success return on a `const success = false` that was never reassigned:

```ts
const success = false;
// ...
createdMembership = await membershipsTable.create(membership);
if (success) {            // always false
  return NextResponse.json(createdMembership, { status: 200 });
}
// falls through → returns undefined → Next.js responds 500
```

So a successful invite **wrote the membership to the database** and then returned nothing — Next.js turns a missing response into a 500. Callers saw a failure for a write that actually succeeded.

## Fix

- Drop the dead `success` flag and the unused `createdMembership` placeholder.
- Return the created membership directly after `create`.
- Add a node-env regression test (mirrors the sibling `api-keys/route.test.ts`) asserting the success path returns 200 with the created membership.

## Context

Flagged by the automated review on #369 as a pre-existing bug, not introduced by the dependency cleanup. Fixed here as a separate, focused PR so #369 (deps) and #370 (dead code) stay scoped.

`npm run type-check` clean · 40 suites / 333 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)