### PR TITLE
feat: add external link icon to open data viewers in a new tab

### DIFF
--- a/src/components/features/products/object-browser/ObjectPreviewExternal.tsx
+++ b/src/components/features/products/object-browser/ObjectPreviewExternal.tsx
@@ -2,7 +2,8 @@ import "server-only";
 
 import { LOGGER } from "@/lib";
 import { fileSourceUrl } from "@/lib/urls";
-import { Box, Code } from "@radix-ui/themes";
+import { Box, Code, Flex, Link } from "@radix-ui/themes";
+import { ExternalLinkIcon } from "@radix-ui/react-icons";
 import type { CSSProperties } from "react";
 import { getExtension } from "@/lib/files";
 import { DuckDBConnection } from "@duckdb/node-api";
@@ -142,6 +143,14 @@ export async function ObjectPreviewExternal(props: ObjectPreviewExternalProps) {
   const { src, style } = iframeProps;
   return (
     <Box mt="4" pt="4" style={{ borderTop: "1px solid var(--gray-6)" }}>
+      <Flex justify="end" mb="2">
+        <Link href={src} target="_blank" rel="noopener noreferrer" size="1">
+          <Flex align="center" gap="1">
+            Open in new tab
+            <ExternalLinkIcon width="14" height="14" />
+          </Flex>
+        </Link>
+      </Flex>
       <iframe
         width="100%"
         height="600px"


### PR DESCRIPTION
## Summary

Adds an "Open in new tab" link with an external-link icon above embedded data viewer iframes (pmtiles, parquet, CSV/TSV, COG, images, PDF, 3D models, zip, JSON), so viewers that are hard to use inside the constrained iframe can be opened full-size in their own browser tab/window.

Closes #417

Generated with [Claude Code](https://claude.ai/code)