### PR TITLE
feat(authz): let product owners view their own deactivated products

### DIFF
--- a/src/app/(app)/[account_id]/[product_id]/(product)/[[...path]]/layout.tsx
+++ b/src/app/(app)/[account_id]/[product_id]/(product)/[[...path]]/layout.tsx
@@ -60,8 +60,9 @@ export default async function ProductLayout({
   return (
     <>
       <ProductSchemaMetadata product={product} />
-      {/* Deactivated products are visible only to admins (backend authz 404s
-          everyone else) — make that state unmistakable. */}
+      {/* A deactivated product is visible only to its owners/maintainers and
+          admins (backend authz 404s everyone else) — make that state
+          unmistakable to whoever can see it. */}
       {product.disabled && (
         <Box mt="4">
           <Callout.Root color="amber" role="alert">
@@ -69,8 +70,8 @@ export default async function ProductLayout({
               <ExclamationTriangleIcon />
             </Callout.Icon>
             <Callout.Text>
-              This product is deactivated. It is hidden from everyone except
-              administrators.
+              This product is deactivated. It is hidden from everyone except its
+              owners and administrators.
             </Callout.Text>
           </Callout.Root>
         </Box>

--- a/src/app/(app)/[account_id]/[product_id]/(product)/[[...path]]/page.test.tsx
+++ b/src/app/(app)/[account_id]/[product_id]/(product)/[[...path]]/page.test.tsx
@@ -287,9 +287,10 @@ describe("ProductPathPage authenticated-read gate for deactivated products", () 
   });
 
   it("routes a deactivated product through ProxyCredentialsGate regardless of visibility", async () => {
-    // A disabled product is reachable only by admins, and the proxy won't serve
-    // its data anonymously — even a *public* disabled product must mint signed
-    // credentials rather than attempt an anonymous read.
+    // A disabled product is reachable only by its owners/maintainers and
+    // admins, and the proxy won't serve its data anonymously — even a *public*
+    // disabled product must mint signed credentials rather than attempt an
+    // anonymous read.
     (productsTable.fetchById as jest.Mock).mockResolvedValue({
       product_id: "test-product",
       visibility: "public",

--- a/src/app/(app)/[account_id]/[product_id]/(product)/[[...path]]/page.tsx
+++ b/src/app/(app)/[account_id]/[product_id]/(product)/[[...path]]/page.tsx
@@ -46,10 +46,11 @@ export default async function ProductPathPage({ params }: PageProps) {
   // product.
   const product = await getAuthorizedProduct(account_id, product_id);
 
-  // A deactivated (disabled) product is reachable here only by an admin — backend
-  // authz 404s everyone else — and the data proxy won't serve its objects to an
-  // anonymous reader. So read its data with signed credentials regardless of
-  // visibility, taking the same gate-and-mint path a restricted product takes.
+  // A deactivated (disabled) product is reachable here only by its
+  // owners/maintainers and admins — backend authz 404s everyone else — and the
+  // data proxy won't serve its objects to an anonymous reader. So read its data
+  // with signed credentials regardless of visibility, taking the same
+  // gate-and-mint path a restricted product takes.
   const needsAuthenticatedRead =
     product.visibility === "restricted" || product.disabled;
 

--- a/src/lib/api/authz.test.ts
+++ b/src/lib/api/authz.test.ts
@@ -258,10 +258,10 @@ describe("Authorization Tests", () => {
     expect(isAuthorized(sessions["admin"], repo, action)).toBe(true);
     expect(
       isAuthorized(sessions["organization-owner-user"], repo, action)
-    ).toBe(false);
+    ).toBe(true);
     expect(
       isAuthorized(sessions["organization-maintainer-user"], repo, action)
-    ).toBe(false);
+    ).toBe(true);
     expect(
       isAuthorized(sessions["organization-read-data-user"], repo, action)
     ).toBe(false);
@@ -806,10 +806,10 @@ describe("Authorization Tests", () => {
     expect(isAuthorized(sessions["admin"], repo, action)).toBe(true);
     expect(
       isAuthorized(sessions["organization-owner-user"], repo, action)
-    ).toBe(false);
+    ).toBe(true);
     expect(
       isAuthorized(sessions["organization-maintainer-user"], repo, action)
-    ).toBe(false);
+    ).toBe(true);
     expect(
       isAuthorized(sessions["organization-read-data-user"], repo, action)
     ).toBe(false);

--- a/src/lib/api/authz.ts
+++ b/src/lib/api/authz.ts
@@ -704,9 +704,17 @@ function readRepositoryData(
     return true;
   }
 
-  // If the repository is disabled, they are not authorized
+  // A deactivated product stays visible to its owners and maintainers — the
+  // same people who can deactivate it — but is hidden from everyone else,
+  // including ReadData members and public/unlisted viewers. (Re-activating a
+  // deactivated product remains admin-only; see putRepository.)
   if (product.disabled) {
-    return false;
+    return hasRole(
+      principal,
+      [MembershipRole.Owners, MembershipRole.Maintainers],
+      product.account_id,
+      product.product_id
+    );
   }
 
   // If the repository is public or unlisted, everyone is authorized
@@ -747,9 +755,17 @@ function getRepository(
     return true;
   }
 
-  // If the repository is disabled, they are not authorized
+  // A deactivated product stays visible to its owners and maintainers — the
+  // same people who can deactivate it — but is hidden from everyone else,
+  // including ReadData members and public/unlisted viewers. (Re-activating a
+  // deactivated product remains admin-only; see putRepository.)
   if (product.disabled) {
-    return false;
+    return hasRole(
+      principal,
+      [MembershipRole.Owners, MembershipRole.Maintainers],
+      product.account_id,
+      product.product_id
+    );
   }
 
   // If the repository is public or unlisted, everyone is authorized


### PR DESCRIPTION
## Problem

A deactivated (disabled) product was visible **only to admins**. The `product.disabled` short-circuit in `getRepository` and `readRepositoryData` sat *above* the owner/member checks, so even a product's own owners and maintainers received a `404` — indistinguishable from a product that doesn't exist. They couldn't see that their product was deactivated, let alone browse it.

## Change

Allow a product's **owners and maintainers** (the same set that can deactivate it, per `disableRepository`) past the disabled gate in the two read-path authz functions:

- **`getRepository`** — page + metadata no longer 404 the owner. The owner's profile page filters products by `Actions.GetRepository`, so their deactivated products now appear there (their discovery path).
- **`readRepositoryData`** — the action the data proxy's `permissions` endpoint checks, so the owner's file contents actually load.

Everyone else is unchanged: ReadData members, public/unlisted viewers, and anonymous requests still `404` (existence stays hidden from people not permitted to view it).

`hasRole(..., [Owners, Maintainers], ...)` already returns `true` for the direct account-owner of a personal product, so this covers both individual- and org-owned products without a new helper.

### Deliberately out of scope
- **`listRepository` / the v1 `/api/v1/products/[account_id]` listing API is unchanged** — it still omits disabled products for everyone, including the owner, preserving its existing contract (`org account does not see disabled products`). The owner discovers/opens deactivated products via their profile page and direct URLs.
- **Re-activating** a deactivated product stays **admin-only** — `putRepository`/`disableRepository` are unchanged. This PR makes a deactivated product *visible* to its owner, not *editable*.

## Also updated
- The "visible only to admins" comments in `layout.tsx` / `page.tsx` / `page.test.tsx` and the deactivated-product callout text, which described the old behavior.
- Authz unit-test expectations: org owner/maintainer now `true` for `GetRepository` and `ReadRepositoryData` on the disabled fixture; all other sessions (and the `ListRepository` expectations) remain `false`.

## Verification
- `jest src/lib/api/authz.test.ts` — 45 passed
- `jest` products-listing route test (`org account does not see disabled products`) — passes (listing contract preserved)
- `jest` product repository route + product page tests — pass
- Full `jest` suite — only failure is `DropdownSection.integration.test.tsx`, a local-environment artifact that **passes in CI** and is untouched by this PR
- `tsc --noEmit` + `next lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
