### PR TITLE
fix(uploader): show timezone abbreviation on credentials expiration

### DIFF
--- a/src/components/features/uploader/ViewCredentialsDialog.tsx
+++ b/src/components/features/uploader/ViewCredentialsDialog.tsx
@@ -104,7 +104,9 @@ export function ViewCredentialsDialog({
                 [
                   "Expiration",
                   <span key="expiration" title={credentials.expiration}>
-                    {new Date(credentials.expiration).toLocaleString()}
+                    {new Date(credentials.expiration).toLocaleString(undefined, {
+                      timeZoneName: "short",
+                    })}
                   </span>,
                   credentials.expiration,
                 ],


### PR DESCRIPTION
Closes #424

The Expiration timestamp in the View Credentials dialog was rendered via `toLocaleString()` with no timezone indication, leaving it ambiguous whether it was local, UTC, etc. This adds `timeZoneName: "short"` so the browser's local timezone abbreviation is shown alongside the timestamp.

Generated with [Claude Code](https://claude.ai/code)