### PR TITLE
fix(globe): fall back to static image when WebGL is disabled

### DIFF
--- a/src/app/(marketing)/HeroGlobe.tsx
+++ b/src/app/(marketing)/HeroGlobe.tsx
@@ -23,10 +23,14 @@ export function HeroGlobe({ wsUrl }: { wsUrl: string }) {
     // synchronously during render when WebGL is disabled, bypassing onError.
     try {
       const probe = document.createElement("canvas");
-      if (!probe.getContext("webgl2") && !probe.getContext("webgl")) {
+      const gl = probe.getContext("webgl2") ?? probe.getContext("webgl");
+      if (!gl) {
         setErrored(true);
         return;
       }
+      // Release the probe context so it doesn't count against the
+      // per-origin WebGL context limit while waiting on GC.
+      gl.getExtension("WEBGL_lose_context")?.loseContext();
     } catch {
       setErrored(true);
       return;

--- a/src/app/(marketing)/HeroGlobe.tsx
+++ b/src/app/(marketing)/HeroGlobe.tsx
@@ -19,6 +19,19 @@ export function HeroGlobe({ wsUrl }: { wsUrl: string }) {
   const handleError = useCallback(() => setErrored(true), []);
 
   useEffect(() => {
+    // ponytail: probe WebGL before mounting LiveGlobe — react-globe.gl throws
+    // synchronously during render when WebGL is disabled, bypassing onError.
+    try {
+      const probe = document.createElement("canvas");
+      if (!probe.getContext("webgl2") && !probe.getContext("webgl")) {
+        setErrored(true);
+        return;
+      }
+    } catch {
+      setErrored(true);
+      return;
+    }
+
     const el = containerRef.current;
     if (!el) return;
 


### PR DESCRIPTION
## Problem

When a browser has WebGL disabled, the homepage crashes:

```
THREE.WebGLRenderer: A WebGL context could not be created. Reason: WebGL is currently disabled.
Uncaught Error: Error creating WebGL context.
```

A static-image fallback already exists in `HeroGlobe`, but it only fires via the `onError` callback raised from `LiveGlobe`'s **post-mount** `useEffect` try/catch. `react-globe.gl` creates its `WebGLRenderer` **during render** — so the context error is thrown before that effect ever runs, propagates as an unhandled React error, and takes down the page.

## Fix

Probe for a WebGL context before mounting `LiveGlobe`. If none is available, trigger the existing `errored` state → the static `/img/dithered-globe.png` fallback renders and `LiveGlobe` is never mounted, so the throwing code path is never reached.

```js
const probe = document.createElement("canvas");
if (!probe.getContext("webgl2") && !probe.getContext("webgl")) {
  setErrored(true);
  return;
}
```

## Scope / notes

- One-file change in `src/app/(marketing)/HeroGlobe.tsx`.
- `tsc --noEmit` passes.
- Not addressed (separate/cosmetic): the `THREE.Clock` deprecation warning and the `wss://logs.source.coop/ws` socket error — the live-data socket isn't needed for the fallback.
- Did **not** add a React error boundary (would also catch *other* render-time throws from `react-globe.gl`). Easy follow-up if those start appearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)