### PR TITLE
ci: allow github-actions bot to trigger Claude auto-review

### DIFF
--- a/.github/workflows/pr-review-comprehensive.yml
+++ b/.github/workflows/pr-review-comprehensive.yml
@@ -31,9 +31,9 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Allow the github-actions bot to trigger the review so that
-          # Claude-authored PRs (branches like claude/issue-<n>) get reviewed.
-          # Without this, the action aborts on bot actors ("Workflow initiated
-          # by non-human actor").
+          # Claude-authored PRs get reviewed. Without this, the action
+          # aborts on bot actors ("Workflow initiated by non-human 
+          # actor").
           allowed_bots: "github-actions"
           # Deliver the review as ONE sticky PR comment that updates in place each
           # run. track_progress forces tag mode (a single tracking comment the

--- a/.github/workflows/pr-review-comprehensive.yml
+++ b/.github/workflows/pr-review-comprehensive.yml
@@ -30,6 +30,11 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Allow the github-actions bot to trigger the review so that
+          # Claude-authored PRs (branches like claude/issue-<n>) get reviewed.
+          # Without this, the action aborts on bot actors ("Workflow initiated
+          # by non-human actor").
+          allowed_bots: "github-actions"
           # Deliver the review as ONE sticky PR comment that updates in place each
           # run. track_progress forces tag mode (a single tracking comment the
           # action owns and updates with the final result on these pull_request


### PR DESCRIPTION
## What I'm changing

Allowlist the `github-actions` bot as a valid trigger actor for the **Claude Auto Review** workflow (`.github/workflows/pr-review-comprehensive.yml`), so that Claude-authored PRs actually get reviewed instead of failing.

## How I did it

Claude-authored PRs use branches like `claude/issue-<n>`, and the auto-review workflow runs with actor `github-actions[bot]`. `anthropics/claude-code-action@v1` blocks bot actors by default (`allowed_bots` defaults to `""`), aborting the run with:

> Workflow initiated by non-human actor: github-actions (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.

(The job's existing `if: github.event.pull_request.user.type != 'Bot'` guard checks the PR *author*, not the triggering *actor*, so it doesn't cover this case — the action performs its own actor check.)

Fix: set `allowed_bots: "github-actions"` on the action step. Scoped to `github-actions` rather than `"*"` per the action's own warning that `"*"` on public repos lets external Apps invoke the action with attacker-controlled prompts.

Failing run: https://github.com/source-cooperative/source.coop/actions/runs/28485677208/job/84434781704?pr=406

## How you can test it

Once merged to `main`, a Claude-authored PR (e.g. a fresh `claude/issue-<n>` branch) should trigger the Claude Auto Review workflow and post its sticky review comment instead of erroring out with "Workflow initiated by non-human actor".
