### PR TITLE
feat(data-connections): require unsigned connections to be read-only

### DIFF
--- a/fixtures/data-connections.json
+++ b/fixtures/data-connections.json
@@ -3,7 +3,7 @@
     "data_connection_id": "aws-opendata-us-west-2",
     "name": "Staging Bucket",
     "prefix_template": "{account_id}/{repository_id}/",
-    "read_only": false,
+    "read_only": true,
     "allowed_visibilities": ["public", "unlisted"],
     "details": {
       "provider": "s3",
@@ -23,6 +23,11 @@
       "bucket": "source-coop-data",
       "base_prefix": "",
       "region": "us-east-1"
+    },
+    "authentication": {
+      "type": "s3_access_key",
+      "access_key_id": "AKIAIOSFODNN7EXAMPLE",
+      "secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
     }
   },
   {
@@ -73,6 +78,11 @@
       "bucket": "source-coop-subscription",
       "base_prefix": "premium/",
       "region": "eu-west-1"
+    },
+    "authentication": {
+      "type": "s3_access_key",
+      "access_key_id": "AKIAIOSFODNN7EXAMPLE",
+      "secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
     }
   }
 ]

--- a/src/components/features/data-connections/DataConnectionForm.tsx
+++ b/src/components/features/data-connections/DataConnectionForm.tsx
@@ -309,7 +309,8 @@ export function DataConnectionForm({
         <Field
           label="Read Only"
           name="read_only"
-          description="Prevents products from writing or modifying data through this connection — browse and download only."
+          description="Prevents products from writing or modifying data through this connection — browse and download only. Required for unsigned (no-auth) connections."
+          errors={state.fieldErrors?.read_only}
         >
           <Flex align="center" gap="2" asChild>
             <label>

--- a/src/lib/actions/data-connections.test.ts
+++ b/src/lib/actions/data-connections.test.ts
@@ -284,6 +284,8 @@ describe("createDataConnection", () => {
       FORM_STATE,
       formDataFor({
         ...baseS3Fields,
+        // unsigned (no auth_type) ⇒ must be read-only
+        read_only: "on",
       })
     );
 
@@ -329,6 +331,8 @@ describe("createDataConnection", () => {
       FORM_STATE,
       formDataFor({
         ...baseS3Fields,
+        // unsigned (no auth_type) ⇒ must be read-only
+        read_only: "on",
       })
     );
 
@@ -347,6 +351,8 @@ describe("createDataConnection", () => {
       FORM_STATE,
       formDataFor({
         ...baseS3Fields,
+        // unsigned (no auth_type) ⇒ must be read-only
+        read_only: "on",
       })
     );
 
@@ -431,6 +437,8 @@ describe("updateDataConnection", () => {
       FORM_STATE,
       formDataFor({
         ...baseS3Fields,
+        // unsigned (no auth_type) ⇒ must be read-only
+        read_only: "on",
       })
     );
 
@@ -450,6 +458,8 @@ describe("updateDataConnection", () => {
       FORM_STATE,
       formDataFor({
         ...baseS3Fields,
+        // unsigned (no auth_type) ⇒ must be read-only
+        read_only: "on",
       })
     );
 

--- a/src/types/data-connection.test.ts
+++ b/src/types/data-connection.test.ts
@@ -205,7 +205,7 @@ describe("DataConnection V2 workload-identity variants", () => {
     const dc = DataConnectionSchema.parse({
       data_connection_id: "conn-1",
       name: "Conn",
-      read_only: false,
+      read_only: true,
       allowed_visibilities: [],
       details: {
         provider: "s3",
@@ -391,8 +391,28 @@ describe("DataConnection provider ↔ authentication cross-validation", () => {
   test("allows a connection with no authentication regardless of provider", () => {
     const dc = DataConnectionSchema.parse({
       ...baseFields,
+      read_only: true,
       details: gcpDetails,
     });
     expect(dc.authentication).toBeUndefined();
+  });
+
+  test("rejects an unsigned (no-auth) connection that is not read-only", () => {
+    expect(() =>
+      DataConnectionSchema.parse({
+        ...baseFields,
+        read_only: false,
+        details: s3Details,
+      })
+    ).toThrow();
+  });
+
+  test("accepts an unsigned (no-auth) connection that is read-only", () => {
+    const dc = DataConnectionSchema.parse({
+      ...baseFields,
+      read_only: true,
+      details: s3Details,
+    });
+    expect(dc.read_only).toBe(true);
   });
 });

--- a/src/types/data-connection.ts
+++ b/src/types/data-connection.ts
@@ -307,15 +307,27 @@ export const DataConnectionObjectSchema = z
   .openapi("DataConnection");
 
 /**
- * Full data connection schema: the object shape plus the cross-field check that
- * `authentication.type` is valid for `details.provider`. Use this for parsing/
+ * Full data connection schema: the object shape plus the cross-field checks
+ * that `authentication.type` is valid for `details.provider` and that unsigned
+ * (no-auth) connections are read-only. Use this for parsing/
  * validating whole connections; use {@link DataConnectionObjectSchema} when you
  * need `ZodObject` operations such as `.omit()`.
  */
 export const DataConnectionSchema = DataConnectionObjectSchema.superRefine(
   (connection, ctx) => {
     const { authentication, details } = connection;
-    if (!authentication) return;
+    if (!authentication) {
+      // Unsigned (omitted auth) ⇒ anonymous/public access, so it must be
+      // read-only: there are no credentials to authorize writes with.
+      if (!connection.read_only) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["read_only"],
+          message: "Unsigned connections must be read-only",
+        });
+      }
+      return;
+    }
     if (
       !PROVIDER_AUTH_TYPES[details.provider].includes(authentication.type)
     ) {


### PR DESCRIPTION
## What

Enforce that a data connection using **unsigned requests** (no `authentication`) must be **read-only**.

An unsigned connection serves anonymous/public access — there are no credentials to authorize writes with — so allowing a writable unsigned connection is meaningless and unsafe.

## How

- Added a cross-field check to `DataConnectionSchema.superRefine` in `src/types/data-connection.ts`: when `authentication` is omitted and `read_only` is `false`, validation fails with a `read_only` field error (`"Unsigned connections must be read-only"`).
- Because both the API route (`POST /api/v1/data-connections`) and the create/update server actions parse through this schema, the rule holds at every write path — no per-call-site enforcement needed.
- Surfaced the validation message on the admin form's Read-Only field (`DataConnectionForm.tsx`) and noted the requirement in its description.

## Tests

- New cases: rejects unsigned + writable, accepts unsigned + read-only.
- Fixed pre-existing fixtures that built unsigned-but-writable connections (now invalid).
- `npm run type-check` clean; data-connection suites green.

## Not included

Auto-forcing/disabling the form checkbox when "None (unsigned)" is selected — a Radix disabled checkbox won't submit its value, so it's more code than the rule itself. The inline error message already explains the requirement; can add the UX touch later if the submit-then-error round-trip proves annoying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)