### PR TITLE
fix(login): refresh return_to on query-only navigation

### DIFF
--- a/src/components/core/LoginButton.tsx
+++ b/src/components/core/LoginButton.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from "@radix-ui/themes";
 import { ReactNode, useEffect, useState } from "react";
-import { usePathname } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import { loginUrl } from "@/lib/urls";
 
 /**
@@ -14,7 +14,7 @@ import { loginUrl } from "@/lib/urls";
  *
  * The return_to (current absolute URL) is filled in after mount and refreshed
  * on navigation, since this button sits in the persistent header.
- * ponytail: before mount the href is the bare login URL, so a click in that
+ * Note: before mount the href is the bare login URL, so a click in that
  * first frame returns to Ory's default rather than the current page.
  */
 export function LoginButton({
@@ -23,10 +23,11 @@ export function LoginButton({
   children?: ReactNode;
 }) {
   const pathname = usePathname();
+  const searchParams = useSearchParams();
   const [href, setHref] = useState(loginUrl());
   useEffect(() => {
     setHref(loginUrl(window.location.href));
-  }, [pathname]);
+  }, [pathname, searchParams]);
 
   return (
     <Button asChild>


### PR DESCRIPTION
Follow-up to the post-merge review findings on #412.

## Changes

- **`LoginButton.tsx`**: the `return_to` href only recomputed on `usePathname()` changes, but `usePathname()` excludes the query string. Since LoginButton lives in the persistent header, query-only client navigations (pagination cursors in `Pagination.tsx`, filters in `ProductsFilters.tsx`) left the sign-in link pointing at a stale URL. Now also depends on `useSearchParams()` so the href recomputes on query-only navigation too.
- Removed a stray `ponytail:` artifact in the doc comment (now `Note:`).

## Suspense safety

`useSearchParams` requires a Suspense boundary on statically prerendered pages. Both render paths are safe:
- Header: `Navigation` wraps `AuthButtons` (→ `LoginButton`) in `<Suspense>`.
- `LoginRequired`: only rendered by session-gated pages (`getPageSession()` reads cookies → always dynamically rendered).

## Verification

- `npm run type-check` passes
- `npx jest src/components` — 37 tests pass
- `next build` compiles and lints clean; prerender aborts on a pre-existing sandbox limitation (no DynamoDB creds for `getFeaturedProducts` on `/`), unrelated to this diff — notably no `useSearchParams` missing-Suspense bailout errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)