### PR TITLE
fix(products): degrade gracefully when a data-proxy read fails

### DIFF
--- a/src/app/(app)/[account_id]/[product_id]/(product)/[[...path]]/page.test.tsx
+++ b/src/app/(app)/[account_id]/[product_id]/(product)/[[...path]]/page.test.tsx
@@ -213,10 +213,10 @@ describe("ProductPathPage proxy AccessDenied handling", () => {
     expect(element.type).toBe(ProductDataUnavailable);
   });
 
-  it("lets an AccessDenied on a public product reach the error boundary", async () => {
-    // An anonymous read of a public product can only be denied by a proxy
-    // misconfiguration — the private-product copy would be wrong, so the
-    // error must propagate instead.
+  it("degrades to ProductDataUnavailable when a public product's read is denied", async () => {
+    // An anonymous read of a public product denied by a proxy misconfiguration
+    // must not blank the whole product — degrade in place so the header and Edit
+    // link (where an owner fixes the connection) stay reachable.
     (productsTable.fetchById as jest.Mock).mockResolvedValue(
       mockProduct("public"),
     );
@@ -225,7 +225,49 @@ describe("ProductPathPage proxy AccessDenied handling", () => {
       getObjectInfo: jest.fn(),
     });
 
-    await expect(renderPage()).rejects.toThrow(S3ServiceException);
+    const element = await renderPage();
+    expect(element.type).toBe(ProductDataUnavailable);
+  });
+
+  it("degrades to ProductDataUnavailable when the listing fails to deserialize (proxy hang)", async () => {
+    // The reported bug: the proxy hangs, Cloudflare returns a non-XML body, and
+    // the AWS SDK throws a deserialization error (not an S3ServiceException).
+    // Must degrade in place, not throw to the route error boundary.
+    (productsTable.fetchById as jest.Mock).mockResolvedValue(
+      mockProduct("restricted"),
+    );
+    (getStorageClient as jest.Mock).mockResolvedValue({
+      listObjects: jest
+        .fn()
+        .mockRejectedValue(new Error("char 'e' is not expected.:1:1")),
+      getObjectInfo: jest.fn(),
+    });
+
+    const element = await renderPage();
+    expect(element.type).toBe(ProductDataUnavailable);
+  });
+
+  it("degrades to ProductDataUnavailable on a proxy ServiceUnavailable (503) wrapping a backend 403", async () => {
+    // Production shape: the proxy's assumed role can't list the backend bucket,
+    // so S3 returns 403; the proxy re-wraps it as a 503 ServiceUnavailable (Code
+    // "ServiceUnavailable", httpStatusCode 503 — not 403, so isAccessDeniedError
+    // is false). Must degrade in place, never reach the route error boundary.
+    (productsTable.fetchById as jest.Mock).mockResolvedValue(
+      mockProduct("restricted"),
+    );
+    (getStorageClient as jest.Mock).mockResolvedValue({
+      listObjects: jest.fn().mockRejectedValue(
+        new S3ServiceException({
+          name: "ServiceUnavailable",
+          $fault: "client",
+          $metadata: { httpStatusCode: 503 },
+        }),
+      ),
+      getObjectInfo: jest.fn(),
+    });
+
+    const element = await renderPage();
+    expect(element.type).toBe(ProductDataUnavailable);
   });
 
   it("falls through to the directory listing when the file HEAD is denied", async () => {
@@ -253,7 +295,9 @@ describe("ProductPathPage proxy AccessDenied handling", () => {
     expect(element.type).toBe(DirectoryList);
   });
 
-  it("surfaces a non-AccessDenied HEAD failure instead of degrading to a directory", async () => {
+  it("degrades to ProductDataUnavailable on a non-AccessDenied HEAD failure", async () => {
+    // A backend failure on the file-detection HEAD must keep the product
+    // rendering (degraded), not crash the whole page.
     (productsTable.fetchById as jest.Mock).mockResolvedValue(
       mockProduct("restricted"),
     );
@@ -262,15 +306,14 @@ describe("ProductPathPage proxy AccessDenied handling", () => {
       listObjects: jest.fn(),
     });
 
-    await expect(
-      ProductPathPage({
-        params: Promise.resolve({
-          account_id: "test-account",
-          product_id: "test-product",
-          path: ["file.txt"],
-        }),
+    const element = await ProductPathPage({
+      params: Promise.resolve({
+        account_id: "test-account",
+        product_id: "test-product",
+        path: ["file.txt"],
       }),
-    ).rejects.toThrow("proxy exploded");
+    });
+    expect(element.type).toBe(ProductDataUnavailable);
   });
 });
 

--- a/src/app/(app)/[account_id]/[product_id]/(product)/[[...path]]/page.test.tsx
+++ b/src/app/(app)/[account_id]/[product_id]/(product)/[[...path]]/page.test.tsx
@@ -81,6 +81,7 @@ import { ProductDataUnavailable } from "@/components/features/products/ProductDa
 import { DirectoryList } from "@/components/features/products/object-browser/DirectoryList";
 import { ProxyCredentialsGate } from "@/components/features/products/ProxyCredentialsGate";
 import { S3ServiceException } from "@aws-sdk/client-s3";
+import { Actions } from "@/types/shared";
 
 describe("Product Page Metadata", () => {
   afterEach(() => {
@@ -268,6 +269,57 @@ describe("ProductPathPage proxy AccessDenied handling", () => {
 
     const element = await renderPage();
     expect(element.type).toBe(ProductDataUnavailable);
+  });
+
+  it("surfaces raw error details to a maintainer (can edit the product)", async () => {
+    // Anyone authorized to edit the product (Actions.PutRepository — the same
+    // gate as the Edit button) sees the underlying failure to debug a broken
+    // data connection. isAuthorized is true for all actions here (beforeEach).
+    (productsTable.fetchById as jest.Mock).mockResolvedValue(
+      mockProduct("restricted"),
+    );
+    (getStorageClient as jest.Mock).mockResolvedValue({
+      listObjects: jest.fn().mockRejectedValue(
+        new S3ServiceException({
+          name: "ServiceUnavailable",
+          message: "backend error: ...403 Forbidden...",
+          $fault: "client",
+          $metadata: { httpStatusCode: 503 },
+        }),
+      ),
+      getObjectInfo: jest.fn(),
+    });
+
+    const element = await renderPage();
+    expect(element.type).toBe(ProductDataUnavailable);
+    expect(element.props.details).toContain("backend error");
+  });
+
+  it("hides error details from a non-maintainer (cannot edit the product)", async () => {
+    // A viewer who can read but not edit (PutRepository denied) gets the notice
+    // but never the raw error — gated server-side, so details is undefined and
+    // the internals are never sent to their browser.
+    (isAuthorized as jest.Mock).mockImplementation(
+      (_session, _product, action) => action !== Actions.PutRepository,
+    );
+    (productsTable.fetchById as jest.Mock).mockResolvedValue(
+      mockProduct("restricted"),
+    );
+    (getStorageClient as jest.Mock).mockResolvedValue({
+      listObjects: jest.fn().mockRejectedValue(
+        new S3ServiceException({
+          name: "ServiceUnavailable",
+          message: "backend error: ...403 Forbidden...",
+          $fault: "client",
+          $metadata: { httpStatusCode: 503 },
+        }),
+      ),
+      getObjectInfo: jest.fn(),
+    });
+
+    const element = await renderPage();
+    expect(element.type).toBe(ProductDataUnavailable);
+    expect(element.props.details).toBeUndefined();
   });
 
   it("falls through to the directory listing when the file HEAD is denied", async () => {

--- a/src/app/(app)/[account_id]/[product_id]/(product)/[[...path]]/page.tsx
+++ b/src/app/(app)/[account_id]/[product_id]/(product)/[[...path]]/page.tsx
@@ -1,10 +1,11 @@
 import { Suspense } from "react";
 import { Metadata } from "next";
 
-import { LOGGER, dataConnectionsTable } from "@/lib";
+import { LOGGER, dataConnectionsTable, getPageSession } from "@/lib";
 import { getStorageClient } from "@/lib/clients/storage";
 import { isAccessDeniedError } from "@/lib/storage/s3";
-import { DataConnection, ProductMirror, ProductObject } from "@/types";
+import { isAuthorized } from "@/lib/api/authz";
+import { Actions, DataConnection, ProductMirror, ProductObject } from "@/types";
 import { readProxyCredentials } from "@/lib/services/proxy-credentials-read";
 import { getAuthorizedProduct } from "./data";
 import { ProxyCredentialsGate } from "@/components/features/products/ProxyCredentialsGate";
@@ -59,6 +60,16 @@ export default async function ProductPathPage({ params }: PageProps) {
   const needsAuthenticatedRead =
     product.visibility === "restricted" || product.disabled;
 
+  // Maintainers (anyone who can edit the product — same gate as the Edit button,
+  // Actions.PutRepository) get the raw failure surfaced in ProductDataUnavailable
+  // so they can debug a broken data connection. Everyone else only sees the
+  // generic notice. The gate is here, server-side, so error internals never reach
+  // a non-maintainer's browser.
+  const session = await getPageSession();
+  const canEditProduct = isAuthorized(session, product, Actions.PutRepository);
+  const errorDetailsFor = (error: unknown) =>
+    canEditProduct ? String(error) : undefined;
+
   // Read the user's cached proxy credentials once for this request: used both to
   // build the (signed-or-anonymous) storage client and, below, to decide whether
   // the product needs the credential gate. Build one storage client and
@@ -95,7 +106,12 @@ export default async function ProductPathPage({ params }: PageProps) {
           context: "object info lookup",
           metadata: { account_id, product_id, objectPath, error: String(error) },
         });
-        return <ProductDataUnavailable message={DATA_UNAVAILABLE_MESSAGE} />;
+        return (
+          <ProductDataUnavailable
+            message={DATA_UNAVAILABLE_MESSAGE}
+            details={errorDetailsFor(error)}
+          />
+        );
       }
       LOGGER.debug("HEAD request denied, treating as directory", {
         operation: "ProductPathPage",
@@ -184,14 +200,19 @@ export default async function ProductPathPage({ params }: PageProps) {
         context: "directory listing",
         metadata: { account_id, product_id, objectPath },
       });
-      return <ProductDataUnavailable />;
+      return <ProductDataUnavailable details={errorDetailsFor(error)} />;
     }
     LOGGER.warn("Storage backend unavailable for directory listing", {
       operation: "ProductPathPage",
       context: "directory listing",
       metadata: { account_id, product_id, objectPath, error: String(error) },
     });
-    return <ProductDataUnavailable message={DATA_UNAVAILABLE_MESSAGE} />;
+    return (
+      <ProductDataUnavailable
+        message={DATA_UNAVAILABLE_MESSAGE}
+        details={errorDetailsFor(error)}
+      />
+    );
   }
 
   // Strip the bucket-key product prefix so paths are relative to the product.

--- a/src/app/(app)/[account_id]/[product_id]/(product)/[[...path]]/page.tsx
+++ b/src/app/(app)/[account_id]/[product_id]/(product)/[[...path]]/page.tsx
@@ -36,6 +36,12 @@ interface PageProps {
   }>;
 }
 
+// Shown when a read through the data proxy fails for a non-authz reason (the
+// backend hung / 5xx'd / returned an unparseable body). Recoverable, so the
+// ProductDataUnavailable "Try again" button refreshes.
+const DATA_UNAVAILABLE_MESSAGE =
+  "This product's files couldn't be loaded just now — the storage backend didn't respond. Try again in a moment.";
+
 export default async function ProductPathPage({ params }: PageProps) {
   let { account_id, product_id, path } = await params;
   path = path?.map((p) => decodeURIComponent(p)) || [];
@@ -70,21 +76,34 @@ export default async function ProductPathPage({ params }: PageProps) {
   // ProxyCredentialsGate below mints credentials and refreshes; the next
   // render's signed HEAD then succeeds and the file view shows. So the HEAD is
   // not expected to succeed on the initial render for a restricted product.
-  // Anything else (e.g. a proxy 500) is a real failure — let it reach the
-  // error boundary rather than silently degrading a file page into a
-  // (probably empty) directory listing.
+  // Anything else (a proxy hang / 5xx / unparseable response) means the backend
+  // is unreachable, not an authz problem — degrade in place (ProductDataUnavailable)
+  // so the product header and Edit link stay visible, instead of throwing to the
+  // route error boundary, which would blank the whole product.
   if (objectPath) {
-    const objectInfo = await s3
-      .getObjectInfo({ account_id, product_id, object_path: objectPath })
-      .catch((error) => {
-        if (!isAccessDeniedError(error)) throw error;
-        LOGGER.debug("HEAD request denied, treating as directory", {
+    let objectInfo: ProductObject | null;
+    try {
+      objectInfo = await s3.getObjectInfo({
+        account_id,
+        product_id,
+        object_path: objectPath,
+      });
+    } catch (error) {
+      if (!isAccessDeniedError(error)) {
+        LOGGER.warn("Storage backend unavailable for object HEAD", {
           operation: "ProductPathPage",
           context: "object info lookup",
           metadata: { account_id, product_id, objectPath, error: String(error) },
         });
-        return null;
+        return <ProductDataUnavailable message={DATA_UNAVAILABLE_MESSAGE} />;
+      }
+      LOGGER.debug("HEAD request denied, treating as directory", {
+        operation: "ProductPathPage",
+        context: "object info lookup",
+        metadata: { account_id, product_id, objectPath, error: String(error) },
       });
+      objectInfo = null;
+    }
 
     if (objectInfo?.type === "file") {
       let connectionDetails:
@@ -140,13 +159,14 @@ export default async function ProductPathPage({ params }: PageProps) {
 
   // The directory listing goes through the data proxy with the user's signed
   // credentials. The viewer is already app-authorized (getAuthorizedProduct
-  // above), so for a RESTRICTED product an AccessDenied here is not "you can't
-  // see this" — it's the proxy refusing the signed read, usually because the
-  // just-minted credentials haven't propagated yet. Surface a clear,
-  // recoverable notice for that case. On a public/unlisted product the read is
-  // anonymous and a 403 means the proxy is misconfigured — let it (and any
-  // other error) fall through to the route error boundary (retry) rather than
-  // showing the private-product copy.
+  // above), so any failure here is a proxy/backend problem, not "you can't see
+  // this" — and we never want it to blank the whole product (the header + Edit
+  // link must stay reachable so an owner can fix a broken connection). So we
+  // degrade in place for every error:
+  //  - RESTRICTED + AccessDenied: the signed read was refused, usually because
+  //    just-minted credentials haven't propagated yet — the private-data copy.
+  //  - anything else (proxy hung / 5xx / unparseable response, or a misconfigured
+  //    public connection): a generic "couldn't load the contents" notice.
   // An empty listing is a valid S3 state (e.g. a directory with no uploads yet);
   // DirectoryList renders the empty state. We intentionally do NOT fall back to
   // the parent prefix here — that masked legitimately empty directories.
@@ -166,7 +186,12 @@ export default async function ProductPathPage({ params }: PageProps) {
       });
       return <ProductDataUnavailable />;
     }
-    throw error;
+    LOGGER.warn("Storage backend unavailable for directory listing", {
+      operation: "ProductPathPage",
+      context: "directory listing",
+      metadata: { account_id, product_id, objectPath, error: String(error) },
+    });
+    return <ProductDataUnavailable message={DATA_UNAVAILABLE_MESSAGE} />;
   }
 
   // Strip the bucket-key product prefix so paths are relative to the product.

--- a/src/components/features/products/ProductDataUnavailable.tsx
+++ b/src/components/features/products/ProductDataUnavailable.tsx
@@ -4,22 +4,27 @@ import { useRouter } from "next/navigation";
 import { Box, Button, Callout, Flex } from "@radix-ui/themes";
 
 /**
- * Rendered by the product page when the data proxy returns AccessDenied (403)
- * for a viewer who IS authorized at the app level (they passed the product's
- * read-authorization check). That mismatch means the signed read was refused by
- * the proxy — typically because freshly minted credentials haven't propagated
- * yet, or a proxy-side auth misconfiguration — not because the user lacks
- * access. We surface a clear, recoverable message instead of the generic error
- * boundary.
+ * Rendered by the product page when a read through the data proxy fails for a
+ * viewer who IS authorized at the app level (they passed the product's
+ * read-authorization check). Two cases:
+ *  - default copy: the proxy returned AccessDenied (403) — usually freshly
+ *    minted credentials that haven't propagated yet, or a proxy auth
+ *    misconfiguration — not a real "you can't see this".
+ *  - `message` override: the backend was unreachable (proxy hung / 5xx /
+ *    unparseable response), so we couldn't load the contents at all.
+ *
+ * Either way we degrade in place — keeping the product header and Edit link
+ * visible — instead of throwing to the route error boundary, which would blank
+ * the whole product.
  */
-export function ProductDataUnavailable() {
+export function ProductDataUnavailable({ message }: { message?: string }) {
   const router = useRouter();
   return (
     <Box mt="4">
       <Callout.Root color="amber" role="alert">
         <Callout.Text>
-          Your access to this private product&apos;s data couldn&apos;t be
-          confirmed just now.
+          {message ??
+            "Your access to this private product's data couldn't be confirmed just now."}
         </Callout.Text>
       </Callout.Root>
       <Flex mt="3">

--- a/src/components/features/products/ProductDataUnavailable.tsx
+++ b/src/components/features/products/ProductDataUnavailable.tsx
@@ -16,8 +16,19 @@ import { Box, Button, Callout, Flex } from "@radix-ui/themes";
  * Either way we degrade in place — keeping the product header and Edit link
  * visible — instead of throwing to the route error boundary, which would blank
  * the whole product.
+ *
+ * `details` carries the raw error and is passed ONLY for viewers who can edit
+ * the product (the caller gates on Actions.PutRepository). It is never sent to
+ * the client for non-maintainers — the gating happens server-side, so this
+ * disclosure simply renders when present.
  */
-export function ProductDataUnavailable({ message }: { message?: string }) {
+export function ProductDataUnavailable({
+  message,
+  details,
+}: {
+  message?: string;
+  details?: string;
+}) {
   const router = useRouter();
   return (
     <Box mt="4">
@@ -27,6 +38,33 @@ export function ProductDataUnavailable({ message }: { message?: string }) {
             "Your access to this private product's data couldn't be confirmed just now."}
         </Callout.Text>
       </Callout.Root>
+      {details && (
+        <details style={{ marginTop: "var(--space-3)" }}>
+          <summary
+            style={{
+              cursor: "pointer",
+              fontSize: "var(--font-size-1)",
+              color: "var(--gray-11)",
+            }}
+          >
+            Error details (visible to maintainers only)
+          </summary>
+          <pre
+            style={{
+              marginTop: "var(--space-2)",
+              padding: "var(--space-2)",
+              background: "var(--gray-2)",
+              borderRadius: "var(--radius-2)",
+              whiteSpace: "pre-wrap",
+              wordBreak: "break-word",
+              fontSize: "var(--font-size-1)",
+              overflowX: "auto",
+            }}
+          >
+            {details}
+          </pre>
+        </details>
+      )}
       <Flex mt="3">
         <Button variant="soft" onClick={() => router.refresh()}>
           Try again


### PR DESCRIPTION
## Problem

Loading a product occasionally crashes the **whole** product view. The data proxy returns a failure the AWS S3 SDK surfaces as a non-`AccessDenied` error — e.g. a `ServiceUnavailable` (HTTP 503) wrapping a backend S3 403, or an unparseable Cloudflare "worker hung" body (`char 'e' is not expected.:1:1`). `page.tsx` rethrew it, so it reached the route error boundary and Next.js blanked the product (the `digest`'d `[error]` line in the Vercel logs).

## Fix

Degrade in place instead of crashing. Both proxy reads in `page.tsx` — the file-detection HEAD (`getObjectInfo`) and the directory `listObjects` — now catch non-authz failures and render `<ProductDataUnavailable>` rather than rethrowing. Because `page.tsx` is the page slot inside the persistent product `layout.tsx`, the `ProductHeader` + Edit link stay mounted and only the contents card shows a recoverable "try again" notice — so an owner can still reach the edit form to fix a misconfigured data connection.

- `ProductDataUnavailable` gains an optional `message` for the backend-unreachable case (vs. the existing "access couldn't be confirmed" copy).
- Existing behavior preserved: a restricted-product `AccessDenied` still shows the credentials-propagating notice, and the first-visit `ProxyCredentialsGate` flow is unchanged.

## Tests

`page.test.tsx` updated — the two cases that previously asserted "let it reach the error boundary" now assert graceful degradation, plus new regression tests for the proxy-hang deserialization error and the exact `ServiceUnavailable` (503) production shape. Suite: **10/10**. `tsc --noEmit` clean.

## Note — proxy side, out of scope

The root cause of that specific 503 is a proxy bug: it lists at the S3 **service root** (`GET /?list-type=2&prefix=…`, which requires `s3:ListAllMyBuckets`) instead of against the bucket, so the role's bucket-scoped policy can never satisfy it. That's a `data.source.coop` / `multistore` fix; this PR only stops the frontend from crashing on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)