### PR TITLE
refactor: clearer link icons

### DIFF
--- a/src/app/(app)/edit/account/[account_id]/layout.tsx
+++ b/src/app/(app)/edit/account/[account_id]/layout.tsx
@@ -5,10 +5,7 @@ import {
   SettingsHeader,
 } from "@/components/features/settings";
 import { getPageSession } from "@/lib/api/utils";
-import {
-  isAuthorized,
-  canManageAccountDataConnections,
-} from "@/lib/api/authz";
+import { isAuthorized, canManageAccountDataConnections } from "@/lib/api/authz";
 import { Actions } from "@/types";
 import { accountsTable } from "@/lib/clients/database";
 import { notFound, redirect } from "next/navigation";
@@ -17,9 +14,9 @@ import {
   PersonIcon,
   LockClosedIcon,
   Pencil1Icon,
-  GearIcon,
   ImageIcon,
   Link1Icon,
+  ExternalLinkIcon,
 } from "@radix-ui/react-icons";
 import {
   loginUrl,
@@ -31,7 +28,7 @@ import {
   accountUrl,
   orySettingsUrl,
 } from "@/lib/urls";
-import { ExternalLink } from "@/components/core/ExternalLink";
+import { LinkAway } from "@/components/core/LinkAway";
 import { getManageableAccounts } from "@/lib/clients/lookups";
 
 interface AccountLayoutProps {
@@ -68,27 +65,28 @@ export default async function AccountLayout({
   const canReadAccount = isAuthorized(
     userSession,
     accountToEdit,
-    Actions.GetAccount
+    Actions.GetAccount,
   );
   const canReadMembership = isAuthorized(
     userSession,
     accountToEdit,
-    Actions.ListAccountMemberships
+    Actions.ListAccountMemberships,
   );
   const canEditAccount = isAuthorized(
     userSession,
     accountToEdit,
-    Actions.PutAccountProfile
+    Actions.PutAccountProfile,
   );
   const canManageDataConnections = canManageAccountDataConnections(
     userSession,
-    accountToEdit
+    accountToEdit,
   );
 
   // Authentication details (email, password, keys) live in Ory and can only
   // be changed by the account owner themselves — not by an admin acting on
   // someone else's account.
-  const isOwnAccount = userSession.account.account_id === accountToEdit.account_id;
+  const isOwnAccount =
+    userSession.account.account_id === accountToEdit.account_id;
 
   const menuItems = [
     {
@@ -122,7 +120,7 @@ export default async function AccountLayout({
       condition: isAuthorized(
         userSession,
         accountToEdit,
-        Actions.GetAccountFlags
+        Actions.GetAccountFlags,
       ),
     },
     ...(accountToEdit.type === "organization"
@@ -140,7 +138,7 @@ export default async function AccountLayout({
             id: "authentication",
             label: "Authentication",
             href: orySettingsUrl(),
-            icon: <GearIcon width="16" height="16" />,
+            icon: <ExternalLinkIcon width="16" height="16" />,
             condition: canReadAccount,
             external: true,
             disabled: !isOwnAccount,
@@ -159,9 +157,9 @@ export default async function AccountLayout({
           linkToSameView
         />
 
-        <ExternalLink href={accountUrl(accountToEdit.account_id)}>
+        <LinkAway href={accountUrl(accountToEdit.account_id)}>
           View Profile
-        </ExternalLink>
+        </LinkAway>
       </SettingsHeader>
 
       <SettingsLayout menuItems={menuItems}>{children}</SettingsLayout>

--- a/src/app/(app)/edit/product/[account_id]/[product_id]/layout.tsx
+++ b/src/app/(app)/edit/product/[account_id]/[product_id]/layout.tsx
@@ -13,7 +13,7 @@ import { Actions } from "@/types";
 import { productsTable } from "@/lib/clients/database";
 import { notFound, redirect } from "next/navigation";
 import { getReturnToUrl } from "@/lib/baseUrl";
-import { ExternalLink } from "@/components/core/ExternalLink";
+import { LinkAway } from "@/components/core/LinkAway";
 import {
   loginUrl,
   productUrl,
@@ -106,9 +106,9 @@ export default async function ProductLayout({
           />
         </Flex>
 
-        <ExternalLink href={productUrl(product.account_id, product.product_id)}>
+        <LinkAway href={productUrl(product.account_id, product.product_id)}>
           View Product
-        </ExternalLink>
+        </LinkAway>
       </SettingsHeader>
       <SettingsLayout menuItems={menuItems}>{children}</SettingsLayout>
     </>

--- a/src/components/core/LinkAway.tsx
+++ b/src/components/core/LinkAway.tsx
@@ -1,19 +1,19 @@
 import { ReactNode } from "react";
 import { Flex, Text } from "@radix-ui/themes";
-import { ExternalLinkIcon } from "@radix-ui/react-icons";
+import { ChevronRightIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
 
-interface ExternalLinkProps {
+interface LinkAwayProps {
   href: string;
   children: ReactNode;
   useNextLink?: boolean;
 }
 
-export function ExternalLink({ href, children }: ExternalLinkProps) {
+export function LinkAway({ href, children }: LinkAwayProps) {
   const content = (
     <Flex align="center" gap="2">
       <Text size="1">{children}</Text>
-      <ExternalLinkIcon width="14" height="14" />
+      <ChevronRightIcon width="14" height="14" />
     </Flex>
   );
 

--- a/src/components/core/index.ts
+++ b/src/components/core/index.ts
@@ -8,6 +8,6 @@ export type { FormField } from "./DynamicForm";
 export { SmallColumnContainer } from "./SmallColumnContainer";
 export { StatusPage, NotFoundPage, NotAuthorizedPage } from "./StatusPage";
 export { EditButton } from "./EditButton";
-export { ExternalLink } from "./ExternalLink";
+export { LinkAway } from "./LinkAway";
 export * from "./AccountLinks";
 export { CopyToClipboard } from "./CopyToClipboard";


### PR DESCRIPTION
## What I'm changing

Rework links with icons that more clearly state whether they open a new tab or not. This was pointed out by @PowerChell as "odd" to which I agree.

| Before | After |
| --- | --- |
| <img width="244" height="332" alt="image" src="https://github.com/user-attachments/assets/3b008b61-60c8-41e7-ad26-b08c9da1d04c" /> | <img width="265" height="335" alt="image" src="https://github.com/user-attachments/assets/9dc715b5-7dea-4163-b53c-8330bff60190" /> |
| <img width="246" height="150" alt="image" src="https://github.com/user-attachments/assets/0c07d072-8a99-4100-9987-2bf2c432c491" /> | <img width="246" height="155" alt="image" src="https://github.com/user-attachments/assets/e7cf32d0-17fc-4994-8969-dc7fe22709f3" /> |
| <img width="251" height="136" alt="image" src="https://github.com/user-attachments/assets/e0230c8c-3acc-445b-ae9b-f38512f9a8fb" /> | <img width="238" height="162" alt="image" src="https://github.com/user-attachments/assets/c0af93cf-fc06-44f2-9eb7-dfb908c21b86" /> |

## How I did it

The new authentication menu (#349) opens a new tab. The icon should demonstrate this appropriately. We will use the ExternalLink icon.

The View Profile and View Product links open in the same tab. They should NOT use the ExternalLink icon, instead we will use the ChevronRight icon.

## How you can test it

<!--
  Instructions on how a reviewer can verify these changes.

  Consider including screenshots or video demonstrating feature.
-->
