### PR TITLE
feat(products): mark deactivated products in account product list

### DIFF
--- a/src/components/features/products/ProductListItem.tsx
+++ b/src/components/features/products/ProductListItem.tsx
@@ -64,6 +64,11 @@ export function ProductListItem({ product, isSelected }: ProductListItemProps) {
           >
             {visibility.label}
           </Badge>
+          {product.disabled && (
+            <Badge size="1" color="amber" aria-label="Deactivated product">
+              Deactivated
+            </Badge>
+          )}
         </Box>
 
         {product.metadata.tags &&


### PR DESCRIPTION
## What

Add an amber **Deactivated** badge to product list items when `product.disabled` is true, shown next to the existing visibility badge.

## Why

Deactivated products remain accessible to admins and product owners, and the detail page already shows a deactivated banner. But in the account's product list there was no indication a product was deactivated until you clicked in. This makes it clear before clicking.

## Notes

- Deactivated products are already filtered out of the list for everyone except admins/owners (via `isAuthorized(session, product, Actions.GetRepository)` in `IndividualProfilePage.tsx`), so the badge only appears for viewers who are allowed to see them. No access logic changed.
- Reuses the existing `Badge` component; amber matches the detail-page deactivated banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)