### PR TITLE
fix(uploader): reject filenames with characters that break upload signature

### DIFF
--- a/src/components/features/products/object-browser/DirectoryRow.tsx
+++ b/src/components/features/products/object-browser/DirectoryRow.tsx
@@ -68,6 +68,7 @@ export function DirectoryRow({
   const {
     cancelUpload,
     retryUpload,
+    removeUpload,
     getUploadsForScope,
     deleteObject,
     deletePrefix,
@@ -216,22 +217,38 @@ export function DirectoryRow({
               {/* Upload control buttons */}
               {!item.isDirectory && isUploading && uploadItem && (
                 <Flex gap="1">
-                  {/* Retry button for failed uploads */}
+                  {/* Retry / dismiss buttons for failed uploads */}
                   {item.uploadProgress?.status === "error" && (
-                    <Tooltip content="Retry upload">
-                      <IconButton
-                        variant="soft"
-                        size="1"
-                        color="amber"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          retryUpload(uploadItem.id);
-                        }}
-                        style={{ minWidth: "auto", cursor: "pointer" }}
-                      >
-                        <ReloadIcon width={14} height={14} />
-                      </IconButton>
-                    </Tooltip>
+                    <>
+                      <Tooltip content="Retry upload">
+                        <IconButton
+                          variant="soft"
+                          size="1"
+                          color="amber"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            retryUpload(uploadItem.id);
+                          }}
+                          style={{ minWidth: "auto", cursor: "pointer" }}
+                        >
+                          <ReloadIcon width={14} height={14} />
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip content="Dismiss">
+                        <IconButton
+                          variant="soft"
+                          size="1"
+                          color="gray"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            removeUpload(uploadItem.id);
+                          }}
+                          style={{ minWidth: "auto", cursor: "pointer" }}
+                        >
+                          <Cross2Icon width={14} height={14} />
+                        </IconButton>
+                      </Tooltip>
+                    </>
                   )}
 
                   {/* Cancel button for active/queued uploads */}

--- a/src/components/features/uploader/UploadProvider.tsx
+++ b/src/components/features/uploader/UploadProvider.tsx
@@ -34,6 +34,7 @@ interface UploadContextType {
   cancelUpload: (id: string) => Promise<void>;
   cancelAllUploads: (scope?: CredentialsScope) => Promise<void>;
   retryUpload: (id: string) => Promise<void>;
+  removeUpload: (id: string) => void;
   deleteObject: (key: string, scope: CredentialsScope) => Promise<void>;
   deletePrefix: (prefix: string, scope: CredentialsScope) => Promise<void>;
   clearUploads: (status?: UploadStatus, scope?: CredentialsScope) => void;
@@ -152,6 +153,10 @@ export function UploadProvider({ children }: UploadProviderProps) {
     await queueRef.current!.retry(id);
   }, []);
 
+  const removeUpload = useCallback((id: string) => {
+    queueRef.current!.remove(id);
+  }, []);
+
   const deleteObject = useCallback(
     async (key: string, scope: CredentialsScope) => {
       const s3Service = getS3Service(scope);
@@ -204,6 +209,7 @@ export function UploadProvider({ children }: UploadProviderProps) {
     cancelUpload,
     cancelAllUploads,
     retryUpload,
+    removeUpload,
     deleteObject,
     deletePrefix,
     clearUploads,

--- a/src/lib/services/upload-queue-manager.test.ts
+++ b/src/lib/services/upload-queue-manager.test.ts
@@ -35,4 +35,29 @@ describe("UploadQueueManager", () => {
 
     expect(s3Service.uploadFile).toHaveBeenCalled();
   });
+
+  it("rejects filenames with spaces", () => {
+    const manager = new UploadQueueManager(2);
+    const s3Service = makeS3Service();
+    const file = new File(["x"], "catalog 1.jsonl");
+
+    manager.add([file], "", scope, s3Service);
+
+    const [item] = manager.getAll();
+    expect(item.status).toBe("error");
+    expect(item.error).toMatch(/Unsupported character space/);
+    expect(s3Service.uploadFile).not.toHaveBeenCalled();
+  });
+
+  it("removes a single item from the queue", () => {
+    const manager = new UploadQueueManager(2);
+    const s3Service = makeS3Service();
+    const file = new File(["x"], "test().txt");
+
+    manager.add([file], "", scope, s3Service);
+    const [item] = manager.getAll();
+    manager.remove(item.id);
+
+    expect(manager.getAll()).toHaveLength(0);
+  });
 });

--- a/src/lib/services/upload-queue-manager.test.ts
+++ b/src/lib/services/upload-queue-manager.test.ts
@@ -1,0 +1,38 @@
+import { UploadQueueManager } from "./upload-queue-manager";
+import type { S3UploadService } from "./s3-upload";
+
+const scope = { accountId: "acc", productId: "prod" };
+
+function makeS3Service(): S3UploadService {
+  return {
+    uploadFile: jest.fn().mockResolvedValue({
+      upload: {},
+      result: Promise.resolve({ key: "" }),
+    }),
+  } as unknown as S3UploadService;
+}
+
+describe("UploadQueueManager", () => {
+  it("rejects filenames with characters that break the storage proxy's signature check", () => {
+    const manager = new UploadQueueManager(2);
+    const s3Service = makeS3Service();
+    const file = new File(["x"], "test().txt");
+
+    manager.add([file], "", scope, s3Service);
+
+    const [item] = manager.getAll();
+    expect(item.status).toBe("error");
+    expect(item.error).toMatch(/Unsupported character/);
+    expect(s3Service.uploadFile).not.toHaveBeenCalled();
+  });
+
+  it("uploads filenames without unsupported characters", async () => {
+    const manager = new UploadQueueManager(2);
+    const s3Service = makeS3Service();
+    const file = new File(["x"], "test.txt");
+
+    manager.add([file], "", scope, s3Service);
+
+    expect(s3Service.uploadFile).toHaveBeenCalled();
+  });
+});

--- a/src/lib/services/upload-queue-manager.ts
+++ b/src/lib/services/upload-queue-manager.ts
@@ -10,10 +10,11 @@ export type UploadStatus =
   | "cancelled";
 
 // The storage proxy's SigV4 verification mismatches on these characters
-// (browser encodeURIComponent leaves them un-escaped) — reject up front with
-// an actionable message instead of failing deep in the upload as a cryptic
-// "signature mismatch" (issue #405).
-const UNSUPPORTED_KEY_CHARS = /[!'()*]/;
+// (browser encodeURIComponent leaves them un-escaped, or in the case of
+// spaces, encodes them in a way the proxy doesn't expect) — reject up front
+// with an actionable message instead of failing deep in the upload as a
+// cryptic "signature mismatch" (issue #405).
+const UNSUPPORTED_KEY_CHARS = /[!'()* ]/;
 
 export interface QueuedUpload {
   id: string;
@@ -133,6 +134,14 @@ export class UploadQueueManager {
   }
 
   /**
+   * Remove a single upload from the queue (e.g. dismissing an error)
+   */
+  remove(id: string) {
+    this.items = this.items.filter((item) => item.id !== id);
+    this.onChange();
+  }
+
+  /**
    * Clear uploads from queue
    */
   clear(status?: UploadStatus, scope?: CredentialsScope) {
@@ -182,8 +191,9 @@ export class UploadQueueManager {
 
       const badChar = next.key.match(UNSUPPORTED_KEY_CHARS)?.[0];
       if (badChar) {
+        const label = badChar === " " ? "space" : `"${badChar}"`;
         next.status = "error";
-        next.error = `Unsupported character "${badChar}" in filename. Rename to remove ! ' ( ) * and try again.`;
+        next.error = `Unsupported character ${label} in filename. Rename to remove spaces and ! ' ( ) * and try again.`;
         this.onChange();
         continue; // doesn't consume a concurrency slot, check the next queued item
       }

--- a/src/lib/services/upload-queue-manager.ts
+++ b/src/lib/services/upload-queue-manager.ts
@@ -9,6 +9,12 @@ export type UploadStatus =
   | "error"
   | "cancelled";
 
+// The storage proxy's SigV4 verification mismatches on these characters
+// (browser encodeURIComponent leaves them un-escaped) — reject up front with
+// an actionable message instead of failing deep in the upload as a cryptic
+// "signature mismatch" (issue #405).
+const UNSUPPORTED_KEY_CHARS = /[!'()*]/;
+
 export interface QueuedUpload {
   id: string;
   file: File;
@@ -173,6 +179,14 @@ export class UploadQueueManager {
     while (this.activeIds.size < this.maxConcurrent) {
       const next = this.items.find((i) => i.status === "queued");
       if (!next) break; // No more queued items
+
+      const badChar = next.key.match(UNSUPPORTED_KEY_CHARS)?.[0];
+      if (badChar) {
+        next.status = "error";
+        next.error = `Unsupported character "${badChar}" in filename. Rename to remove ! ' ( ) * and try again.`;
+        this.onChange();
+        continue; // doesn't consume a concurrency slot, check the next queued item
+      }
 
       // Mark as active immediately
       this.activeIds.add(next.id);


### PR DESCRIPTION
## Summary
- Uploading a filename containing `!`, `'`, `(`, `)`, or `*` fails with a cryptic "Error: signature mismatch". The storage proxy's SigV4 signature verification doesn't handle those characters the way S3 does (an external service, outside this repo, so the signing bug itself can't be fixed here).
- This implements the issue's other acceptable behavior instead: reject those filenames up front with a clear, actionable error rather than failing deep inside the upload.
- `UploadQueueManager.process()` now marks any queued item whose key contains those characters as `error` with an explanatory message. Both upload entry points (drag-and-drop and the file picker) funnel through this same queue, so the check applies uniformly.

## Test plan
- [x] Added `upload-queue-manager.test.ts` covering the rejection and the unaffected happy path.
- [ ] Could not run `npm test` / `npm run lint` in this sandbox (no `node_modules`, no permission to install dependencies) - please run before merging.

Closes #405

Generated with [Claude Code](https://claude.ai/code)
