### PR TITLE
fix(data-connections): correct trust-policy aud to sts.amazonaws.com

### DIFF
--- a/src/components/features/data-connections/DataConnectionForm.tsx
+++ b/src/components/features/data-connections/DataConnectionForm.tsx
@@ -720,7 +720,7 @@ export function DataConnectionForm({
                     <Text weight="medium">data.source.coop:sub</Text> matching
                     it, alongside{" "}
                     <Text weight="medium">
-                      data.source.coop:aud = source-coop-data-proxy
+                      data.source.coop:aud = sts.amazonaws.com
                     </Text>
                     .
                   </>


### PR DESCRIPTION
The S3 web-identity role form hinted that the trust policy should check `data.source.coop:aud = source-coop-data-proxy`. That's wrong — for `AssumeRoleWithWebIdentity`, AWS STS is the token audience, so the condition must check `data.source.coop:aud = sts.amazonaws.com`.

One-line text fix in `DataConnectionForm.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)