### PR TITLE
fix(uploads): refresh STS credentials mid-upload (#401)

### DIFF
--- a/src/components/features/uploader/UploadProvider.tsx
+++ b/src/components/features/uploader/UploadProvider.tsx
@@ -10,6 +10,7 @@ import {
   useRef,
 } from "react";
 import { S3UploadService } from "@/lib/services/s3-upload";
+import { getTemporaryCredentials } from "@/lib";
 import { useS3Credentials } from "./CredentialsProvider";
 import type { CredentialsScope } from "./CredentialsProvider";
 import { useBeforeUnload } from "@/hooks/useBeforeUnload";
@@ -87,7 +88,28 @@ export function UploadProvider({ children }: UploadProviderProps) {
       for (const [scope, credentials] of getAllCredentials()) {
         const key = s3ServiceKey(scope);
         if (!next.has(key)) {
-          next.set(key, new S3UploadService(credentials));
+          // endpoint/bucket/region/prefix are stable per scope (taken from the
+          // first mint); only the STS token rotates. Hand the client a provider
+          // that re-mints via the server action so the SDK refreshes it before
+          // expiry, keeping long uploads alive (#401).
+          next.set(
+            key,
+            new S3UploadService({
+              endpoint: credentials.endpoint,
+              bucket: credentials.bucket,
+              region: credentials.region,
+              prefix: credentials.prefix,
+              credentials: async () => {
+                const c = await getTemporaryCredentials(scope);
+                return {
+                  accessKeyId: c.accessKeyId,
+                  secretAccessKey: c.secretAccessKey,
+                  sessionToken: c.sessionToken,
+                  expiration: new Date(c.expiration),
+                };
+              },
+            })
+          );
         }
       }
       return next;

--- a/src/components/features/uploader/UploadProvider.tsx
+++ b/src/components/features/uploader/UploadProvider.tsx
@@ -117,8 +117,7 @@ export function UploadProvider({ children }: UploadProviderProps) {
   }, [getAllCredentials]);
 
   const getS3Service = (scope: CredentialsScope) => {
-    const key = `${scope.accountId}:${scope.productId}`;
-    return s3Services.get(key) || null;
+    return s3Services.get(s3ServiceKey(scope)) || null;
   };
 
   const uploadFiles = useCallback(

--- a/src/lib/services/s3-upload.ts
+++ b/src/lib/services/s3-upload.ts
@@ -1,5 +1,6 @@
 import { S3Client } from "@aws-sdk/client-s3";
 import { Upload } from "@aws-sdk/lib-storage";
+import type { AwsCredentialIdentityProvider } from "@aws-sdk/types";
 
 export interface S3UploadConfig {
   /** Data proxy endpoint. Uploads are path-style and routed through the proxy. */
@@ -7,9 +8,14 @@ export interface S3UploadConfig {
   bucket: string;
   region: string;
   prefix: string;
-  accessKeyId: string;
-  secretAccessKey: string;
-  sessionToken: string;
+  /**
+   * Async provider for the proxy STS credentials. Handed straight to the S3
+   * client so the SDK re-invokes it ~5 min before each token's `expiration`
+   * (it auto-refreshes any provider whose identity carries an `expiration`
+   * Date). A static credential object would never refresh, so a multi-hour
+   * upload dies the moment the first token expires — issue #401.
+   */
+  credentials: AwsCredentialIdentityProvider;
 }
 
 // 5MB parts, 4 concurrent — S3's minimum part size and a sensible browser
@@ -45,11 +51,7 @@ export class S3UploadService {
       // The proxy addresses objects as ${endpoint}/${bucket}/${key}, matching
       // the server-side read client (S3StorageClient).
       forcePathStyle: true,
-      credentials: {
-        accessKeyId: config.accessKeyId,
-        secretAccessKey: config.secretAccessKey,
-        sessionToken: config.sessionToken,
-      },
+      credentials: config.credentials,
     });
   }
 


### PR DESCRIPTION
## What

Long uploads (the issue reporter's case: a 250GB file over ~half a day) abort with **"Token expired"** once the first STS token lapses, and the **Retry** button just re-shows the same error. Fixes #401.

## Root cause

The in-browser uploader minted **one** STS token and froze it into a single static `S3Client` credential object that it never rebuilt. AWS SDK v3 only auto-refreshes credentials whose identity carries an `expiration` Date (`@smithy/core`: `doesIdentityRequireRefresh = (id) => id.expiration !== undefined`, refreshed ~5 min before expiry via `EXPIRATION_MS = 300_000`). A static object has no `expiration`, so it never refreshes — the token simply dies mid-upload.

#391 swapped the credential *source* (AWS `AssumeRole` direct-to-S3 → data-proxy STS) but kept the same mint-once-and-freeze pattern, so it did **not** address this.

## Fix

Hand the `S3Client` a credentials **provider function** instead of a static object:

- `S3UploadConfig.credentials` is now an `AwsCredentialIdentityProvider`, passed straight through to `S3Client`.
- `UploadProvider` builds the service with a provider that re-mints via the existing `getTemporaryCredentials` server action and returns `expiration` as a `Date`. `endpoint`/`bucket`/`region`/`prefix` stay from the first mint (stable per scope); only the token rotates.

The SDK then transparently re-invokes the provider before expiry across every multipart `UploadPart`, keeping multi-hour uploads alive. Retry also mints fresh creds now, fixing the "retry is useless" complaint. The provider re-calls `getTemporaryCredentials`, which already reuses the fresh `sc_proxy_creds` cookie and only runs the full Ory + STS chain when it must.

## Testing

- `npm run type-check` clean.
- `npm run lint` clean for both changed files.
- Refresh trigger confirmed against the installed `@smithy/core` (only a provider returning an `expiration` Date is refreshed; the old static object was not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)