### PR TITLE
feat: return to current page after logout

### DIFF
--- a/src/components/layout/AccountDropdown.tsx
+++ b/src/components/layout/AccountDropdown.tsx
@@ -33,7 +33,10 @@ export function AccountDropdown({ session }: { session: UserSession }) {
   const [isOpen, setIsOpen] = useState(false);
 
   const handleLogout = async () => {
-    const response = await fetch(CONFIG.auth.routes.logout, {
+    // Return to the current page after logout instead of Ory's default (root).
+    const logoutFlow = new URL(CONFIG.auth.routes.logout);
+    logoutFlow.searchParams.set("return_to", window.location.href);
+    const response = await fetch(logoutFlow, {
       method: "GET",
       credentials: "include",
     });

--- a/src/components/layout/AccountDropdown.tsx
+++ b/src/components/layout/AccountDropdown.tsx
@@ -34,7 +34,9 @@ export function AccountDropdown({ session }: { session: UserSession }) {
 
   const handleLogout = async () => {
     // Return to the current page after logout instead of Ory's default (root).
-    const logoutFlow = new URL(CONFIG.auth.routes.logout);
+    // Base arg resolves the dev-only relative route (frontendUrl is "" in dev,
+    // proxied same-origin); ignored when the route is already absolute (prod).
+    const logoutFlow = new URL(CONFIG.auth.routes.logout, window.location.origin);
     logoutFlow.searchParams.set("return_to", window.location.href);
     const response = await fetch(logoutFlow, {
       method: "GET",


### PR DESCRIPTION
## What

The Logout button in `AccountDropdown` hit Ory's browser logout flow without a `return_to` param, so after logout Ory redirected users to its server-configured default (the app root). This passes the current page URL as `return_to` so users land back on the page they were on.

This mirrors the existing **login** flow, which already passes the full current URL via `return_to` (`loginUrl` / `getReturnToUrl`), so the mechanism is proven.

## Change

```tsx
const logoutFlow = new URL(CONFIG.auth.routes.logout);
logoutFlow.searchParams.set("return_to", window.location.href);
```

One line, client-side (`window.location.href`), in `src/components/layout/AccountDropdown.tsx`.

## Notes / caveats

- **Ory allow-list**: Ory only honors `return_to` values in `selfservice.allowed_return_urls`. Login already returns to full same-origin URLs, so same-origin paths are almost certainly already allowed — that config lives outside this repo, worth a confirm.
- **Auth-gated pages**: returning to a protected page right after logout will just bounce to login. Left as-is for now (usual behavior); can add a skip-list if desired.
- **Pre-existing**: the dropdown button bypasses the separate `/logout` route, which also clears the `sc_proxy_creds` cookie. Not addressed here — this PR is scoped to the redirect. Consolidating the two logout paths could be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)