### PR TITLE
fix: automatically retry uploads on transient network errors

### DIFF
--- a/src/lib/services/upload-queue-manager.test.ts
+++ b/src/lib/services/upload-queue-manager.test.ts
@@ -67,4 +67,24 @@ describe("UploadQueueManager auto-retry", () => {
     expect(manager.getAll()[0].status).toBe("error");
     expect(uploadFile).toHaveBeenCalledTimes(1);
   });
+
+  it("does not resurrect an item that was cancelled while an auto-retry was pending", async () => {
+    const uploadFile = jest
+      .fn()
+      .mockResolvedValue({ upload: {}, result: Promise.reject(new TypeError("Failed to fetch")) });
+
+    const manager = new UploadQueueManager(1);
+    manager.add([makeFile()], "", scope, fakeService(uploadFile));
+
+    await jest.advanceTimersByTimeAsync(0); // first attempt fails, backoff scheduled
+    const id = manager.getAll()[0].id;
+
+    manager.cancelAll(); // user cancels before the backoff elapses
+    expect(manager.getAll()[0].status).toBe("error"); // cancelAll leaves errored items as-is...
+
+    await jest.advanceTimersByTimeAsync(10000); // ...but the pending timer must not fire
+
+    expect(manager.getAll().find((i) => i.id === id)?.status).toBe("error");
+    expect(uploadFile).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/lib/services/upload-queue-manager.test.ts
+++ b/src/lib/services/upload-queue-manager.test.ts
@@ -1,0 +1,70 @@
+import { UploadQueueManager } from "./upload-queue-manager";
+import type { S3UploadService } from "./s3-upload";
+import type { CredentialsScope } from "@/components/features/uploader/CredentialsProvider";
+
+const scope: CredentialsScope = { accountId: "acct", productId: "prod" };
+
+function fakeService(uploadFile: jest.Mock): S3UploadService {
+  return { uploadFile } as unknown as S3UploadService;
+}
+
+function makeFile(name = "file.txt") {
+  return new File(["content"], name);
+}
+
+describe("UploadQueueManager auto-retry", () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it("auto-retries a 'failed to fetch' error and completes on the next attempt", async () => {
+    let attempt = 0;
+    const uploadFile = jest.fn().mockImplementation(async () => {
+      attempt++;
+      if (attempt < 2) {
+        return { upload: {}, result: Promise.reject(new TypeError("Failed to fetch")) };
+      }
+      return { upload: {}, result: Promise.resolve({ key: "k" }) };
+    });
+
+    const manager = new UploadQueueManager(1);
+    manager.add([makeFile()], "", scope, fakeService(uploadFile));
+
+    await jest.advanceTimersByTimeAsync(0);
+    expect(manager.getAll()[0].status).toBe("error");
+
+    await jest.advanceTimersByTimeAsync(2000); // backoff before retry #1
+    expect(manager.getAll()[0].status).toBe("completed");
+    expect(attempt).toBe(2);
+  });
+
+  it("gives up after the max auto-retries and stays in error state", async () => {
+    const uploadFile = jest
+      .fn()
+      .mockResolvedValue({ upload: {}, result: Promise.reject(new TypeError("Failed to fetch")) });
+
+    const manager = new UploadQueueManager(1);
+    manager.add([makeFile()], "", scope, fakeService(uploadFile));
+
+    await jest.advanceTimersByTimeAsync(0);
+    await jest.advanceTimersByTimeAsync(2000);
+    await jest.advanceTimersByTimeAsync(4000);
+    await jest.advanceTimersByTimeAsync(6000);
+
+    expect(manager.getAll()[0].status).toBe("error");
+    expect(uploadFile).toHaveBeenCalledTimes(4); // initial attempt + 3 retries
+  });
+
+  it("does not auto-retry non-network errors", async () => {
+    const uploadFile = jest
+      .fn()
+      .mockResolvedValue({ upload: {}, result: Promise.reject(new Error("Access Denied")) });
+
+    const manager = new UploadQueueManager(1);
+    manager.add([makeFile()], "", scope, fakeService(uploadFile));
+
+    await jest.advanceTimersByTimeAsync(10000);
+
+    expect(manager.getAll()[0].status).toBe("error");
+    expect(uploadFile).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/services/upload-queue-manager.ts
+++ b/src/lib/services/upload-queue-manager.ts
@@ -21,6 +21,7 @@ export interface QueuedUpload {
   s3Service: S3UploadService;
   uploadInstance?: Upload;
   retryCount: number;
+  retryTimeoutId?: ReturnType<typeof setTimeout>;
 }
 
 // Browsers throw "TypeError: Failed to fetch" (or "NetworkError...") for
@@ -43,6 +44,14 @@ export class UploadQueueManager {
 
   constructor(maxConcurrent = 2) {
     this.maxConcurrent = maxConcurrent;
+  }
+
+  /** Stop a pending auto-retry so it can't resurrect an item after cancel/clear/retry. */
+  private clearRetryTimer(item: QueuedUpload) {
+    if (item.retryTimeoutId !== undefined) {
+      clearTimeout(item.retryTimeoutId);
+      item.retryTimeoutId = undefined;
+    }
   }
 
   /**
@@ -78,6 +87,7 @@ export class UploadQueueManager {
     const item = this.items.find((i) => i.id === id);
     if (!item) return;
 
+    this.clearRetryTimer(item);
     item.status = "cancelled";
 
     // Abort if currently uploading
@@ -105,6 +115,10 @@ export class UploadQueueManager {
         return; // Different scope, skip
       }
 
+      // Stop any pending auto-retry too, even for already-"error" items,
+      // so "Cancel All" can't be undone by a timer firing afterwards.
+      this.clearRetryTimer(item);
+
       if (item.status === "uploading" || item.status === "queued") {
         item.status = "cancelled";
 
@@ -129,6 +143,7 @@ export class UploadQueueManager {
     const item = this.items.find((i) => i.id === id);
     if (!item || item.status !== "error") return;
 
+    this.clearRetryTimer(item);
     item.status = "queued";
     item.uploadedBytes = 0;
     item.error = undefined;
@@ -150,9 +165,12 @@ export class UploadQueueManager {
         ) {
           return true; // Keep - different scope
         }
-        return status ? item.status !== status : false;
+        const keep = status ? item.status !== status : false;
+        if (!keep) this.clearRetryTimer(item); // dropped - stop its pending auto-retry
+        return keep;
       });
     } else {
+      this.items.forEach((item) => this.clearRetryTimer(item));
       this.items = [];
     }
     this.onChange();
@@ -234,7 +252,8 @@ export class UploadQueueManager {
     ) {
       item.retryCount++;
       const delay = RETRY_DELAY_MS * item.retryCount;
-      setTimeout(() => {
+      item.retryTimeoutId = setTimeout(() => {
+        item.retryTimeoutId = undefined;
         if (item.status === "error") {
           item.status = "queued";
           item.uploadedBytes = 0;

--- a/src/lib/services/upload-queue-manager.ts
+++ b/src/lib/services/upload-queue-manager.ts
@@ -20,7 +20,16 @@ export interface QueuedUpload {
   scope: CredentialsScope;
   s3Service: S3UploadService;
   uploadInstance?: Upload;
+  retryCount: number;
 }
+
+// Browsers throw "TypeError: Failed to fetch" (or "NetworkError...") for
+// transient connectivity blips — issue #425. Auto-retry those a few times
+// with backoff before surfacing the manual "Retry Upload" button.
+const MAX_AUTO_RETRIES = 3;
+const RETRY_DELAY_MS = 2000;
+const isRetryableError = (message?: string) =>
+  !!message && /failed to fetch|network ?error/i.test(message);
 
 /**
  * Simple imperative upload queue manager
@@ -54,6 +63,7 @@ export class UploadQueueManager {
       totalBytes: file.size,
       scope,
       s3Service,
+      retryCount: 0,
     }));
 
     this.items.push(...newItems);
@@ -122,6 +132,7 @@ export class UploadQueueManager {
     item.status = "queued";
     item.uploadedBytes = 0;
     item.error = undefined;
+    item.retryCount = 0;
     this.onChange();
     this.process();
   }
@@ -214,6 +225,24 @@ export class UploadQueueManager {
       item.uploadInstance = undefined;
       this.onChange();
       this.process(); // Fill the slot we just freed up
+    }
+
+    if (
+      item.status === "error" &&
+      isRetryableError(item.error) &&
+      item.retryCount < MAX_AUTO_RETRIES
+    ) {
+      item.retryCount++;
+      const delay = RETRY_DELAY_MS * item.retryCount;
+      setTimeout(() => {
+        if (item.status === "error") {
+          item.status = "queued";
+          item.uploadedBytes = 0;
+          item.error = undefined;
+          this.onChange();
+          this.process();
+        }
+      }, delay);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Uploads that fail with a transient "failed to fetch" / network error are now retried automatically (up to 3 attempts, with backoff of 2s/4s/6s) before falling back to the manual "Retry Upload" button.
- Fixed a race found during self-review: the scheduled retry timer is now tracked per item and cancelled by cancel(), cancelAll(), clear(), and manual retry(), so a stale timer can no longer resurrect an item the user already cancelled, cleared, or manually retried.

Closes #425

## Test plan
- [x] Added unit tests in src/lib/services/upload-queue-manager.test.ts covering: successful auto-retry, exhausting max retries, skipping non-network errors, and cancel-during-backoff not resurrecting the item.
- [ ] Could not run `npm test`/`npx jest` in this sandboxed environment (Bash permission denied for anything beyond git); please run the suite in CI/locally to confirm.

Generated with [Claude Code](https://claude.ai/code)