### PR TITLE
ci: self-review (ponytail-review + correctness) before @claude opens a PR

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,6 +37,10 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # ponytail-review (over-engineering hunt) runs as a self-review step
+          # before the PR opens; installed from its marketplace.
+          plugin_marketplaces: "https://github.com/DietrichGebert/ponytail.git"
+          plugins: "ponytail@ponytail"
           claude_args: |
-            --allowedTools "Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh issue view:*)"
-            --append-system-prompt "When the request requires code modifications: (1) create a new branch off the default branch named `claude/fix-<short-description>` or `claude/issue-<number>`, (2) make the changes, commit, and push the branch, (3) read `.github/pull_request_template.md`, fill each section (removing the HTML comment instructions), add `Closes #<n>` to 'What I'm changing' if resolving an issue, write the result to a temp file, and run `gh pr create --body-file <path>`, (4) reply in the original thread with the PR link. For read-only questions, skip the PR workflow and just respond."
+            --allowedTools "Skill,Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git diff:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh issue view:*)"
+            --append-system-prompt "When the request requires code modifications: (1) create a new branch off the default branch named `claude/fix-<short-description>` or `claude/issue-<number>`, (2) make the changes and commit, (3) before opening the PR, self-review your own diff and apply fixes: run `/ponytail:ponytail-review` to cut over-engineering, then do an adversarial correctness, security, and edge-case pass — commit any fixes from either, (4) push the branch, (5) read `.github/pull_request_template.md`, fill each section (removing the HTML comment instructions), add `Closes #<n>` to 'What I'm changing' if resolving an issue, note what the self-review changed, write the result to a temp file, and run `gh pr create --body-file <path>`, (6) reply in the original thread with the PR link. For read-only questions, skip the PR workflow and just respond."


### PR DESCRIPTION
## What I'm changing

The `@claude` implement workflow (`.github/workflows/claude.yml`) now self-reviews its own diff **before** opening the PR. Two passes:

1. `/ponytail:ponytail-review` — hunts over-engineering (reinvented stdlib, speculative abstractions, dead flexibility).
2. An adversarial correctness / security / edge-case pass.

It applies and commits any fixes from either, so feature PRs arrive already-improved instead of needing a second human round-trip for things it could have caught itself. Motivated by [#361's reviewer finding](https://github.com/source-cooperative/source.coop/pull/361#issuecomment-4725432345), which had to be reported as a "Fix this →" link because nothing applied it automatically.

## How I did it

- Added `plugin_marketplaces: https://github.com/DietrichGebert/ponytail.git` and `plugins: ponytail@ponytail` inputs so the action installs the ponytail plugin (the documented way to load plugins in `claude-code-action@v1`).
- Added `Skill` to `--allowedTools` so the review skill can actually be invoked, and `Bash(git diff:*)` so it can read the diff.
- Inserted a self-review step into the `--append-system-prompt` ordering: branch → make changes & commit → **self-review + apply fixes** → push → open PR (now noting what the self-review changed).

This only touches the *implementer* workflow. The separate `pr-review-comprehensive.yml` reviewer stays read-only and unchanged — keeping an independent, fresh-context second opinion on top of the implementer's self-review.

## How you can test it

`@claude implement <small feature>` on an issue and watch the run: the job should install the ponytail plugin, invoke `/ponytail:ponytail-review` after committing the implementation, and the resulting PR body should note what the self-review changed.

**One thing to verify on first real run:** that `Skill` in `--allowedTools` is sufficient for the action to invoke `/ponytail:ponytail-review` non-interactively. The plugin-install inputs are documented for v1; whether a plugin-provided skill runs cleanly under the restricted allowlist is the only piece I couldn't test offline. If it's blocked, the fallback is to inline the ponytail-review rubric directly into the system prompt (no plugin/Skill dependency).
