### PR TITLE
fix(product): remove object preview loading skeleton

### DIFF
--- a/src/app/(app)/[account_id]/[product_id]/(product)/[[...path]]/page.tsx
+++ b/src/app/(app)/[account_id]/[product_id]/(product)/[[...path]]/page.tsx
@@ -12,10 +12,7 @@ import { ProxyCredentialsGate } from "@/components/features/products/ProxyCreden
 import { ProductDataUnavailable } from "@/components/features/products/ProductDataUnavailable";
 import { DirectoryList } from "@/components/features/products/object-browser/DirectoryList";
 import { ObjectSummary } from "@/components/features/products/object-browser/ObjectSummary";
-import {
-  ObjectPreview,
-  ObjectPreviewLoading,
-} from "@/components/features/products/object-browser/ObjectPreview";
+import { ObjectPreview } from "@/components/features/products/object-browser/ObjectPreview";
 import { generateProductMetadata } from "@/components/features/metadata/ProductMetadata";
 
 export async function generateMetadata({
@@ -145,7 +142,7 @@ export default async function ProductPathPage({ params }: PageProps) {
             objectInfo={objectInfo}
             connectionDetails={connectionDetails}
           />
-          <Suspense fallback={<ObjectPreviewLoading />}>
+          <Suspense fallback={null}>
             <ObjectPreview
               account_id={account_id}
               product_id={product_id}

--- a/src/components/features/products/object-browser/ObjectPreview.tsx
+++ b/src/components/features/products/object-browser/ObjectPreview.tsx
@@ -3,7 +3,6 @@ import {
   ObjectPreviewInternal,
 } from "./ObjectPreviewInternal";
 import { ObjectPreviewExternal } from "./ObjectPreviewExternal";
-import { Box, Skeleton } from "@radix-ui/themes";
 
 interface ObjectPreviewProps {
   account_id: string;
@@ -17,14 +16,4 @@ export async function ObjectPreview(props: ObjectPreviewProps) {
   } else {
     return <ObjectPreviewExternal {...props} />;
   }
-}
-
-export function ObjectPreviewLoading() {
-  return (
-    <Skeleton>
-      <Box mt="4" pt="4" style={{ borderTop: "1px solid var(--gray-6)" }}>
-        <Box width="100%" height="600px" />
-      </Box>
-    </Skeleton>
-  );
 }


### PR DESCRIPTION
Navigating to a subpath (e.g. `/{account}/{product}/{path}`) showed a 600px shimmering `Skeleton` below the file summary while `ObjectPreview` streamed in. The product root never shows one because the `@readme` slot's loading state is `null` — this makes the preview behave the same way: no fallback, content appears when ready.

- `Suspense` fallback for `ObjectPreview` is now `null` (streaming behavior unchanged — `ObjectSummary` still renders immediately)
- Deleted the now-unused `ObjectPreviewLoading`

🤖 Generated with [Claude Code](https://claude.com/claude-code)