### PR TITLE
feat(data-connections): link product-owned connections to admin form

### DIFF
--- a/src/app/(app)/edit/product/[account_id]/[product_id]/data-connections/page.tsx
+++ b/src/app/(app)/edit/product/[account_id]/[product_id]/data-connections/page.tsx
@@ -30,11 +30,29 @@ export default async function ProductDataConnectionsPage({
     ? (await dataConnectionsTable.listAll()).map(toDataConnectionOption)
     : [];
 
+  // A mirror only links to a connection's admin form when the product owner
+  // owns that connection (or the viewer is an admin), so resolve each mirror's
+  // connection owner here. Reads are globally cached, so per-mirror fetches are
+  // cheap even when the admin list above already loaded them.
+  const mirrorConnectionIds = [
+    ...new Set(
+      Object.values(product.metadata.mirrors).map((m) => m.connection_id)
+    ),
+  ];
+  const ownedConnectionIds = (
+    await Promise.all(
+      mirrorConnectionIds.map((id) => dataConnectionsTable.fetchById(id))
+    )
+  )
+    .filter((c) => c?.owner === product.account_id)
+    .map((c) => c!.data_connection_id);
+
   return (
     <ProductMirrorsManager
       product={product}
       availableConnections={availableConnections}
       isAdmin={userIsAdmin}
+      ownedConnectionIds={ownedConnectionIds}
     />
   );
 }

--- a/src/components/features/data-connections/ProductMirrorsManager.tsx
+++ b/src/components/features/data-connections/ProductMirrorsManager.tsx
@@ -19,6 +19,9 @@ interface ProductMirrorsManagerProps {
   product: Product;
   availableConnections: DataConnectionOption[];
   isAdmin: boolean;
+  // Connection ids owned by the product owner; their admin form is reachable
+  // even by non-admins, so we render the link for them.
+  ownedConnectionIds: string[];
 }
 
 // Distinct color per backend so GCS isn't confused with Azure. minio/ceph are
@@ -45,7 +48,9 @@ export function ProductMirrorsManager({
   product,
   availableConnections,
   isAdmin,
+  ownedConnectionIds,
 }: ProductMirrorsManagerProps) {
+  const ownedConnections = new Set(ownedConnectionIds);
   const [addState, addAction, addPending] = useActionState(
     addProductMirror,
     emptyFormState
@@ -109,7 +114,7 @@ export function ProductMirrorsManager({
                 <Table.Cell>
                   <Flex align="center" gap="2">
                     <Code size="2">{mirror.connection_id}</Code>
-                    {isAdmin && (
+                    {(isAdmin || ownedConnections.has(mirror.connection_id)) && (
                       <Link
                         href={adminDataConnectionEditUrl(mirror.connection_id)}
                         aria-label={`Manage ${mirror.connection_id} in the admin data connections view`}


### PR DESCRIPTION
## What

In the product-admin data-connections view (`/edit/product/[account_id]/[product_id]/data-connections`), each mirror record now links to the data connection's admin form when **either**:

- the viewer is a platform admin (unchanged), **or**
- the connection is **owned by the product owner** (`connection.owner === product.account_id`).

Connections owned by another account (or unowned / Source Cooperative-managed) render no link for non-admins, on the assumption that those users can't view the admin form.

## How

- The page resolves each mirror's connection owner via `dataConnectionsTable.fetchById` (reads are globally cached, so per-mirror fetches are cheap) and passes an `ownedConnectionIds` list to the component.
- `ProductMirrorsManager` renders the link when `isAdmin || ownedConnections.has(connection_id)`.

## Notes

The `/admin/data-connections/[id]` route is still gated by `isAdmin` in the admin layout — this PR only changes when the *link* is rendered, per the requested rule. Owner-based access to that route would be a separate change.

## Verification

- `npm run type-check` — clean
- `next lint` on both changed files — clean
- No existing tests reference these files. No component test added: the change is a trivial set-membership boolean and this component's `useActionState` isn't renderable under RTL in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)