### PR TITLE
feat(data-connections): account-owned data connections

### DIFF
--- a/src/app/(app)/admin/data-connections/[data_connection_id]/page.tsx
+++ b/src/app/(app)/admin/data-connections/[data_connection_id]/page.tsx
@@ -1,11 +1,11 @@
 import { Metadata } from "next";
 import { Suspense } from "react";
-import { Button, Flex, Heading, Text } from "@radix-ui/themes";
+import { Flex, Heading, Text } from "@radix-ui/themes";
 import { notFound } from "next/navigation";
-import { dataConnectionsTable, productsTable } from "@/lib/clients";
+import { dataConnectionsTable } from "@/lib/clients";
 import {
   DataConnectionForm,
-  DeleteDataConnectionButton,
+  DeleteConnectionControl,
 } from "@/components/features/data-connections";
 import { ConnectionUsage } from "@/components/features/data-connections/ConnectionUsage";
 import { toEditableDataConnection } from "@/components/features/data-connections/redact";
@@ -34,17 +34,9 @@ export default async function EditDataConnectionPage({
     <Flex direction="column" gap="4">
       <Flex justify="between" align="center">
         <Heading size="4">Edit Data Connection</Heading>
-        <Suspense
-          fallback={
-            <Button size="2" color="red" variant="soft" disabled>
-              Delete
-            </Button>
-          }
-        >
-          <DeleteConnectionControl
-            connectionId={dataConnection.data_connection_id}
-          />
-        </Suspense>
+        <DeleteConnectionControl
+          connectionId={dataConnection.data_connection_id}
+        />
       </Flex>
       <DataConnectionForm
         mode="edit"
@@ -61,22 +53,5 @@ export default async function EditDataConnectionPage({
         <ConnectionUsage connectionId={dataConnection.data_connection_id} />
       </Suspense>
     </Flex>
-  );
-}
-
-// Fetches the dependent-product count so the delete confirm can be disabled when
-// the connection is in use. The scan is request-deduped with <ConnectionUsage>,
-// so this adds no extra DB work; Suspense keeps it off the form's critical path.
-async function DeleteConnectionControl({
-  connectionId,
-}: {
-  connectionId: string;
-}) {
-  const products = await productsTable.listProductsByConnectionId(connectionId);
-  return (
-    <DeleteDataConnectionButton
-      dataConnectionId={connectionId}
-      productsInUse={products.length}
-    />
   );
 }

--- a/src/app/(app)/admin/data-connections/page.tsx
+++ b/src/app/(app)/admin/data-connections/page.tsx
@@ -1,9 +1,8 @@
 import { Metadata } from "next";
 import { dataConnectionsTable } from "@/lib/clients";
-import { Text, Table, Flex, Badge, Button, Heading } from "@radix-ui/themes";
-import { Link1Icon } from "@radix-ui/react-icons";
+import { Flex, Button, Heading } from "@radix-ui/themes";
 import Link from "next/link";
-import { DataProvider } from "@/types";
+import { DataConnectionsTable } from "@/components/features/data-connections";
 import {
   adminDataConnectionCreateUrl,
   adminDataConnectionEditUrl,
@@ -11,15 +10,6 @@ import {
 
 export const metadata: Metadata = {
   title: "Admin — Data connections",
-};
-
-const PROVIDER_BADGE: Record<
-  DataProvider,
-  { label: string; color: "orange" | "blue" | "green" }
-> = {
-  [DataProvider.S3]: { label: "S3", color: "orange" },
-  [DataProvider.Azure]: { label: "Azure", color: "blue" },
-  [DataProvider.GCP]: { label: "GCP", color: "green" },
 };
 
 export default async function DataConnectionsPage() {
@@ -38,88 +28,10 @@ export default async function DataConnectionsPage() {
         </Button>
       </Flex>
 
-      {connections.length === 0 ? (
-        <Flex
-          direction="column"
-          align="center"
-          gap="2"
-          py="8"
-          style={{ userSelect: "none" }}
-        >
-          <Link1Icon width="48" height="48" color="var(--gray-8)" />
-          <Text size="4" weight="medium" color="gray">
-            No data connections
-          </Text>
-          <Text size="2" color="gray">
-            Create a data connection to get started.
-          </Text>
-        </Flex>
-      ) : (
-        <Table.Root>
-          <Table.Header>
-            <Table.Row>
-              <Table.ColumnHeaderCell>Name</Table.ColumnHeaderCell>
-              <Table.ColumnHeaderCell>Provider</Table.ColumnHeaderCell>
-              <Table.ColumnHeaderCell>Region</Table.ColumnHeaderCell>
-              <Table.ColumnHeaderCell>Read Only</Table.ColumnHeaderCell>
-              <Table.ColumnHeaderCell>Visibilities</Table.ColumnHeaderCell>
-            </Table.Row>
-          </Table.Header>
-          <Table.Body>
-            {connections.map((conn) => (
-              <Table.Row key={conn.data_connection_id}>
-                <Table.Cell>
-                  <Flex direction="column">
-                    <Link
-                      href={adminDataConnectionEditUrl(conn.data_connection_id)}
-                      style={{ color: "var(--accent-11)" }}
-                    >
-                      {conn.name}
-                    </Link>
-                    <Text
-                      size="1"
-                      color="gray"
-                      style={{ fontFamily: "var(--code-font-family)" }}
-                    >
-                      {conn.data_connection_id}
-                    </Text>
-                  </Flex>
-                </Table.Cell>
-                <Table.Cell>
-                  <Badge color={PROVIDER_BADGE[conn.details.provider].color}>
-                    {PROVIDER_BADGE[conn.details.provider].label}
-                  </Badge>
-                </Table.Cell>
-                <Table.Cell>
-                  <Text size="2">
-                    {"region" in conn.details ? conn.details.region : "—"}
-                  </Text>
-                </Table.Cell>
-                <Table.Cell>
-                  <Badge color={conn.read_only ? "red" : "green"}>
-                    {conn.read_only ? "Yes" : "No"}
-                  </Badge>
-                </Table.Cell>
-                <Table.Cell>
-                  <Flex gap="1" wrap="wrap">
-                    {conn.allowed_visibilities.length === 0 ? (
-                      <Text size="2" color="gray">
-                        -
-                      </Text>
-                    ) : (
-                      conn.allowed_visibilities.map((visibility) => (
-                        <Badge key={visibility} variant="soft" size="1">
-                          {visibility}
-                        </Badge>
-                      ))
-                    )}
-                  </Flex>
-                </Table.Cell>
-              </Table.Row>
-            ))}
-          </Table.Body>
-        </Table.Root>
-      )}
+      <DataConnectionsTable
+        connections={connections}
+        editHref={adminDataConnectionEditUrl}
+      />
     </Flex>
   );
 }

--- a/src/app/(app)/admin/data-connections/page.tsx
+++ b/src/app/(app)/admin/data-connections/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from "next";
-import { dataConnectionsTable } from "@/lib/clients";
+import { accountsTable, dataConnectionsTable } from "@/lib/clients";
 import { Flex, Button, Heading } from "@radix-ui/themes";
 import Link from "next/link";
 import { DataConnectionsTable } from "@/components/features/data-connections";
@@ -19,6 +19,16 @@ export default async function DataConnectionsPage() {
       a.name.localeCompare(b.name)
   );
 
+  const ownerIds = connections
+    .map((conn) => conn.owner)
+    .filter((id): id is string => Boolean(id));
+  const ownerAccounts = Object.fromEntries(
+    (await accountsTable.fetchManyByIds(ownerIds)).map((acct) => [
+      acct.account_id,
+      acct,
+    ])
+  );
+
   return (
     <Flex direction="column" gap="4">
       <Flex justify="between" align="center">
@@ -31,6 +41,7 @@ export default async function DataConnectionsPage() {
       <DataConnectionsTable
         connections={connections}
         editHref={adminDataConnectionEditUrl}
+        ownerAccounts={ownerAccounts}
       />
     </Flex>
   );

--- a/src/app/(app)/edit/account/[account_id]/data-connections/[data_connection_id]/page.tsx
+++ b/src/app/(app)/edit/account/[account_id]/data-connections/[data_connection_id]/page.tsx
@@ -1,0 +1,94 @@
+import { Metadata } from "next";
+import { Suspense } from "react";
+import { Button, Flex, Heading, Text } from "@radix-ui/themes";
+import { notFound } from "next/navigation";
+import {
+  accountsTable,
+  dataConnectionsTable,
+  productsTable,
+} from "@/lib/clients";
+import { getPageSession } from "@/lib/api/utils";
+import { canManageAccountDataConnections } from "@/lib/api/authz";
+import {
+  DataConnectionForm,
+  DeleteDataConnectionButton,
+} from "@/components/features/data-connections";
+import { ConnectionUsage } from "@/components/features/data-connections/ConnectionUsage";
+import { toEditableDataConnection } from "@/components/features/data-connections/redact";
+
+export const metadata: Metadata = {
+  title: "Edit data connection",
+};
+
+interface PageProps {
+  params: Promise<{ account_id: string; data_connection_id: string }>;
+}
+
+export default async function AccountEditDataConnectionPage({
+  params,
+}: PageProps) {
+  const { account_id, data_connection_id } = await params;
+  const session = await getPageSession();
+  const account = await accountsTable.fetchById(account_id);
+  if (!account || !canManageAccountDataConnections(session, account)) {
+    notFound();
+  }
+
+  const dataConnection =
+    await dataConnectionsTable.fetchById(data_connection_id);
+  // Isolation: an account may only edit connections it owns. Hiding others as
+  // 404 also avoids leaking that the connection exists.
+  if (!dataConnection || dataConnection.owner !== account_id) {
+    notFound();
+  }
+
+  return (
+    <Flex direction="column" gap="4">
+      <Flex justify="between" align="center">
+        <Heading size="4">Edit Data Connection</Heading>
+        <Suspense
+          fallback={
+            <Button size="2" color="red" variant="soft" disabled>
+              Delete
+            </Button>
+          }
+        >
+          <DeleteConnectionControl
+            connectionId={dataConnection.data_connection_id}
+          />
+        </Suspense>
+      </Flex>
+      <DataConnectionForm
+        mode="edit"
+        ownerAccountId={account_id}
+        dataConnection={toEditableDataConnection(dataConnection)}
+      />
+
+      <Suspense
+        fallback={
+          <Text size="2" color="gray">
+            Loading product usage…
+          </Text>
+        }
+      >
+        <ConnectionUsage connectionId={dataConnection.data_connection_id} />
+      </Suspense>
+    </Flex>
+  );
+}
+
+// Mirrors the admin page: fetch the dependent-product count so delete can be
+// disabled when the connection is in use. Request-deduped with <ConnectionUsage>.
+async function DeleteConnectionControl({
+  connectionId,
+}: {
+  connectionId: string;
+}) {
+  const products = await productsTable.listProductsByConnectionId(connectionId);
+  return (
+    <DeleteDataConnectionButton
+      dataConnectionId={connectionId}
+      productsInUse={products.length}
+    />
+  );
+}

--- a/src/app/(app)/edit/account/[account_id]/data-connections/[data_connection_id]/page.tsx
+++ b/src/app/(app)/edit/account/[account_id]/data-connections/[data_connection_id]/page.tsx
@@ -1,17 +1,13 @@
 import { Metadata } from "next";
 import { Suspense } from "react";
-import { Button, Flex, Heading, Text } from "@radix-ui/themes";
+import { Flex, Heading, Text } from "@radix-ui/themes";
 import { notFound } from "next/navigation";
-import {
-  accountsTable,
-  dataConnectionsTable,
-  productsTable,
-} from "@/lib/clients";
+import { accountsTable, dataConnectionsTable } from "@/lib/clients";
 import { getPageSession } from "@/lib/api/utils";
 import { canManageAccountDataConnections } from "@/lib/api/authz";
 import {
   DataConnectionForm,
-  DeleteDataConnectionButton,
+  DeleteConnectionControl,
 } from "@/components/features/data-connections";
 import { ConnectionUsage } from "@/components/features/data-connections/ConnectionUsage";
 import { toEditableDataConnection } from "@/components/features/data-connections/redact";
@@ -46,17 +42,9 @@ export default async function AccountEditDataConnectionPage({
     <Flex direction="column" gap="4">
       <Flex justify="between" align="center">
         <Heading size="4">Edit Data Connection</Heading>
-        <Suspense
-          fallback={
-            <Button size="2" color="red" variant="soft" disabled>
-              Delete
-            </Button>
-          }
-        >
-          <DeleteConnectionControl
-            connectionId={dataConnection.data_connection_id}
-          />
-        </Suspense>
+        <DeleteConnectionControl
+          connectionId={dataConnection.data_connection_id}
+        />
       </Flex>
       <DataConnectionForm
         mode="edit"
@@ -74,21 +62,5 @@ export default async function AccountEditDataConnectionPage({
         <ConnectionUsage connectionId={dataConnection.data_connection_id} />
       </Suspense>
     </Flex>
-  );
-}
-
-// Mirrors the admin page: fetch the dependent-product count so delete can be
-// disabled when the connection is in use. Request-deduped with <ConnectionUsage>.
-async function DeleteConnectionControl({
-  connectionId,
-}: {
-  connectionId: string;
-}) {
-  const products = await productsTable.listProductsByConnectionId(connectionId);
-  return (
-    <DeleteDataConnectionButton
-      dataConnectionId={connectionId}
-      productsInUse={products.length}
-    />
   );
 }

--- a/src/app/(app)/edit/account/[account_id]/data-connections/[data_connection_id]/page.tsx
+++ b/src/app/(app)/edit/account/[account_id]/data-connections/[data_connection_id]/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from "next";
 import { Suspense } from "react";
-import { Flex, Heading, Text } from "@radix-ui/themes";
+import { Box, Flex, Text } from "@radix-ui/themes";
 import { notFound } from "next/navigation";
 import { accountsTable, dataConnectionsTable } from "@/lib/clients";
 import { getPageSession } from "@/lib/api/utils";
@@ -11,6 +11,7 @@ import {
 } from "@/components/features/data-connections";
 import { ConnectionUsage } from "@/components/features/data-connections/ConnectionUsage";
 import { toEditableDataConnection } from "@/components/features/data-connections/redact";
+import { FormTitle } from "@/components/core/FormTitle";
 
 export const metadata: Metadata = {
   title: "Edit data connection",
@@ -39,9 +40,14 @@ export default async function AccountEditDataConnectionPage({
   }
 
   return (
-    <Flex direction="column" gap="4">
-      <Flex justify="between" align="center">
-        <Heading size="4">Edit Data Connection</Heading>
+    <Box>
+      <Flex justify="between" align="center" mb="6">
+        <Box>
+          <FormTitle
+            title="Edit Data Connection"
+            description="Update this connection's settings and credentials."
+          />
+        </Box>
         <DeleteConnectionControl
           connectionId={dataConnection.data_connection_id}
         />
@@ -52,15 +58,17 @@ export default async function AccountEditDataConnectionPage({
         dataConnection={toEditableDataConnection(dataConnection)}
       />
 
-      <Suspense
-        fallback={
-          <Text size="2" color="gray">
-            Loading product usage…
-          </Text>
-        }
-      >
-        <ConnectionUsage connectionId={dataConnection.data_connection_id} />
-      </Suspense>
-    </Flex>
+      <Box mt="6">
+        <Suspense
+          fallback={
+            <Text size="2" color="gray">
+              Loading product usage…
+            </Text>
+          }
+        >
+          <ConnectionUsage connectionId={dataConnection.data_connection_id} />
+        </Suspense>
+      </Box>
+    </Box>
   );
 }

--- a/src/app/(app)/edit/account/[account_id]/data-connections/create/page.tsx
+++ b/src/app/(app)/edit/account/[account_id]/data-connections/create/page.tsx
@@ -1,7 +1,8 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { Flex, Heading } from "@radix-ui/themes";
+import { Box } from "@radix-ui/themes";
 import { DataConnectionForm } from "@/components/features/data-connections";
+import { FormTitle } from "@/components/core/FormTitle";
 import { accountsTable } from "@/lib/clients";
 import { getPageSession } from "@/lib/api/utils";
 import { canManageAccountDataConnections } from "@/lib/api/authz";
@@ -25,9 +26,12 @@ export default async function AccountCreateDataConnectionPage({
   }
 
   return (
-    <Flex direction="column" gap="4">
-      <Heading size="4">Create Data Connection</Heading>
+    <Box>
+      <FormTitle
+        title="Create Data Connection"
+        description="Connect external storage this account's products can mirror to."
+      />
       <DataConnectionForm mode="create" ownerAccountId={account_id} />
-    </Flex>
+    </Box>
   );
 }

--- a/src/app/(app)/edit/account/[account_id]/data-connections/create/page.tsx
+++ b/src/app/(app)/edit/account/[account_id]/data-connections/create/page.tsx
@@ -1,0 +1,33 @@
+import { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { Flex, Heading } from "@radix-ui/themes";
+import { DataConnectionForm } from "@/components/features/data-connections";
+import { accountsTable } from "@/lib/clients";
+import { getPageSession } from "@/lib/api/utils";
+import { canManageAccountDataConnections } from "@/lib/api/authz";
+
+export const metadata: Metadata = {
+  title: "Create data connection",
+};
+
+interface PageProps {
+  params: Promise<{ account_id: string }>;
+}
+
+export default async function AccountCreateDataConnectionPage({
+  params,
+}: PageProps) {
+  const { account_id } = await params;
+  const session = await getPageSession();
+  const account = await accountsTable.fetchById(account_id);
+  if (!account || !canManageAccountDataConnections(session, account)) {
+    notFound();
+  }
+
+  return (
+    <Flex direction="column" gap="4">
+      <Heading size="4">Create Data Connection</Heading>
+      <DataConnectionForm mode="create" ownerAccountId={account_id} />
+    </Flex>
+  );
+}

--- a/src/app/(app)/edit/account/[account_id]/data-connections/page.tsx
+++ b/src/app/(app)/edit/account/[account_id]/data-connections/page.tsx
@@ -1,12 +1,11 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { Text, Table, Flex, Badge, Button, Heading } from "@radix-ui/themes";
-import { Link1Icon } from "@radix-ui/react-icons";
+import { Flex, Button, Heading } from "@radix-ui/themes";
 import Link from "next/link";
-import { DataProvider } from "@/types";
 import { accountsTable, dataConnectionsTable } from "@/lib/clients";
 import { getPageSession } from "@/lib/api/utils";
 import { canManageAccountDataConnections } from "@/lib/api/authz";
+import { DataConnectionsTable } from "@/components/features/data-connections";
 import {
   accountDataConnectionCreateUrl,
   accountDataConnectionEditUrl,
@@ -14,15 +13,6 @@ import {
 
 export const metadata: Metadata = {
   title: "Data connections",
-};
-
-const PROVIDER_BADGE: Record<
-  DataProvider,
-  { label: string; color: "orange" | "blue" | "green" }
-> = {
-  [DataProvider.S3]: { label: "S3", color: "orange" },
-  [DataProvider.Azure]: { label: "Azure", color: "blue" },
-  [DataProvider.GCP]: { label: "GCP", color: "green" },
 };
 
 interface PageProps {
@@ -58,91 +48,10 @@ export default async function AccountDataConnectionsPage({ params }: PageProps) 
         </Button>
       </Flex>
 
-      {connections.length === 0 ? (
-        <Flex
-          direction="column"
-          align="center"
-          gap="2"
-          py="8"
-          style={{ userSelect: "none" }}
-        >
-          <Link1Icon width="48" height="48" color="var(--gray-8)" />
-          <Text size="4" weight="medium" color="gray">
-            No data connections
-          </Text>
-          <Text size="2" color="gray">
-            Create a data connection to get started.
-          </Text>
-        </Flex>
-      ) : (
-        <Table.Root>
-          <Table.Header>
-            <Table.Row>
-              <Table.ColumnHeaderCell>Name</Table.ColumnHeaderCell>
-              <Table.ColumnHeaderCell>Provider</Table.ColumnHeaderCell>
-              <Table.ColumnHeaderCell>Region</Table.ColumnHeaderCell>
-              <Table.ColumnHeaderCell>Read Only</Table.ColumnHeaderCell>
-              <Table.ColumnHeaderCell>Visibilities</Table.ColumnHeaderCell>
-            </Table.Row>
-          </Table.Header>
-          <Table.Body>
-            {connections.map((conn) => (
-              <Table.Row key={conn.data_connection_id}>
-                <Table.Cell>
-                  <Flex direction="column">
-                    <Link
-                      href={accountDataConnectionEditUrl(
-                        account_id,
-                        conn.data_connection_id
-                      )}
-                      style={{ color: "var(--accent-11)" }}
-                    >
-                      {conn.name}
-                    </Link>
-                    <Text
-                      size="1"
-                      color="gray"
-                      style={{ fontFamily: "var(--code-font-family)" }}
-                    >
-                      {conn.data_connection_id}
-                    </Text>
-                  </Flex>
-                </Table.Cell>
-                <Table.Cell>
-                  <Badge color={PROVIDER_BADGE[conn.details.provider].color}>
-                    {PROVIDER_BADGE[conn.details.provider].label}
-                  </Badge>
-                </Table.Cell>
-                <Table.Cell>
-                  <Text size="2">
-                    {"region" in conn.details ? conn.details.region : "—"}
-                  </Text>
-                </Table.Cell>
-                <Table.Cell>
-                  <Badge color={conn.read_only ? "red" : "green"}>
-                    {conn.read_only ? "Yes" : "No"}
-                  </Badge>
-                </Table.Cell>
-                <Table.Cell>
-                  <Flex gap="1" wrap="wrap">
-                    {conn.allowed_visibilities.length === 0 ? (
-                      <Text size="2" color="gray">
-                        -
-                      </Text>
-                    ) : (
-                      conn.allowed_visibilities.map((visibility) => (
-                        <Badge key={visibility} variant="soft" size="1">
-                          {visibility}
-                        </Badge>
-                      ))
-                    )}
-                  </Flex>
-                </Table.Cell>
-              </Table.Row>
-            ))}
-          </Table.Body>
-        </Table.Root>
-      )}
+      <DataConnectionsTable
+        connections={connections}
+        editHref={(id) => accountDataConnectionEditUrl(account_id, id)}
+      />
     </Flex>
   );
 }

--- a/src/app/(app)/edit/account/[account_id]/data-connections/page.tsx
+++ b/src/app/(app)/edit/account/[account_id]/data-connections/page.tsx
@@ -1,10 +1,11 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { Flex, Button, Heading } from "@radix-ui/themes";
+import { Box, Flex, Button } from "@radix-ui/themes";
 import Link from "next/link";
 import { accountsTable, dataConnectionsTable } from "@/lib/clients";
 import { getPageSession } from "@/lib/api/utils";
 import { canManageAccountDataConnections } from "@/lib/api/authz";
+import { FormTitle } from "@/components/core/FormTitle";
 import { DataConnectionsTable } from "@/components/features/data-connections";
 import {
   accountDataConnectionCreateUrl,
@@ -38,9 +39,14 @@ export default async function AccountDataConnectionsPage({ params }: PageProps) 
     );
 
   return (
-    <Flex direction="column" gap="4">
-      <Flex justify="between" align="center">
-        <Heading size="4">Data Connections</Heading>
+    <Box>
+      <Flex justify="between" align="center" mb="6">
+        <Box>
+          <FormTitle
+            title="Data Connections"
+            description="Manage this account's connections to external storage."
+          />
+        </Box>
         <Button asChild size="2">
           <Link href={accountDataConnectionCreateUrl(account_id)}>
             New Connection
@@ -52,6 +58,6 @@ export default async function AccountDataConnectionsPage({ params }: PageProps) 
         connections={connections}
         editHref={(id) => accountDataConnectionEditUrl(account_id, id)}
       />
-    </Flex>
+    </Box>
   );
 }

--- a/src/app/(app)/edit/account/[account_id]/data-connections/page.tsx
+++ b/src/app/(app)/edit/account/[account_id]/data-connections/page.tsx
@@ -1,0 +1,148 @@
+import { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { Text, Table, Flex, Badge, Button, Heading } from "@radix-ui/themes";
+import { Link1Icon } from "@radix-ui/react-icons";
+import Link from "next/link";
+import { DataProvider } from "@/types";
+import { accountsTable, dataConnectionsTable } from "@/lib/clients";
+import { getPageSession } from "@/lib/api/utils";
+import { canManageAccountDataConnections } from "@/lib/api/authz";
+import {
+  accountDataConnectionCreateUrl,
+  accountDataConnectionEditUrl,
+} from "@/lib/urls";
+
+export const metadata: Metadata = {
+  title: "Data connections",
+};
+
+const PROVIDER_BADGE: Record<
+  DataProvider,
+  { label: string; color: "orange" | "blue" | "green" }
+> = {
+  [DataProvider.S3]: { label: "S3", color: "orange" },
+  [DataProvider.Azure]: { label: "Azure", color: "blue" },
+  [DataProvider.GCP]: { label: "GCP", color: "green" },
+};
+
+interface PageProps {
+  params: Promise<{ account_id: string }>;
+}
+
+export default async function AccountDataConnectionsPage({ params }: PageProps) {
+  const { account_id } = await params;
+  const session = await getPageSession();
+  const account = await accountsTable.fetchById(account_id);
+  if (!account || !canManageAccountDataConnections(session, account)) {
+    notFound();
+  }
+
+  // ponytail: scan + filter by owner; add an owner GSI only if the connection
+  // table actually grows. Mirrors the admin list, which also scans.
+  const connections = (await dataConnectionsTable.listAll())
+    .filter((conn) => conn.owner === account_id)
+    .sort(
+      (a, b) =>
+        a.details.provider.localeCompare(b.details.provider) ||
+        a.name.localeCompare(b.name)
+    );
+
+  return (
+    <Flex direction="column" gap="4">
+      <Flex justify="between" align="center">
+        <Heading size="4">Data Connections</Heading>
+        <Button asChild size="2">
+          <Link href={accountDataConnectionCreateUrl(account_id)}>
+            New Connection
+          </Link>
+        </Button>
+      </Flex>
+
+      {connections.length === 0 ? (
+        <Flex
+          direction="column"
+          align="center"
+          gap="2"
+          py="8"
+          style={{ userSelect: "none" }}
+        >
+          <Link1Icon width="48" height="48" color="var(--gray-8)" />
+          <Text size="4" weight="medium" color="gray">
+            No data connections
+          </Text>
+          <Text size="2" color="gray">
+            Create a data connection to get started.
+          </Text>
+        </Flex>
+      ) : (
+        <Table.Root>
+          <Table.Header>
+            <Table.Row>
+              <Table.ColumnHeaderCell>Name</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Provider</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Region</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Read Only</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Visibilities</Table.ColumnHeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {connections.map((conn) => (
+              <Table.Row key={conn.data_connection_id}>
+                <Table.Cell>
+                  <Flex direction="column">
+                    <Link
+                      href={accountDataConnectionEditUrl(
+                        account_id,
+                        conn.data_connection_id
+                      )}
+                      style={{ color: "var(--accent-11)" }}
+                    >
+                      {conn.name}
+                    </Link>
+                    <Text
+                      size="1"
+                      color="gray"
+                      style={{ fontFamily: "var(--code-font-family)" }}
+                    >
+                      {conn.data_connection_id}
+                    </Text>
+                  </Flex>
+                </Table.Cell>
+                <Table.Cell>
+                  <Badge color={PROVIDER_BADGE[conn.details.provider].color}>
+                    {PROVIDER_BADGE[conn.details.provider].label}
+                  </Badge>
+                </Table.Cell>
+                <Table.Cell>
+                  <Text size="2">
+                    {"region" in conn.details ? conn.details.region : "—"}
+                  </Text>
+                </Table.Cell>
+                <Table.Cell>
+                  <Badge color={conn.read_only ? "red" : "green"}>
+                    {conn.read_only ? "Yes" : "No"}
+                  </Badge>
+                </Table.Cell>
+                <Table.Cell>
+                  <Flex gap="1" wrap="wrap">
+                    {conn.allowed_visibilities.length === 0 ? (
+                      <Text size="2" color="gray">
+                        -
+                      </Text>
+                    ) : (
+                      conn.allowed_visibilities.map((visibility) => (
+                        <Badge key={visibility} variant="soft" size="1">
+                          {visibility}
+                        </Badge>
+                      ))
+                    )}
+                  </Flex>
+                </Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table.Root>
+      )}
+    </Flex>
+  );
+}

--- a/src/app/(app)/edit/account/[account_id]/layout.tsx
+++ b/src/app/(app)/edit/account/[account_id]/layout.tsx
@@ -5,7 +5,10 @@ import {
   SettingsHeader,
 } from "@/components/features/settings";
 import { getPageSession } from "@/lib/api/utils";
-import { isAuthorized } from "@/lib/api/authz";
+import {
+  isAuthorized,
+  canManageAccountDataConnections,
+} from "@/lib/api/authz";
 import { Actions } from "@/types";
 import { accountsTable } from "@/lib/clients/database";
 import { notFound, redirect } from "next/navigation";
@@ -16,6 +19,7 @@ import {
   Pencil1Icon,
   GearIcon,
   ImageIcon,
+  Link1Icon,
 } from "@radix-ui/react-icons";
 import {
   loginUrl,
@@ -23,6 +27,7 @@ import {
   editAccountProfilePictureUrl,
   editAccountPermissionsUrl,
   editAccountMembershipsUrl,
+  accountDataConnectionsUrl,
   accountUrl,
   orySettingsUrl,
 } from "@/lib/urls";
@@ -75,6 +80,10 @@ export default async function AccountLayout({
     accountToEdit,
     Actions.PutAccountProfile
   );
+  const canManageDataConnections = canManageAccountDataConnections(
+    userSession,
+    accountToEdit
+  );
 
   // Authentication details (email, password, keys) live in Ory and can only
   // be changed by the account owner themselves — not by an admin acting on
@@ -96,6 +105,26 @@ export default async function AccountLayout({
       icon: <ImageIcon width="16" height="16" />,
       condition: canEditAccount,
     },
+    {
+      id: "data-connections",
+      label: "Data Connections",
+      href: accountDataConnectionsUrl(account_id),
+      icon: <Link1Icon width="16" height="16" />,
+      condition: canManageDataConnections,
+    },
+    // Permissions (account flags) apply to both individuals and organizations;
+    // view requires GetAccountFlags, edit is admin-only (enforced in the form).
+    {
+      id: "permissions",
+      label: "Permissions",
+      href: editAccountPermissionsUrl(account_id),
+      icon: <LockClosedIcon width="16" height="16" />,
+      condition: isAuthorized(
+        userSession,
+        accountToEdit,
+        Actions.GetAccountFlags
+      ),
+    },
     ...(accountToEdit.type === "organization"
       ? [
           {
@@ -107,17 +136,6 @@ export default async function AccountLayout({
           },
         ]
       : [
-          {
-            id: "permissions",
-            label: "Permissions",
-            href: editAccountPermissionsUrl(account_id),
-            icon: <LockClosedIcon width="16" height="16" />,
-            condition: isAuthorized(
-              userSession,
-              accountToEdit,
-              Actions.GetAccount
-            ),
-          },
           {
             id: "authentication",
             label: "Authentication",

--- a/src/app/(app)/edit/account/[account_id]/permissions/page.tsx
+++ b/src/app/(app)/edit/account/[account_id]/permissions/page.tsx
@@ -1,15 +1,13 @@
 import { Metadata } from "next";
-import { redirect } from "next/navigation";
 import { FormTitle } from "@/components/core/FormTitle";
 import { AccountFlagsForm } from "@/components/features/accounts/AccountFlagsForm";
-import { accountsTable, isOrganizationalAccount } from "@/lib/clients";
+import { accountsTable } from "@/lib/clients";
 import { Box } from "@radix-ui/themes";
 import { getPageSession } from "@/lib/api/utils";
 import { NotAuthorizedPage } from "@/components/core";
 import { notFound } from "next/navigation";
 import { isAuthorized } from "@/lib/api/authz";
 import { Actions } from "@/types";
-import { editAccountProfileUrl } from "@/lib/urls";
 
 export async function generateMetadata({
   params,
@@ -31,9 +29,6 @@ export default async function PermissionsPage({ params }: PageProps) {
   const account = await accountsTable.fetchById(account_id);
   if (!account) {
     notFound();
-  }
-  if (isOrganizationalAccount(account)) {
-    redirect(editAccountProfileUrl(account_id));
   }
   if (!isAuthorized(session, account, Actions.GetAccountFlags)) {
     return <NotAuthorizedPage />;

--- a/src/app/api/v1/data-connections/[data_connection_id]/route.ts
+++ b/src/app/api/v1/data-connections/[data_connection_id]/route.ts
@@ -136,6 +136,9 @@ export async function PUT(
         { status: StatusCodes.UNAUTHORIZED }
       );
     }
+    // Admin-only route: the spread lets the body overwrite any field, including
+    // `owner` (now load-bearing for account-scoped authz). Acceptable since only
+    // platform admins reach here; the account-scoped server actions preserve it.
     const updatedDataConnection = {
       ...existingDataConnection,
       ...dataConnectionUpdate,

--- a/src/app/api/v1/data-connections/[data_connection_id]/route.ts
+++ b/src/app/api/v1/data-connections/[data_connection_id]/route.ts
@@ -143,7 +143,9 @@ export async function PUT(
       ...existingDataConnection,
       ...dataConnectionUpdate,
     };
-    const dataConnection = await dataConnectionsTable.create(
+    // update() (attribute_exists guard), not create() (attribute_not_exists):
+    // the connection already exists, so create() would fail its condition → 500.
+    const dataConnection = await dataConnectionsTable.update(
       updatedDataConnection
     );
     const sanitized = sanitizeDataConnection(dataConnection);

--- a/src/app/api/v1/data-connections/route.test.ts
+++ b/src/app/api/v1/data-connections/route.test.ts
@@ -79,4 +79,37 @@ describe("/api/v1/data-connections", () => {
     expect(json.authentication).toBeUndefined();
     expect(JSON.stringify(json)).not.toContain("secret");
   });
+
+  test("POST rejects an unowned id containing -- (namespace squat)", async () => {
+    (getApiSession as jest.Mock).mockResolvedValue({ identity_id: "admin" });
+    (isAuthorized as jest.Mock).mockReturnValue(true);
+
+    const connection = {
+      data_connection_id: "acme--slug",
+      name: "X",
+      read_only: false,
+      allowed_visibilities: ["public"],
+      details: {
+        provider: "s3",
+        bucket: "b",
+        base_prefix: "",
+        region: "us-east-1",
+      },
+      authentication: {
+        type: "s3_access_key",
+        access_key_id: "AKIA",
+        secret_access_key: "secret",
+      },
+    };
+
+    const req = new NextRequest("http://localhost/api/v1/data-connections", {
+      method: "POST",
+      body: JSON.stringify(connection),
+      headers: { "content-type": "application/json" },
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    expect(dataConnectionsTable.create).not.toHaveBeenCalled();
+  });
 });

--- a/src/app/api/v1/data-connections/route.test.ts
+++ b/src/app/api/v1/data-connections/route.test.ts
@@ -80,6 +80,41 @@ describe("/api/v1/data-connections", () => {
     expect(JSON.stringify(json)).not.toContain("secret");
   });
 
+  test("POST returns 401 before the -- guard for unauthorized callers", async () => {
+    // Auth must run before validation so an unauthenticated request can't learn
+    // that `--` is reserved via a 400 oracle.
+    (getApiSession as jest.Mock).mockResolvedValue(null);
+    (isAuthorized as jest.Mock).mockReturnValue(false);
+
+    const connection = {
+      data_connection_id: "acme--slug",
+      name: "X",
+      read_only: false,
+      allowed_visibilities: ["public"],
+      details: {
+        provider: "s3",
+        bucket: "b",
+        base_prefix: "",
+        region: "us-east-1",
+      },
+      authentication: {
+        type: "s3_access_key",
+        access_key_id: "AKIA",
+        secret_access_key: "secret",
+      },
+    };
+
+    const req = new NextRequest("http://localhost/api/v1/data-connections", {
+      method: "POST",
+      body: JSON.stringify(connection),
+      headers: { "content-type": "application/json" },
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(401);
+    expect(dataConnectionsTable.create).not.toHaveBeenCalled();
+  });
+
   test("POST rejects an unowned id containing -- (namespace squat)", async () => {
     (getApiSession as jest.Mock).mockResolvedValue({ identity_id: "admin" });
     (isAuthorized as jest.Mock).mockReturnValue(true);

--- a/src/app/api/v1/data-connections/route.ts
+++ b/src/app/api/v1/data-connections/route.ts
@@ -80,6 +80,14 @@ export async function POST(request: NextRequest) {
     const session = await getApiSession(request);
     const body = await request.json();
     const dataConnection = DataConnectionSchema.parse(body);
+    // Auth before validation: an unauthenticated request must get 401, not leak
+    // that `--` is reserved via a 400.
+    if (!isAuthorized(session, dataConnection, Actions.CreateDataConnection)) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: StatusCodes.UNAUTHORIZED }
+      );
+    }
     // `--` is reserved as the account-namespacing delimiter (`owner--slug`).
     // The schema regex permits it for namespaced ids; reject it on unowned
     // (admin-created) ids so an admin can't squat an account's slug namespace.
@@ -90,12 +98,6 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         { error: "ID may not contain consecutive hyphens (--)" },
         { status: StatusCodes.BAD_REQUEST }
-      );
-    }
-    if (!isAuthorized(session, dataConnection, Actions.CreateDataConnection)) {
-      return NextResponse.json(
-        { error: "Unauthorized" },
-        { status: StatusCodes.UNAUTHORIZED }
       );
     }
     try {

--- a/src/app/api/v1/data-connections/route.ts
+++ b/src/app/api/v1/data-connections/route.ts
@@ -80,6 +80,18 @@ export async function POST(request: NextRequest) {
     const session = await getApiSession(request);
     const body = await request.json();
     const dataConnection = DataConnectionSchema.parse(body);
+    // `--` is reserved as the account-namespacing delimiter (`owner--slug`).
+    // The schema regex permits it for namespaced ids; reject it on unowned
+    // (admin-created) ids so an admin can't squat an account's slug namespace.
+    if (
+      !dataConnection.owner &&
+      dataConnection.data_connection_id.includes("--")
+    ) {
+      return NextResponse.json(
+        { error: "ID may not contain consecutive hyphens (--)" },
+        { status: StatusCodes.BAD_REQUEST }
+      );
+    }
     if (!isAuthorized(session, dataConnection, Actions.CreateDataConnection)) {
       return NextResponse.json(
         { error: "Unauthorized" },

--- a/src/components/features/accounts/AccountFlagsForm.tsx
+++ b/src/components/features/accounts/AccountFlagsForm.tsx
@@ -30,12 +30,15 @@ export function AccountFlagsForm({ session, account }: AccountFlagsFormProps) {
   // To avoid a bug where the checkboxes are reverting to the initial values after form
   // submission, we track the current flag values for controlled checkboxes
   const [flagValues, setFlagValues] = useState(initialValues);
+  // Re-sync from the freshly-fetched account after a save. Read from
+  // account.flags (the source of truth), not the current UI state, or the
+  // checkboxes would keep showing the pre-save values.
   useEffect(() => {
     setFlagValues(
       Object.fromEntries(
         Object.values(AccountFlags).map((flag) => [
           flag,
-          flagValues[flag] || false,
+          account.flags?.includes(flag) || false,
         ])
       ) as AccountFlagsFormData
     );

--- a/src/components/features/accounts/AccountFlagsForm.tsx
+++ b/src/components/features/accounts/AccountFlagsForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Account, AccountFlags, Actions, UserSession } from "@/types";
+import { Account, AccountFlags, AccountType, Actions, UserSession } from "@/types";
 import { Text, Flex, Checkbox } from "@radix-ui/themes";
 import { Label } from "radix-ui";
 import { DynamicForm } from "@/components/core";
@@ -41,26 +41,37 @@ export function AccountFlagsForm({ session, account }: AccountFlagsFormProps) {
     );
   }, [account.flags, account.updated_at]);
 
-  // Flag configurations with display names and descriptions
-  const fields: Array<[AccountFlags, string, string]> = [
-    [
-      AccountFlags.CREATE_REPOSITORIES,
-      "Create Repositories",
-      "Allows this account to create new repositories and manage repository settings.",
-    ],
-    [
-      AccountFlags.CREATE_ORGANIZATIONS,
-      "Create Organizations",
-      "Allows this account to create new organizations and manage organizational accounts.",
-    ],
-    [
-      AccountFlags.CREATE_DATA_CONNECTIONS,
-      "Create Data Connections",
-      "Allows this account to create and manage its own data connections to external storage.",
-    ],
-  ];
+  const isOrganization = account.type === AccountType.ORGANIZATION;
 
-  if (isAdmin(session)) {
+  // Organizations can only be granted the data-connection capability; the other
+  // flags (repositories, organizations, admin) are individual-account concerns.
+  const fields: Array<[AccountFlags, string, string]> = isOrganization
+    ? [
+        [
+          AccountFlags.CREATE_DATA_CONNECTIONS,
+          "Create Data Connections",
+          "Allows this organization to create and manage its own data connections to external storage.",
+        ],
+      ]
+    : [
+        [
+          AccountFlags.CREATE_REPOSITORIES,
+          "Create Repositories",
+          "Allows this account to create new repositories and manage repository settings.",
+        ],
+        [
+          AccountFlags.CREATE_ORGANIZATIONS,
+          "Create Organizations",
+          "Allows this account to create new organizations and manage organizational accounts.",
+        ],
+        [
+          AccountFlags.CREATE_DATA_CONNECTIONS,
+          "Create Data Connections",
+          "Allows this account to create and manage its own data connections to external storage.",
+        ],
+      ];
+
+  if (!isOrganization && isAdmin(session)) {
     fields.push([
       AccountFlags.ADMIN,
       "Administrator",

--- a/src/components/features/accounts/AccountFlagsForm.tsx
+++ b/src/components/features/accounts/AccountFlagsForm.tsx
@@ -53,6 +53,11 @@ export function AccountFlagsForm({ session, account }: AccountFlagsFormProps) {
       "Create Organizations",
       "Allows this account to create new organizations and manage organizational accounts.",
     ],
+    [
+      AccountFlags.CREATE_DATA_CONNECTIONS,
+      "Create Data Connections",
+      "Allows this account to create and manage its own data connections to external storage.",
+    ],
   ];
 
   if (isAdmin(session)) {

--- a/src/components/features/data-connections/DataConnectionForm.tsx
+++ b/src/components/features/data-connections/DataConnectionForm.tsx
@@ -22,6 +22,10 @@ import type { EditableDataConnection } from "./redact";
 interface DataConnectionFormProps {
   dataConnection?: EditableDataConnection;
   mode: "create" | "edit";
+  // When set, the form is account-scoped: the connection is owned by this
+  // account. Posts a hidden `owner`, hides the platform-only Required Flag, and
+  // (on create) shows the ID namespacing prefix.
+  ownerAccountId?: string;
 }
 
 // Storage providers limited to those with a `details` schema (S3, Azure, GCP).
@@ -126,6 +130,7 @@ function Field({
 export function DataConnectionForm({
   dataConnection,
   mode,
+  ownerAccountId,
 }: DataConnectionFormProps) {
   const router = useRouter();
   const action = mode === "create" ? createDataConnection : updateDataConnection;
@@ -225,10 +230,17 @@ export function DataConnectionForm({
   return (
     <form onSubmit={handleSubmit}>
       <Flex direction="column" gap="4">
+        {ownerAccountId && (
+          <input type="hidden" name="owner" value={ownerAccountId} />
+        )}
         <Field
           label="Connection ID"
           name="data_connection_id"
-          description="Unique identifier used in URLs and as the storage key. Lowercase letters, numbers, and hyphens only; cannot be changed after creation."
+          description={
+            ownerAccountId && mode === "create"
+              ? `Lowercase letters, numbers, and hyphens only. It will be stored as ${ownerAccountId}-<id>; cannot be changed after creation.`
+              : "Unique identifier used in URLs and as the storage key. Lowercase letters, numbers, and hyphens only; cannot be changed after creation."
+          }
           errors={state.fieldErrors?.data_connection_id}
         >
           <input
@@ -335,31 +347,34 @@ export function DataConnectionForm({
           </Flex>
         </Field>
 
-        <Field
-          label="Required Flag"
-          name="required_flag"
-          description="Account flag a user must have for their products to use this connection. Choose None for no restriction. (Not currently enforced.)"
-          errors={state.fieldErrors?.required_flag}
-        >
-          <select
+        {/* Required Flag is a platform-only gate; hidden on owned connections. */}
+        {!ownerAccountId && (
+          <Field
+            label="Required Flag"
             name="required_flag"
-            defaultValue={
-              // has()-check, not ||: a user-selected "None" ("") must survive a
-              // failed submit instead of reverting to the stored flag.
-              state.data.has("required_flag")
-                ? (state.data.get("required_flag") as string)
-                : (dataConnection?.required_flag ?? "")
-            }
-            style={fieldStyle}
+            description="Account flag a user must have for their products to use this connection. Choose None for no restriction. (Not currently enforced.)"
+            errors={state.fieldErrors?.required_flag}
           >
-            <option value="">None</option>
-            {Object.values(AccountFlags).map((flag) => (
-              <option key={flag} value={flag}>
-                {flag}
-              </option>
-            ))}
-          </select>
-        </Field>
+            <select
+              name="required_flag"
+              defaultValue={
+                // has()-check, not ||: a user-selected "None" ("") must survive a
+                // failed submit instead of reverting to the stored flag.
+                state.data.has("required_flag")
+                  ? (state.data.get("required_flag") as string)
+                  : (dataConnection?.required_flag ?? "")
+              }
+              style={fieldStyle}
+            >
+              <option value="">None</option>
+              {Object.values(AccountFlags).map((flag) => (
+                <option key={flag} value={flag}>
+                  {flag}
+                </option>
+              ))}
+            </select>
+          </Field>
+        )}
 
         <Field
           label="Provider"

--- a/src/components/features/data-connections/DataConnectionForm.tsx
+++ b/src/components/features/data-connections/DataConnectionForm.tsx
@@ -238,7 +238,7 @@ export function DataConnectionForm({
           name="data_connection_id"
           description={
             ownerAccountId && mode === "create"
-              ? `Lowercase letters, numbers, and hyphens only. It will be stored as ${ownerAccountId}-<id>; cannot be changed after creation.`
+              ? `Lowercase letters, numbers, and hyphens only. It will be stored as ${ownerAccountId}--<id>; cannot be changed after creation.`
               : "Unique identifier used in URLs and as the storage key. Lowercase letters, numbers, and hyphens only; cannot be changed after creation."
           }
           errors={state.fieldErrors?.data_connection_id}

--- a/src/components/features/data-connections/DataConnectionsTable.test.tsx
+++ b/src/components/features/data-connections/DataConnectionsTable.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from "@testing-library/react";
+import { Theme } from "@radix-ui/themes";
+import { DataConnectionsTable } from "./DataConnectionsTable";
+import { Account, DataConnection, DataProvider } from "@/types";
+
+const conn = (over: Partial<DataConnection>): DataConnection =>
+  ({
+    data_connection_id: "conn-1",
+    name: "Conn 1",
+    details: { provider: DataProvider.S3, region: "us-east-1" },
+    read_only: false,
+    allowed_visibilities: [],
+    ...over,
+  }) as DataConnection;
+
+const acme = { account_id: "acme", name: "Acme Corp" } as Account;
+
+const renderWithTheme = (ui: React.ReactElement) =>
+  render(<Theme>{ui}</Theme>);
+
+describe("DataConnectionsTable owner column", () => {
+  it("hides the Owner column when ownerAccounts is omitted", () => {
+    renderWithTheme(
+      <DataConnectionsTable
+        connections={[conn({ owner: "acme" })]}
+        editHref={(id) => `/edit/${id}`}
+      />
+    );
+
+    expect(screen.queryByText("Owner")).not.toBeInTheDocument();
+    expect(screen.queryByText("System")).not.toBeInTheDocument();
+  });
+
+  it("labels unowned connections as System", () => {
+    renderWithTheme(
+      <DataConnectionsTable
+        connections={[conn({ data_connection_id: "sys", owner: undefined })]}
+        editHref={(id) => `/edit/${id}`}
+        ownerAccounts={{}}
+      />
+    );
+
+    expect(screen.getByText("Owner")).toBeInTheDocument();
+    expect(screen.getByText("System")).toBeInTheDocument();
+  });
+
+  it("shows the owning account's name when resolvable", () => {
+    renderWithTheme(
+      <DataConnectionsTable
+        connections={[conn({ owner: "acme" })]}
+        editHref={(id) => `/edit/${id}`}
+        ownerAccounts={{ acme }}
+      />
+    );
+
+    const link = screen.getByText("Acme Corp");
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/acme");
+  });
+
+  it("falls back to the raw owner id for unresolvable accounts", () => {
+    renderWithTheme(
+      <DataConnectionsTable
+        connections={[conn({ owner: "ghost" })]}
+        editHref={(id) => `/edit/${id}`}
+        ownerAccounts={{}}
+      />
+    );
+
+    expect(screen.getByText("ghost")).toBeInTheDocument();
+  });
+});

--- a/src/components/features/data-connections/DataConnectionsTable.tsx
+++ b/src/components/features/data-connections/DataConnectionsTable.tsx
@@ -1,0 +1,112 @@
+import { Text, Table, Flex, Badge } from "@radix-ui/themes";
+import { Link1Icon } from "@radix-ui/react-icons";
+import Link from "next/link";
+import { DataConnection, DataProvider } from "@/types";
+
+const PROVIDER_BADGE: Record<
+  DataProvider,
+  { label: string; color: "orange" | "blue" | "green" }
+> = {
+  [DataProvider.S3]: { label: "S3", color: "orange" },
+  [DataProvider.Azure]: { label: "Azure", color: "blue" },
+  [DataProvider.GCP]: { label: "GCP", color: "green" },
+};
+
+interface DataConnectionsTableProps {
+  connections: DataConnection[];
+  /** Link target for a connection's edit page (admin- or account-scoped). */
+  editHref: (dataConnectionId: string) => string;
+}
+
+/** Shared list table for both the admin and account-scoped connection views. */
+export function DataConnectionsTable({
+  connections,
+  editHref,
+}: DataConnectionsTableProps) {
+  if (connections.length === 0) {
+    return (
+      <Flex
+        direction="column"
+        align="center"
+        gap="2"
+        py="8"
+        style={{ userSelect: "none" }}
+      >
+        <Link1Icon width="48" height="48" color="var(--gray-8)" />
+        <Text size="4" weight="medium" color="gray">
+          No data connections
+        </Text>
+        <Text size="2" color="gray">
+          Create a data connection to get started.
+        </Text>
+      </Flex>
+    );
+  }
+
+  return (
+    <Table.Root>
+      <Table.Header>
+        <Table.Row>
+          <Table.ColumnHeaderCell>Name</Table.ColumnHeaderCell>
+          <Table.ColumnHeaderCell>Provider</Table.ColumnHeaderCell>
+          <Table.ColumnHeaderCell>Region</Table.ColumnHeaderCell>
+          <Table.ColumnHeaderCell>Read Only</Table.ColumnHeaderCell>
+          <Table.ColumnHeaderCell>Visibilities</Table.ColumnHeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {connections.map((conn) => (
+          <Table.Row key={conn.data_connection_id}>
+            <Table.Cell>
+              <Flex direction="column">
+                <Link
+                  href={editHref(conn.data_connection_id)}
+                  style={{ color: "var(--accent-11)" }}
+                >
+                  {conn.name}
+                </Link>
+                <Text
+                  size="1"
+                  color="gray"
+                  style={{ fontFamily: "var(--code-font-family)" }}
+                >
+                  {conn.data_connection_id}
+                </Text>
+              </Flex>
+            </Table.Cell>
+            <Table.Cell>
+              <Badge color={PROVIDER_BADGE[conn.details.provider].color}>
+                {PROVIDER_BADGE[conn.details.provider].label}
+              </Badge>
+            </Table.Cell>
+            <Table.Cell>
+              <Text size="2">
+                {"region" in conn.details ? conn.details.region : "—"}
+              </Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Badge color={conn.read_only ? "red" : "green"}>
+                {conn.read_only ? "Yes" : "No"}
+              </Badge>
+            </Table.Cell>
+            <Table.Cell>
+              <Flex gap="1" wrap="wrap">
+                {conn.allowed_visibilities.length === 0 ? (
+                  <Text size="2" color="gray">
+                    -
+                  </Text>
+                ) : (
+                  conn.allowed_visibilities.map((visibility) => (
+                    <Badge key={visibility} variant="soft" size="1">
+                      {visibility}
+                    </Badge>
+                  ))
+                )}
+              </Flex>
+            </Table.Cell>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table.Root>
+  );
+}

--- a/src/components/features/data-connections/DataConnectionsTable.tsx
+++ b/src/components/features/data-connections/DataConnectionsTable.tsx
@@ -1,7 +1,10 @@
 import { Text, Table, Flex, Badge } from "@radix-ui/themes";
 import { Link1Icon } from "@radix-ui/react-icons";
 import Link from "next/link";
-import { DataConnection, DataProvider } from "@/types";
+import { Account, DataConnection, DataProvider } from "@/types";
+import { AccountInfoHoverCard } from "@/components/core/AccountInfoHoverCard";
+import { MonoText } from "@/components/core/MonoText";
+import { accountUrl } from "@/lib/urls";
 
 const PROVIDER_BADGE: Record<
   DataProvider,
@@ -16,12 +19,54 @@ interface DataConnectionsTableProps {
   connections: DataConnection[];
   /** Link target for a connection's edit page (admin- or account-scoped). */
   editHref: (dataConnectionId: string) => string;
+  /**
+   * Owner accounts keyed by `account_id`. Pass this (admin view) to render an
+   * Owner column distinguishing system-owned (unowned) from account-owned
+   * connections. Omit it (account-scoped view) to hide the column entirely.
+   */
+  ownerAccounts?: Record<string, Account>;
+}
+
+/** Owner cell: system badge when unowned, hover-carded account otherwise. */
+function OwnerCell({
+  owner,
+  ownerAccounts,
+}: {
+  owner?: string;
+  ownerAccounts: Record<string, Account>;
+}) {
+  if (!owner) {
+    return (
+      <Badge color="gray" variant="soft">
+        System
+      </Badge>
+    );
+  }
+
+  const account = ownerAccounts[owner];
+  if (!account) {
+    // Owner id with no loadable account (e.g. deleted). Show the raw id.
+    return (
+      <MonoText size="1" color="gray">
+        {owner}
+      </MonoText>
+    );
+  }
+
+  return (
+    <AccountInfoHoverCard account={account}>
+      <Link href={accountUrl(account.account_id)} style={{ color: "var(--accent-11)" }}>
+        {account.name}
+      </Link>
+    </AccountInfoHoverCard>
+  );
 }
 
 /** Shared list table for both the admin and account-scoped connection views. */
 export function DataConnectionsTable({
   connections,
   editHref,
+  ownerAccounts,
 }: DataConnectionsTableProps) {
   if (connections.length === 0) {
     return (
@@ -48,6 +93,9 @@ export function DataConnectionsTable({
       <Table.Header>
         <Table.Row>
           <Table.ColumnHeaderCell>Name</Table.ColumnHeaderCell>
+          {ownerAccounts && (
+            <Table.ColumnHeaderCell>Owner</Table.ColumnHeaderCell>
+          )}
           <Table.ColumnHeaderCell>Provider</Table.ColumnHeaderCell>
           <Table.ColumnHeaderCell>Region</Table.ColumnHeaderCell>
           <Table.ColumnHeaderCell>Read Only</Table.ColumnHeaderCell>
@@ -74,6 +122,11 @@ export function DataConnectionsTable({
                 </Text>
               </Flex>
             </Table.Cell>
+            {ownerAccounts && (
+              <Table.Cell>
+                <OwnerCell owner={conn.owner} ownerAccounts={ownerAccounts} />
+              </Table.Cell>
+            )}
             <Table.Cell>
               <Badge color={PROVIDER_BADGE[conn.details.provider].color}>
                 {PROVIDER_BADGE[conn.details.provider].label}

--- a/src/components/features/data-connections/DeleteConnectionControl.tsx
+++ b/src/components/features/data-connections/DeleteConnectionControl.tsx
@@ -1,0 +1,38 @@
+import { Suspense } from "react";
+import { Button } from "@radix-ui/themes";
+import { productsTable } from "@/lib/clients";
+import { DeleteDataConnectionButton } from "./DeleteDataConnectionButton";
+
+/**
+ * Delete control with the dependent-product count loaded behind Suspense, so it
+ * stays off the edit form's critical path. The scan is request-deduped with
+ * <ConnectionUsage>, so it adds no extra DB work. Shared by the admin and
+ * account-scoped connection detail pages.
+ */
+export function DeleteConnectionControl({
+  connectionId,
+}: {
+  connectionId: string;
+}) {
+  return (
+    <Suspense
+      fallback={
+        <Button size="2" color="red" variant="soft" disabled>
+          Delete
+        </Button>
+      }
+    >
+      <DeleteControlInner connectionId={connectionId} />
+    </Suspense>
+  );
+}
+
+async function DeleteControlInner({ connectionId }: { connectionId: string }) {
+  const products = await productsTable.listProductsByConnectionId(connectionId);
+  return (
+    <DeleteDataConnectionButton
+      dataConnectionId={connectionId}
+      productsInUse={products.length}
+    />
+  );
+}

--- a/src/components/features/data-connections/index.ts
+++ b/src/components/features/data-connections/index.ts
@@ -1,4 +1,5 @@
 export { DataConnectionForm } from "./DataConnectionForm";
 export { DataConnectionsTable } from "./DataConnectionsTable";
+export { DeleteConnectionControl } from "./DeleteConnectionControl";
 export { DeleteDataConnectionButton } from "./DeleteDataConnectionButton";
 export { ProductMirrorsManager } from "./ProductMirrorsManager";

--- a/src/components/features/data-connections/index.ts
+++ b/src/components/features/data-connections/index.ts
@@ -1,3 +1,4 @@
 export { DataConnectionForm } from "./DataConnectionForm";
+export { DataConnectionsTable } from "./DataConnectionsTable";
 export { DeleteDataConnectionButton } from "./DeleteDataConnectionButton";
 export { ProductMirrorsManager } from "./ProductMirrorsManager";

--- a/src/lib/actions/data-connections.test.ts
+++ b/src/lib/actions/data-connections.test.ts
@@ -3,10 +3,11 @@ import {
   updateDataConnection,
   deleteDataConnection,
 } from "./data-connections";
-import { dataConnectionsTable, productsTable } from "../clients";
+import { dataConnectionsTable, productsTable, accountsTable } from "../clients";
 import { getPageSession } from "../api/utils";
-import { isAuthorized } from "../api/authz";
+import { isAuthorized, canManageAccountDataConnections } from "../api/authz";
 import {
+  Account,
   DataConnection,
   DataConnectionAuthenticationType,
   DataProvider,
@@ -22,6 +23,9 @@ jest.mock("../clients", () => ({
   productsTable: {
     listProductsByConnectionId: jest.fn(),
   },
+  accountsTable: {
+    fetchById: jest.fn(),
+  },
 }));
 
 jest.mock("../api/utils", () => ({
@@ -30,6 +34,7 @@ jest.mock("../api/utils", () => ({
 
 jest.mock("../api/authz", () => ({
   isAuthorized: jest.fn(),
+  canManageAccountDataConnections: jest.fn(),
 }));
 
 jest.mock("next/cache", () => ({
@@ -43,6 +48,10 @@ const mockGetPageSession = getPageSession as jest.MockedFunction<
 >;
 const mockIsAuthorized = isAuthorized as jest.MockedFunction<
   typeof isAuthorized
+>;
+const mockAccountsTable = accountsTable as jest.Mocked<typeof accountsTable>;
+const mockCanManage = canManageAccountDataConnections as jest.MockedFunction<
+  typeof canManageAccountDataConnections
 >;
 
 const FORM_STATE = {
@@ -92,6 +101,10 @@ beforeEach(() => {
   mockTable.create.mockImplementation(async (dc) => dc);
   mockTable.update.mockImplementation(async (dc) => dc);
   mockProductsTable.listProductsByConnectionId.mockResolvedValue([]);
+  mockAccountsTable.fetchById.mockResolvedValue({
+    account_id: "acme",
+  } as Account);
+  mockCanManage.mockReturnValue(true);
 });
 
 describe("createDataConnection", () => {
@@ -492,5 +505,91 @@ describe("deleteDataConnection", () => {
     expect(result.success).toBe(false);
     expect(result.message).toContain("still use this connection");
     expect(mockTable.delete).not.toHaveBeenCalled();
+  });
+});
+
+describe("account-owned connections", () => {
+  // Posted by the account-scoped page: `owner` hidden field + a bare slug as
+  // the id. Caller is not a platform admin, so authorization runs through the
+  // owner account (mockCanManage).
+  const ownedFields = {
+    ...baseS3Fields,
+    data_connection_id: "myslug",
+    owner: "acme",
+    auth_type: DataConnectionAuthenticationType.S3AccessKey,
+    access_key_id: "AKIA",
+    secret_access_key: "secret",
+  };
+
+  test("namespaces the id as ${owner}--${slug} and redirects to the account view", async () => {
+    mockIsAuthorized.mockReturnValue(false); // not a platform admin
+
+    const result = await createDataConnection(
+      FORM_STATE,
+      formDataFor(ownedFields)
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockCanManage).toHaveBeenCalled();
+    const created = mockTable.create.mock.calls[0][0];
+    expect(created.data_connection_id).toBe("acme--myslug");
+    expect(created.owner).toBe("acme");
+    expect(result.redirectTo).toBe(
+      "/edit/account/acme/data-connections/acme--myslug"
+    );
+  });
+
+  test("ignores a required_flag injected via a crafted POST on an owned connection", async () => {
+    mockIsAuthorized.mockReturnValue(false);
+
+    const result = await createDataConnection(
+      FORM_STATE,
+      formDataFor({ ...ownedFields, required_flag: "admin" })
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockTable.create.mock.calls[0][0].required_flag).toBeUndefined();
+  });
+
+  test("rejects a caller who is not an admin of the owner account", async () => {
+    mockIsAuthorized.mockReturnValue(false);
+    mockCanManage.mockReturnValue(false);
+
+    const result = await createDataConnection(
+      FORM_STATE,
+      formDataFor(ownedFields)
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("Unauthorized");
+    expect(mockTable.create).not.toHaveBeenCalled();
+  });
+
+  test("lets a platform admin manage an orphaned connection whose owner was deleted", async () => {
+    mockIsAuthorized.mockReturnValue(true); // platform admin
+    mockAccountsTable.fetchById.mockResolvedValue(null); // owner account gone
+    mockTable.fetchById.mockResolvedValue({
+      data_connection_id: "ghost--conn",
+      name: "Orphan",
+      read_only: false,
+      allowed_visibilities: [],
+      owner: "ghost",
+      details: {
+        provider: DataProvider.S3,
+        bucket: "b",
+        base_prefix: "",
+        region: "us-east-1",
+      },
+    } as DataConnection);
+
+    const result = await deleteDataConnection(
+      FORM_STATE,
+      formDataFor({ data_connection_id: "ghost--conn" })
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockTable.delete).toHaveBeenCalledWith("ghost--conn");
+    // Admin short-circuits before the (now-missing) owner-account lookup.
+    expect(mockAccountsTable.fetchById).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/actions/data-connections.test.ts
+++ b/src/lib/actions/data-connections.test.ts
@@ -592,4 +592,23 @@ describe("account-owned connections", () => {
     // Admin short-circuits before the (now-missing) owner-account lookup.
     expect(mockAccountsTable.fetchById).not.toHaveBeenCalled();
   });
+
+  test("rejects an admin-created (unowned) id containing the reserved -- delimiter", async () => {
+    const result = await createDataConnection(
+      FORM_STATE,
+      formDataFor({
+        ...baseS3Fields,
+        data_connection_id: "acme--myconn", // no `owner` field → unowned path
+        auth_type: DataConnectionAuthenticationType.S3AccessKey,
+        access_key_id: "AKIA",
+        secret_access_key: "secret",
+      })
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.fieldErrors.data_connection_id?.[0]).toContain(
+      "consecutive hyphens"
+    );
+    expect(mockTable.create).not.toHaveBeenCalled();
+  });
 });

--- a/src/lib/actions/data-connections.ts
+++ b/src/lib/actions/data-connections.ts
@@ -9,13 +9,48 @@ import {
   DataProvider,
   DataConnectionAuthenticationType,
   ProductVisibility,
+  UserSession,
+  MIN_ID_LENGTH,
+  MAX_ID_LENGTH,
+  ID_REGEX,
 } from "@/types";
-import { isAuthorized } from "../api/authz";
+import { isAuthorized, canManageAccountDataConnections } from "../api/authz";
 import { getPageSession } from "../api/utils";
-import { dataConnectionsTable, productsTable } from "../clients";
+import {
+  accountsTable,
+  dataConnectionsTable,
+  productsTable,
+} from "../clients";
 import { FormState } from "@/components/core/DynamicForm";
 import { revalidatePath } from "next/cache";
-import { adminDataConnectionsUrl, adminDataConnectionEditUrl } from "@/lib/urls";
+import {
+  adminDataConnectionsUrl,
+  adminDataConnectionEditUrl,
+  accountDataConnectionsUrl,
+  accountDataConnectionEditUrl,
+} from "@/lib/urls";
+
+/**
+ * Authorizes managing a connection. An *owned* connection is governed by its
+ * owner account's capability flag + the caller's role there (admin-of-owner);
+ * an unowned connection stays admin-only — the caller passes that admin check
+ * (`isAuthorized(... CreateDataConnection|PutDataConnection|...)`) as
+ * `adminAuthorized`. Keeps the owner/flag rule in one place across CRUD.
+ */
+async function canManageConnection(
+  session: UserSession,
+  connection: DataConnection,
+  adminAuthorized: boolean
+): Promise<boolean> {
+  if (!connection.owner) {
+    return adminAuthorized;
+  }
+  const ownerAccount = await accountsTable.fetchById(connection.owner);
+  if (!ownerAccount) {
+    return false;
+  }
+  return canManageAccountDataConnections(session, ownerAccount);
+}
 
 export async function createDataConnection(
   _prevState: FormState<DataConnection>,
@@ -32,8 +67,39 @@ export async function createDataConnection(
     };
   }
 
+  // Account-scoped create: the page posts the owning account as `owner`. The
+  // submitted ID is just a slug; namespace it as `${owner}-${slug}` so two
+  // accounts can't collide and an account can't probe another's connection IDs.
+  const owner = (formData.get("owner") as string) || undefined;
+  if (owner) {
+    const slug = ((formData.get("data_connection_id") as string) || "")
+      .trim()
+      .toLowerCase();
+    if (
+      slug.length < MIN_ID_LENGTH ||
+      slug.length > MAX_ID_LENGTH ||
+      !ID_REGEX.test(slug)
+    ) {
+      return {
+        fieldErrors: {
+          data_connection_id: [
+            `ID must be ${MIN_ID_LENGTH}–${MAX_ID_LENGTH} lowercase letters, numbers, or hyphens.`,
+          ],
+        },
+        data: formData,
+        message: "Invalid connection ID",
+        success: false,
+      };
+    }
+    formData.set("data_connection_id", `${owner}-${slug}`);
+  }
+
   try {
     const dataConnection = buildDataConnectionFromForm(formData);
+    // Owned connections never carry a required_flag (use is already owner-locked).
+    if (owner) {
+      dataConnection.required_flag = undefined;
+    }
 
     const validated = DataConnectionSchema.safeParse(dataConnection);
     if (!validated.success) {
@@ -45,7 +111,13 @@ export async function createDataConnection(
       };
     }
 
-    if (!isAuthorized(session, validated.data, Actions.CreateDataConnection)) {
+    if (
+      !(await canManageConnection(
+        session,
+        validated.data,
+        isAuthorized(session, validated.data, Actions.CreateDataConnection)
+      ))
+    ) {
       return {
         fieldErrors: {},
         data: formData,
@@ -98,18 +170,22 @@ export async function createDataConnection(
       metadata: { data_connection_id: validated.data.data_connection_id },
     });
 
-    revalidatePath(adminDataConnectionsUrl());
+    const newId = validated.data.data_connection_id;
+    revalidatePath(
+      owner ? accountDataConnectionsUrl(owner) : adminDataConnectionsUrl()
+    );
 
-    // Navigate client-side (see FormState.redirectTo) so the shared admin layout
-    // is refetched with the current session, rather than a server redirect()
-    // that leaves the client Router Cache stale. Land on the new connection's
-    // page rather than back on the list.
+    // Navigate client-side (see FormState.redirectTo) so the shared layout is
+    // refetched with the current session, rather than a server redirect() that
+    // leaves the client Router Cache stale. Land on the new connection's page.
     return {
       fieldErrors: {},
       data: formData,
       message: "Data connection created successfully!",
       success: true,
-      redirectTo: adminDataConnectionEditUrl(validated.data.data_connection_id),
+      redirectTo: owner
+        ? accountDataConnectionEditUrl(owner, newId)
+        : adminDataConnectionEditUrl(newId),
     };
   } catch (error) {
     LOGGER.error("Error creating data connection", {
@@ -162,7 +238,13 @@ export async function updateDataConnection(
       };
     }
 
-    if (!isAuthorized(session, existing, Actions.PutDataConnection)) {
+    if (
+      !(await canManageConnection(
+        session,
+        existing,
+        isAuthorized(session, existing, Actions.PutDataConnection)
+      ))
+    ) {
       return {
         fieldErrors: {},
         data: formData,
@@ -172,8 +254,12 @@ export async function updateDataConnection(
     }
 
     // `existing` lets blank secret fields fall back to the stored credentials,
-    // so an admin can edit other fields without re-entering secrets.
+    // and preserves `owner` (the form never changes it), so an account can't
+    // be edited into giving its connection away.
     const dataConnection = buildDataConnectionFromForm(formData, existing);
+    if (existing.owner) {
+      dataConnection.required_flag = undefined;
+    }
     const validated = DataConnectionSchema.safeParse(dataConnection);
     if (!validated.success) {
       return {
@@ -208,8 +294,15 @@ export async function updateDataConnection(
       metadata: { data_connection_id: dataConnectionId },
     });
 
-    revalidatePath(adminDataConnectionsUrl());
-    revalidatePath(adminDataConnectionEditUrl(dataConnectionId));
+    if (existing.owner) {
+      revalidatePath(accountDataConnectionsUrl(existing.owner));
+      revalidatePath(
+        accountDataConnectionEditUrl(existing.owner, dataConnectionId)
+      );
+    } else {
+      revalidatePath(adminDataConnectionsUrl());
+      revalidatePath(adminDataConnectionEditUrl(dataConnectionId));
+    }
 
     return {
       fieldErrors: {},
@@ -268,7 +361,13 @@ export async function deleteDataConnection(
       };
     }
 
-    if (!isAuthorized(session, existing, Actions.DeleteDataConnection)) {
+    if (
+      !(await canManageConnection(
+        session,
+        existing,
+        isAuthorized(session, existing, Actions.DeleteDataConnection)
+      ))
+    ) {
       return {
         fieldErrors: {},
         data: formData,
@@ -298,14 +397,17 @@ export async function deleteDataConnection(
       metadata: { data_connection_id: dataConnectionId },
     });
 
-    revalidatePath(adminDataConnectionsUrl());
+    const listUrl = existing.owner
+      ? accountDataConnectionsUrl(existing.owner)
+      : adminDataConnectionsUrl();
+    revalidatePath(listUrl);
 
     return {
       fieldErrors: {},
       data: formData,
       message: "Data connection deleted successfully!",
       success: true,
-      redirectTo: adminDataConnectionsUrl(),
+      redirectTo: listUrl,
     };
   } catch (error) {
     LOGGER.error("Error deleting data connection", {
@@ -405,6 +507,10 @@ function buildDataConnectionFromForm(
     read_only: formData.get("read_only") === "on",
     allowed_visibilities: allowedVisibilities,
     required_flag: requiredFlag || undefined,
+    // Owner is never client-editable: on edit it is preserved from the stored
+    // connection; on create it comes from the account-scoped page's hidden
+    // `owner` field (validated against the caller's role before the write).
+    owner: existing ? existing.owner : (formData.get("owner") as string) || undefined,
     details,
     authentication,
   };

--- a/src/lib/actions/data-connections.ts
+++ b/src/lib/actions/data-connections.ts
@@ -96,10 +96,6 @@ export async function createDataConnection(
 
   try {
     const dataConnection = buildDataConnectionFromForm(formData);
-    // Owned connections never carry a required_flag (use is already owner-locked).
-    if (owner) {
-      dataConnection.required_flag = undefined;
-    }
 
     const validated = DataConnectionSchema.safeParse(dataConnection);
     if (!validated.success) {
@@ -257,9 +253,6 @@ export async function updateDataConnection(
     // and preserves `owner` (the form never changes it), so an account can't
     // be edited into giving its connection away.
     const dataConnection = buildDataConnectionFromForm(formData, existing);
-    if (existing.owner) {
-      dataConnection.required_flag = undefined;
-    }
     const validated = DataConnectionSchema.safeParse(dataConnection);
     if (!validated.success) {
       return {

--- a/src/lib/actions/data-connections.ts
+++ b/src/lib/actions/data-connections.ts
@@ -45,6 +45,12 @@ async function canManageConnection(
   if (!connection.owner) {
     return adminAuthorized;
   }
+  // adminAuthorized is true only for platform admins (the data-connection
+  // isAuthorized helpers are admin-only), who can manage any connection — even
+  // an orphaned one whose owner account has since been deleted.
+  if (adminAuthorized) {
+    return true;
+  }
   const ownerAccount = await accountsTable.fetchById(connection.owner);
   if (!ownerAccount) {
     return false;
@@ -91,7 +97,11 @@ export async function createDataConnection(
         success: false,
       };
     }
-    formData.set("data_connection_id", `${owner}-${slug}`);
+    // `--` delimiter: ID_REGEX forbids consecutive hyphens inside an account_id
+    // or slug, so the only `--` is this separator — `${owner}--${slug}` is
+    // therefore unambiguous and collision-free across accounts (a single `-`
+    // would not be, since both halves may themselves contain hyphens).
+    formData.set("data_connection_id", `${owner}--${slug}`);
   }
 
   try {
@@ -493,17 +503,24 @@ function buildDataConnectionFromForm(
 
   const requiredFlag = formData.get("required_flag") as string;
 
+  // Owner is never client-editable: on edit it is preserved from the stored
+  // connection; on create it comes from the account-scoped page's hidden
+  // `owner` field (validated against the caller's role before the write).
+  const owner = existing
+    ? existing.owner
+    : (formData.get("owner") as string) || undefined;
+
   return {
     data_connection_id: formData.get("data_connection_id") as string,
     name: formData.get("name") as string,
     prefix_template: (formData.get("prefix_template") as string) || undefined,
     read_only: formData.get("read_only") === "on",
     allowed_visibilities: allowedVisibilities,
-    required_flag: requiredFlag || undefined,
-    // Owner is never client-editable: on edit it is preserved from the stored
-    // connection; on create it comes from the account-scoped page's hidden
-    // `owner` field (validated against the caller's role before the write).
-    owner: existing ? existing.owner : (formData.get("owner") as string) || undefined,
+    // required_flag is a platform-only gate; an owned connection never carries
+    // one (it's already isolated to the owner's products), so drop it even if a
+    // crafted POST supplies it.
+    required_flag: owner ? undefined : requiredFlag || undefined,
+    owner,
     details,
     authentication,
   };

--- a/src/lib/actions/data-connections.ts
+++ b/src/lib/actions/data-connections.ts
@@ -102,6 +102,22 @@ export async function createDataConnection(
     // therefore unambiguous and collision-free across accounts (a single `-`
     // would not be, since both halves may themselves contain hyphens).
     formData.set("data_connection_id", `${owner}--${slug}`);
+  } else {
+    // Unowned (admin) ids may not contain `--`: that sequence is reserved for
+    // the namespacing delimiter, so an admin id like `acme--x` would shadow
+    // account `acme`'s slug `x` (DATA_CONNECTION_ID_REGEX permits `--` only so
+    // the composed namespaced id above validates).
+    const rawId = ((formData.get("data_connection_id") as string) || "").trim();
+    if (rawId.includes("--")) {
+      return {
+        fieldErrors: {
+          data_connection_id: ["ID may not contain consecutive hyphens (--)."],
+        },
+        data: formData,
+        message: "Invalid connection ID",
+        success: false,
+      };
+    }
   }
 
   try {

--- a/src/lib/actions/data-connections.ts
+++ b/src/lib/actions/data-connections.ts
@@ -76,7 +76,11 @@ export async function createDataConnection(
   // Account-scoped create: the page posts the owning account as `owner`. The
   // submitted ID is just a slug; namespace it as `${owner}-${slug}` so two
   // accounts can't collide and an account can't probe another's connection IDs.
-  const owner = (formData.get("owner") as string) || undefined;
+  // Lowercase to match the schema's `.toLowerCase()` on `data_connection_id`;
+  // otherwise an admin-supplied `owner` of "ACME" stores a connection that the
+  // "acme" account's list (filtered on `conn.owner === account_id`) never sees.
+  const owner =
+    ((formData.get("owner") as string) || "").trim().toLowerCase() || undefined;
   if (owner) {
     const slug = ((formData.get("data_connection_id") as string) || "")
       .trim()

--- a/src/lib/api/authz.test.ts
+++ b/src/lib/api/authz.test.ts
@@ -3764,4 +3764,17 @@ describe("canManageAccountDataConnections", () => {
       canManageAccountDataConnections(sessions["anonymous"], withFlag(org))
     ).toBe(false);
   });
+
+  test("denies members (but not admins) when the owner account is disabled", () => {
+    const disabledOrg: Account = { ...withFlag(org), disabled: true };
+    expect(
+      canManageAccountDataConnections(
+        sessions["organization-owner-user"],
+        disabledOrg
+      )
+    ).toBe(false);
+    expect(
+      canManageAccountDataConnections(sessions["admin"], disabledOrg)
+    ).toBe(true);
+  });
 });

--- a/src/lib/api/authz.test.ts
+++ b/src/lib/api/authz.test.ts
@@ -1,6 +1,7 @@
-import { isAuthorized } from "./authz";
+import { isAuthorized, canManageAccountDataConnections } from "./authz";
 import {
   sessions,
+  accounts,
   mappedProducts,
   mappedAPIKeys,
   memberships,
@@ -3684,5 +3685,83 @@ describe("Authorization Tests", () => {
       },
     };
     expect(isAuthorized(userWithAdminAndOtherFlags, "*", action)).toBe(true);
+  });
+});
+
+describe("canManageAccountDataConnections", () => {
+  const org = accounts.find((a) => a.account_id === "organization")!;
+  const regularUser = accounts.find((a) => a.account_id === "regular-user")!;
+  const withFlag = (account: Account): Account => ({
+    ...account,
+    flags: [AccountFlags.CREATE_DATA_CONNECTIONS],
+  });
+  const noFlag = (account: Account): Account => ({ ...account, flags: [] });
+
+  test("org owner/maintainer may manage only when the org holds the flag", () => {
+    const orgWithFlag = withFlag(org);
+    // Owners and maintainers of a flagged org can manage its connections.
+    expect(
+      canManageAccountDataConnections(
+        sessions["organization-owner-user"],
+        orgWithFlag
+      )
+    ).toBe(true);
+    expect(
+      canManageAccountDataConnections(
+        sessions["organization-maintainer-user"],
+        orgWithFlag
+      )
+    ).toBe(true);
+    // Read-data members and non-members cannot, even with the flag.
+    expect(
+      canManageAccountDataConnections(
+        sessions["organization-read-data-user"],
+        orgWithFlag
+      )
+    ).toBe(false);
+    expect(
+      canManageAccountDataConnections(sessions["regular-user"], orgWithFlag)
+    ).toBe(false);
+    // Without the flag, even an owner is blocked.
+    expect(
+      canManageAccountDataConnections(
+        sessions["organization-owner-user"],
+        noFlag(org)
+      )
+    ).toBe(false);
+  });
+
+  test("individuals manage their own account only with the flag", () => {
+    expect(
+      canManageAccountDataConnections(
+        sessions["regular-user"],
+        withFlag(regularUser)
+      )
+    ).toBe(true);
+    expect(
+      canManageAccountDataConnections(
+        sessions["regular-user"],
+        noFlag(regularUser)
+      )
+    ).toBe(false);
+    // Another user can't manage someone else's individual account.
+    expect(
+      canManageAccountDataConnections(
+        sessions["organization-owner-user"],
+        withFlag(regularUser)
+      )
+    ).toBe(false);
+  });
+
+  test("admins bypass the flag; disabled accounts are always denied", () => {
+    expect(
+      canManageAccountDataConnections(sessions["admin"], noFlag(org))
+    ).toBe(true);
+    expect(
+      canManageAccountDataConnections(sessions["disabled"], withFlag(org))
+    ).toBe(false);
+    expect(
+      canManageAccountDataConnections(sessions["anonymous"], withFlag(org))
+    ).toBe(false);
   });
 });

--- a/src/lib/api/authz.ts
+++ b/src/lib/api/authz.ts
@@ -526,6 +526,12 @@ export function canManageAccountDataConnections(
     return true;
   }
 
+  // A disabled owner account can't have its connections managed by its members
+  // (admins, handled above, still can). Mirrors getAccountFlags/putAccountProfile.
+  if (account.disabled) {
+    return false;
+  }
+
   if (!account.flags?.includes(AccountFlags.CREATE_DATA_CONNECTIONS)) {
     return false;
   }

--- a/src/lib/api/authz.ts
+++ b/src/lib/api/authz.ts
@@ -503,6 +503,40 @@ function deleteDataConnection(
   return false;
 }
 
+/**
+ * Whether `session` may create/manage data connections *owned by* `account`.
+ *
+ * The per-action authz functions above only ever see a connection's `owner`
+ * id, so they can't check the owner account's capability flag and stay
+ * admin-only — which keeps the public `/api/v1/data-connections` routes
+ * admin-only. This helper takes the owner *account* (the account-scoped UI has
+ * already fetched it) so it can additionally require the platform-granted
+ * CREATE_DATA_CONNECTIONS flag: an account (individual or org) must hold it to
+ * own connections at all. Admins bypass the flag.
+ */
+export function canManageAccountDataConnections(
+  session: UserSession | null,
+  account: Account
+): boolean {
+  if (session?.account?.disabled) {
+    return false;
+  }
+
+  if (isAdmin(session)) {
+    return true;
+  }
+
+  if (!account.flags?.includes(AccountFlags.CREATE_DATA_CONNECTIONS)) {
+    return false;
+  }
+
+  return hasRole(
+    session,
+    [MembershipRole.Owners, MembershipRole.Maintainers],
+    account.account_id
+  );
+}
+
 function putAccountFlags(
   principal: UserSession | null,
   _account: Account

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -21,6 +21,16 @@ export const adminDataConnectionCreateUrl = () =>
 export const adminDataConnectionEditUrl = (data_connection_id: string) =>
   `/admin/data-connections/${data_connection_id}`;
 
+// Account-scoped data connection URLs (an account managing the connections it owns)
+export const accountDataConnectionsUrl = (account_id: string) =>
+  `/edit/account/${account_id}/data-connections`;
+export const accountDataConnectionCreateUrl = (account_id: string) =>
+  `/edit/account/${account_id}/data-connections/create`;
+export const accountDataConnectionEditUrl = (
+  account_id: string,
+  data_connection_id: string
+) => `/edit/account/${account_id}/data-connections/${data_connection_id}`;
+
 // Auth URLs
 export const loginUrl = (returnTo?: string) => {
   const base = CONFIG.auth.routes.login;

--- a/src/types/data-connection.ts
+++ b/src/types/data-connection.ts
@@ -16,6 +16,7 @@ import {
   MAX_ID_LENGTH,
   MAX_DATA_CONNECTION_ID_LENGTH,
   ID_REGEX,
+  DATA_CONNECTION_ID_REGEX,
   AccountFlags,
 } from "./shared";
 import { ProductVisibility } from "./product";
@@ -277,7 +278,7 @@ export const DataConnectionObjectSchema = z
       .min(MIN_ID_LENGTH)
       .max(MAX_DATA_CONNECTION_ID_LENGTH)
       .toLowerCase()
-      .regex(ID_REGEX, "Invalid data connection ID format")
+      .regex(DATA_CONNECTION_ID_REGEX, "Invalid data connection ID format")
       .openapi({ example: "data-connection-id" }),
     name: z.string(),
     prefix_template: z.optional(z.string()),

--- a/src/types/data-connection.ts
+++ b/src/types/data-connection.ts
@@ -11,7 +11,13 @@
 
 import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
 import { z } from "zod";
-import { MIN_ID_LENGTH, MAX_ID_LENGTH, ID_REGEX, AccountFlags } from "./shared";
+import {
+  MIN_ID_LENGTH,
+  MAX_ID_LENGTH,
+  MAX_DATA_CONNECTION_ID_LENGTH,
+  ID_REGEX,
+  AccountFlags,
+} from "./shared";
 import { ProductVisibility } from "./product";
 
 extendZodWithOpenApi(z);
@@ -269,7 +275,7 @@ export const DataConnectionObjectSchema = z
     data_connection_id: z
       .string()
       .min(MIN_ID_LENGTH)
-      .max(MAX_ID_LENGTH)
+      .max(MAX_DATA_CONNECTION_ID_LENGTH)
       .toLowerCase()
       .regex(ID_REGEX, "Invalid data connection ID format")
       .openapi({ example: "data-connection-id" }),

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -17,6 +17,9 @@ extendZodWithOpenApi(z);
 // Common constants
 export const MIN_ID_LENGTH = 3;
 export const MAX_ID_LENGTH = 40;
+// Account-owned connection IDs are namespaced as `${account_id}-${slug}`, so
+// they need room for two ID segments plus the joining hyphen.
+export const MAX_DATA_CONNECTION_ID_LENGTH = MAX_ID_LENGTH * 2 + 1;
 export const MIN_NAME_LENGTH = 3;
 export const MAX_NAME_LENGTH = 100;
 export const ID_REGEX = /^[a-z0-9](?:(?!--)[a-z0-9-])*[a-z0-9]$/;
@@ -26,6 +29,7 @@ export enum AccountFlags {
   ADMIN = "admin",
   CREATE_REPOSITORIES = "create_repositories",
   CREATE_ORGANIZATIONS = "create_organizations",
+  CREATE_DATA_CONNECTIONS = "create_data_connections",
 }
 
 export const DEFAULT_INDIVIDUAL_FLAGS: AccountFlags[] = [];

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -17,12 +17,17 @@ extendZodWithOpenApi(z);
 // Common constants
 export const MIN_ID_LENGTH = 3;
 export const MAX_ID_LENGTH = 40;
-// Account-owned connection IDs are namespaced as `${account_id}-${slug}`, so
-// they need room for two ID segments plus the joining hyphen.
-export const MAX_DATA_CONNECTION_ID_LENGTH = MAX_ID_LENGTH * 2 + 1;
+// Account-owned connection IDs are namespaced as `${account_id}--${slug}`, so
+// they need room for two ID segments plus the 2-char `--` delimiter.
+export const MAX_DATA_CONNECTION_ID_LENGTH = MAX_ID_LENGTH * 2 + 2;
 export const MIN_NAME_LENGTH = 3;
 export const MAX_NAME_LENGTH = 100;
 export const ID_REGEX = /^[a-z0-9](?:(?!--)[a-z0-9-])*[a-z0-9]$/;
+// Like ID_REGEX but permits consecutive hyphens, so an account-owned connection
+// id can use `--` as the `${account_id}--${slug}` delimiter. Both halves are
+// still validated with the strict ID_REGEX before composing, so the only `--`
+// is the separator.
+export const DATA_CONNECTION_ID_REGEX = /^[a-z0-9][a-z0-9-]*[a-z0-9]$/;
 
 // Common enums
 export enum AccountFlags {


### PR DESCRIPTION
## What

Lets individual and organization accounts **own and manage their own data connections** (list / create / edit / delete), with isolation so an account can't use another account's connections.

The model already had an `owner` field and the security-critical *use*-isolation was already enforced in `createProduct` (`owner !== account_id` → reject), so this PR adds the **management surface** and the **authorization** to loosen "platform-admin-only" into "admin-of-the-owning-account".

## How

- **New capability flag** `AccountFlags.CREATE_DATA_CONNECTIONS`, granted by a platform admin. The permissions page is now enabled for **organizations** (was individual-only) so org flags can be managed.
- **`canManageAccountDataConnections(session, ownerAccount)`** = admin **OR** (owner account holds the flag **AND** caller is `Owners`/`Maintainers`). This deliberately lives *outside* the synchronous `isAuthorized` dispatch: the flag lives on the **owner** account (an org member's session doesn't carry the org's flags), so it needs an async fetch. Consequence: the public `/api/v1/data-connections` routes stay **admin-only**; account ownership is UI-only.
- **Account-scoped pages** under `/edit/account/[account_id]/data-connections` (list / create / `[id]`), reusing `DataConnectionForm` via a new `ownerAccountId` prop that posts a hidden `owner`, hides the platform-only Required Flag, and namespaces the connection id as `${account_id}-${slug}` (avoids cross-account collision + an existence oracle).
- **Owner-aware create/update/delete actions**; also **fixes a latent bug** where editing an owned connection wiped its `owner` (an isolation breach).
- Connection-id max raised to `MAX_DATA_CONNECTION_ID_LENGTH` so namespaced ids fit.

## Commits

1. `feat`: the feature
2. `refactor`: drop inert owned-connection `required_flag` resets
3. `refactor`: extract shared `DataConnectionsTable` (dedups admin + account list)
4. `refactor`: hoist shared `DeleteConnectionControl` (dedups admin + account detail)

(3 & 4 came out of a self-review for over-engineering and also slim the existing admin pages.)

## Isolation — verified

- `createProduct` already rejects using another account's owned connection.
- `addProductMirror` / `removeProductMirror` / `setPrimaryMirror` are **admin-only**, so regular accounts can't bypass isolation via the mirror path. **Forward note:** if non-admin account admins ever get to manage their products' mirrors, `addProductMirror` must add the same `owner === account_id` check `createProduct` has.

## Testing

- New unit tests for `canManageAccountDataConnections` (org owner/maintainer/read-data/non-member, individual self, admin bypass, disabled/anonymous).
- `tsc --noEmit` clean; full `jest` suite **337/338** (the 1 failure, `DropdownSection.integration`, pre-exists on `main` and is unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)