### PR TITLE
refactor: compute login return_to client-side, drop middleware header injection

### DIFF
--- a/src/app/(app)/edit/account/[account_id]/layout.tsx
+++ b/src/app/(app)/edit/account/[account_id]/layout.tsx
@@ -8,8 +8,8 @@ import { getPageSession } from "@/lib/api/utils";
 import { isAuthorized, canManageAccountDataConnections } from "@/lib/api/authz";
 import { Actions } from "@/types";
 import { accountsTable } from "@/lib/clients/database";
-import { notFound, redirect } from "next/navigation";
-import { getReturnToUrl } from "@/lib/baseUrl";
+import { notFound } from "next/navigation";
+import { LoginRequired } from "@/components/core";
 import {
   PersonIcon,
   LockClosedIcon,
@@ -19,7 +19,6 @@ import {
   ExternalLinkIcon,
 } from "@radix-ui/react-icons";
 import {
-  loginUrl,
   editAccountProfileUrl,
   editAccountProfilePictureUrl,
   editAccountPermissionsUrl,
@@ -45,7 +44,7 @@ export default async function AccountLayout({
   const userSession = await getPageSession();
 
   if (!userSession?.account) {
-    redirect(loginUrl(await getReturnToUrl()));
+    return <LoginRequired />;
   }
 
   const accountToEdit = await accountsTable.fetchById(account_id);

--- a/src/app/(app)/edit/page.tsx
+++ b/src/app/(app)/edit/page.tsx
@@ -1,16 +1,12 @@
 import { redirect } from "next/navigation";
 import { getPageSession } from "@/lib/api/utils";
-import { editProfileUrl, homeUrl, loginUrl } from "@/lib/urls";
-import { getReturnToUrl } from "@/lib/baseUrl";
+import { editProfileUrl, homeUrl } from "@/lib/urls";
+import { LoginRequired } from "@/components/core";
 
-interface SettingsPageProps {
-  params: Promise<{ account_id: string }>;
-}
-
-export default async function Redirect({ params }: SettingsPageProps) {
+export default async function Redirect() {
   const session = await getPageSession();
   if (!session) {
-    redirect(loginUrl(await getReturnToUrl()));
+    return <LoginRequired />;
   }
 
   if (!session.account?.account_id) {

--- a/src/app/(app)/edit/product/[account_id]/[product_id]/layout.tsx
+++ b/src/app/(app)/edit/product/[account_id]/[product_id]/layout.tsx
@@ -11,11 +11,10 @@ import { getPageSession } from "@/lib/api/utils";
 import { isAuthorized, isAdmin } from "@/lib/api/authz";
 import { Actions } from "@/types";
 import { productsTable } from "@/lib/clients/database";
-import { notFound, redirect } from "next/navigation";
-import { getReturnToUrl } from "@/lib/baseUrl";
+import { notFound } from "next/navigation";
 import { LinkAway } from "@/components/core/LinkAway";
+import { LoginRequired } from "@/components/core";
 import {
-  loginUrl,
   productUrl,
   editProductDetailsUrl,
   editProductMembershipsUrl,
@@ -37,7 +36,7 @@ export default async function ProductLayout({
   const session = await getPageSession();
 
   if (!session?.account) {
-    redirect(loginUrl(await getReturnToUrl()));
+    return <LoginRequired />;
   }
 
   const product = await productsTable.fetchById(account_id, product_id);

--- a/src/components/core/LoginButton.tsx
+++ b/src/components/core/LoginButton.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Button } from "@radix-ui/themes";
+import { ReactNode } from "react";
+import { loginUrl } from "@/lib/urls";
+
+/**
+ * Sign-in button that returns the user to the current page after login.
+ * Reads window.location at click time so no server-side path plumbing is
+ * needed (login lives on the Ory domain, so this is a full-page navigation).
+ */
+export function LoginButton({
+  children = "Log In / Register",
+}: {
+  children?: ReactNode;
+}) {
+  return (
+    <Button
+      onClick={() => {
+        window.location.href = loginUrl(window.location.href);
+      }}
+    >
+      {children}
+    </Button>
+  );
+}

--- a/src/components/core/LoginButton.tsx
+++ b/src/components/core/LoginButton.tsx
@@ -1,26 +1,36 @@
 "use client";
 
 import { Button } from "@radix-ui/themes";
-import { ReactNode } from "react";
+import { ReactNode, useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
 import { loginUrl } from "@/lib/urls";
 
 /**
- * Sign-in button that returns the user to the current page after login.
- * Reads window.location at click time so no server-side path plumbing is
- * needed (login lives on the Ory domain, so this is a full-page navigation).
+ * Sign-in link that returns the user to the current page after login.
+ *
+ * A plain <a> (not next/link): login lives on the Ory flow — an external
+ * domain in prod, a middleware-proxied relative path in dev — so it must be a
+ * full-page navigation, not a client-side route change.
+ *
+ * The return_to (current absolute URL) is filled in after mount and refreshed
+ * on navigation, since this button sits in the persistent header.
+ * ponytail: before mount the href is the bare login URL, so a click in that
+ * first frame returns to Ory's default rather than the current page.
  */
 export function LoginButton({
   children = "Log In / Register",
 }: {
   children?: ReactNode;
 }) {
+  const pathname = usePathname();
+  const [href, setHref] = useState(loginUrl());
+  useEffect(() => {
+    setHref(loginUrl(window.location.href));
+  }, [pathname]);
+
   return (
-    <Button
-      onClick={() => {
-        window.location.href = loginUrl(window.location.href);
-      }}
-    >
-      {children}
+    <Button asChild>
+      <a href={href}>{children}</a>
     </Button>
   );
 }

--- a/src/components/core/LoginRequired.tsx
+++ b/src/components/core/LoginRequired.tsx
@@ -1,0 +1,16 @@
+import { StatusPage } from "./StatusPage";
+import { LoginButton } from "./LoginButton";
+
+/**
+ * Interstitial shown when an unauthenticated user hits a page that requires
+ * login. Replaces a server-side redirect-to-login so the return_to can be
+ * computed client-side (see LoginButton) instead of via middleware headers.
+ */
+export function LoginRequired() {
+  return (
+    <StatusPage
+      type="unauthenticated"
+      action={<LoginButton>Sign in</LoginButton>}
+    />
+  );
+}

--- a/src/components/core/StatusPage.tsx
+++ b/src/components/core/StatusPage.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Container,
   Heading,
   Text,
@@ -6,10 +7,14 @@ import {
   Link as RadixLink,
 } from "@radix-ui/themes";
 import Link from "next/link";
-import { LinkBreak2Icon, LockClosedIcon } from "@radix-ui/react-icons";
+import {
+  LinkBreak2Icon,
+  LockClosedIcon,
+  PersonIcon,
+} from "@radix-ui/react-icons";
 import { ReactNode } from "react";
 
-type StatusType = "not-found" | "not-authorized";
+type StatusType = "not-found" | "not-authorized" | "unauthenticated";
 
 interface StatusPageProps {
   type: StatusType;
@@ -17,6 +22,8 @@ interface StatusPageProps {
   description?: ReactNode;
   actionText?: ReactNode;
   actionHref?: string;
+  /** Custom action node (e.g. a client button); overrides actionText/actionHref. */
+  action?: ReactNode;
   iconSize?: number;
   containerSize?: "1" | "2" | "3" | "4";
   minHeight?: string;
@@ -46,6 +53,17 @@ const statusConfig = {
       </>
     ),
   },
+  unauthenticated: {
+    icon: PersonIcon,
+    defaultTitle: "Sign in required",
+    defaultDescription: (
+      <>
+        You need to sign in to access this page.
+        <br />
+        You&apos;ll be returned here after logging in.
+      </>
+    ),
+  },
 };
 
 export function StatusPage({
@@ -54,6 +72,7 @@ export function StatusPage({
   description,
   actionText,
   actionHref,
+  action,
   iconSize = 48,
   containerSize,
   minHeight = "60vh",
@@ -90,11 +109,14 @@ export function StatusPage({
           {finalDescription}
         </Text>
 
-        {showAction && (
-          <RadixLink size="3" mt="5" asChild>
-            <Link href={finalActionHref}>{finalActionText}</Link>
-          </RadixLink>
-        )}
+        {showAction &&
+          (action ? (
+            <Box mt="5">{action}</Box>
+          ) : (
+            <RadixLink size="3" mt="5" asChild>
+              <Link href={finalActionHref}>{finalActionText}</Link>
+            </RadixLink>
+          ))}
       </Flex>
     </Container>
   );

--- a/src/components/core/index.ts
+++ b/src/components/core/index.ts
@@ -7,6 +7,8 @@ export { DynamicForm } from "./DynamicForm";
 export type { FormField } from "./DynamicForm";
 export { SmallColumnContainer } from "./SmallColumnContainer";
 export { StatusPage, NotFoundPage, NotAuthorizedPage } from "./StatusPage";
+export { LoginButton } from "./LoginButton";
+export { LoginRequired } from "./LoginRequired";
 export { EditButton } from "./EditButton";
 export { LinkAway } from "./LinkAway";
 export * from "./AccountLinks";

--- a/src/components/layout/AuthButtons.tsx
+++ b/src/components/layout/AuthButtons.tsx
@@ -1,9 +1,9 @@
 import { AccountDropdown } from "./AccountDropdown";
 import { getPageSession } from "@/lib/api/utils";
-import { Button, Callout, Link } from "@radix-ui/themes";
+import { Callout, Link } from "@radix-ui/themes";
 import { ExclamationTriangleIcon } from "@radix-ui/react-icons";
-import { loginUrl, onboardingUrl } from "@/lib/urls";
-import { getReturnToUrl } from "@/lib/baseUrl";
+import { onboardingUrl } from "@/lib/urls";
+import { LoginButton } from "@/components/core";
 
 export async function AuthButtons() {
   const session = await getPageSession();
@@ -26,11 +26,5 @@ export async function AuthButtons() {
     );
   }
 
-  const returnTo = await getReturnToUrl();
-
-  return (
-    <Link href={loginUrl(returnTo)}>
-      <Button>Log In / Register</Button>
-    </Link>
-  );
+  return <LoginButton />;
 }

--- a/src/lib/baseUrl.ts
+++ b/src/lib/baseUrl.ts
@@ -12,16 +12,3 @@ export async function getBaseUrl(): Promise<string> {
   const protocol = headersList.get("x-forwarded-proto") || "http";
   return `${protocol}://${host}`;
 }
-
-/**
- * Get the full URL of the current request, including path and query string.
- * Requires x-pathname and x-search headers injected by middleware.
- */
-export async function getReturnToUrl(): Promise<string> {
-  const headersList = await headers();
-  const host = headersList.get("host") || "source.coop";
-  const protocol = headersList.get("x-forwarded-proto") || "http";
-  const pathname = headersList.get("x-pathname") || "/";
-  const search = headersList.get("x-search") || "";
-  return `${protocol}://${host}${pathname}${search}`;
-}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -66,8 +66,7 @@ const handleLegacyRedirects = (request: NextRequest): NextResponse | null => {
 const ory = createOryMiddleware({});
 
 // Paths the Ory middleware proxies (self-service flows, session checks). For
-// everything else its middleware just returns a no-op NextResponse.next(), so
-// we own the response and inject the current-path headers below.
+// everything else it returns a no-op NextResponse.next().
 // See node_modules/@ory/nextjs/dist/middleware (proxyRequest match list).
 const ORY_PROXIED_PREFIXES = [
   "/self-service",
@@ -93,12 +92,7 @@ export const middleware = async (request: NextRequest) => {
     return ory(request);
   }
 
-  // Inject current path into request headers so server components can read it
-  // via headers() from next/headers (used to build return_to login URLs).
-  const requestHeaders = new Headers(request.headers);
-  requestHeaders.set("x-pathname", request.nextUrl.pathname);
-  requestHeaders.set("x-search", request.nextUrl.search);
-  return NextResponse.next({ request: { headers: requestHeaders } });
+  return NextResponse.next();
 };
 
 export const config = {


### PR DESCRIPTION
## Why

The login flow's `return_to` was built **server-side** from `x-pathname`/`x-search` headers that `middleware.ts` injected on **every** matched request. Server components can't read the current path directly, so the middleware stamped it on for `getReturnToUrl()` to reconstruct. This removes that cross-cutting mechanism by computing `return_to` client-side instead.

Follow-up to #411 (logout return_to). Discussion: the middleware header injection fed not just the header login button but three server-side redirect guards on the edit pages, so making the button client-side alone couldn't remove it — the guards had to stop redirecting server-side too.

## What changed

- **`LoginButton`** (new, client): reads `window.location.href` at click time to build the login URL — same pattern as the logout button. Used by the header and the interstitial.
- **`LoginRequired`** (new): interstitial shown when an unauthenticated user hits a protected edit page, replacing `redirect(loginUrl(await getReturnToUrl()))`. Reuses `StatusPage`.
- **`StatusPage`**: added an `unauthenticated` type and a custom `action` slot (for the client login button).
- **Edit guards** (`edit/page.tsx`, `edit/account/.../layout.tsx`, `edit/product/.../layout.tsx`): unauthenticated → render `<LoginRequired />` instead of server-redirect. **The `isAuthorized` checks (403/404) are unchanged** — only the *unauthenticated* presentation changed.
- **`getReturnToUrl()`** deleted (all callers gone); `getBaseUrl()` kept.
- **`middleware.ts`**: dropped the `x-pathname`/`x-search` injection — the fallthrough is now a plain `NextResponse.next()`. (Ory proxying, legacy redirects, and the devtools 404 are untouched.)
- Removed a stale unused `params`/`SettingsPageProps` from `edit/page.tsx` while there.

## Behavior change

A logged-out user who lands **directly** on an edit page now sees a "Sign in required" page with a Sign in button (one extra click) instead of an instant redirect to login. After login they still return to the edit page. The common case (navigating to edit while already logged in) is unchanged.

## Verification

- `tsc --noEmit` — clean
- `next lint` on touched files — clean
- `next build` — compiles, type-checks, lints, and generates static pages; only fails prerendering `/(marketing)/page` because `getFeaturedProducts` can't reach AWS in the sandbox (no valid credentials). Unrelated to this change.

Note: Ory's `selfservice.allowed_return_urls` must permit same-origin URLs (already required by the existing login flow), so no Ory config change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)