### PR TITLE
fix(product): shorten product page card titles

### DIFF
--- a/src/app/(app)/[account_id]/[product_id]/(product)/[[...path]]/layout.tsx
+++ b/src/app/(app)/[account_id]/[product_id]/(product)/[[...path]]/layout.tsx
@@ -92,7 +92,7 @@ export default async function ProductLayout({
         <Dropzone product={product} prefix={prefix}>
           <Card>
             <SectionHeader
-              title="Product Contents"
+              title="Contents"
               rightButton={
                 canWriteData && (
                   <FetchCredentialsButton

--- a/src/app/(app)/[account_id]/[product_id]/loading.tsx
+++ b/src/app/(app)/[account_id]/[product_id]/loading.tsx
@@ -38,7 +38,7 @@ export default function ProductDetailsLoading() {
         {/* Product Meta Card Skeleton - 1 column */}
         <Box width="100%" className="product-meta">
           <Card style={{ height: "100%" }} size={{ initial: "2", sm: "1" }}>
-            <SectionHeader title="Product Details">
+            <SectionHeader title="Details">
               <DataList.Root>
                 {/* Visibility Badge Skeleton */}
                 <DataList.Item>
@@ -96,7 +96,7 @@ export default function ProductDetailsLoading() {
       <Card mt="4">
         <Box>
           {/* Breadcrumb Skeleton */}
-          <SectionHeader title="Product Contents">
+          <SectionHeader title="Contents">
             <Flex
               pb="3"
               mb="3"

--- a/src/components/features/products/ProductMetaCard.tsx
+++ b/src/components/features/products/ProductMetaCard.tsx
@@ -10,7 +10,7 @@ interface ProductMetaCardProps {
 export function ProductMetaCard({ product }: ProductMetaCardProps) {
   return (
     <Card style={{ height: '100%' }} size={{ initial: '2', sm: '1' }}>
-      <SectionHeader title="Product Details">
+      <SectionHeader title="Details">
         <ProductMetaContent product={product} />
       </SectionHeader>
     </Card>


### PR DESCRIPTION
## What I'm changing

When working on #421, I noticed that almost every card (save for "README") began with either "Product" or "Object": 

| <img width="1160" height="1010" alt="image" src="https://github.com/user-attachments/assets/683114e3-8435-4e73-9ad1-80b4d00b1fd7" /> |
|:--:|
| _"Product ..." overload_ |

This feels unnecessary and overly noise.

## How I did it

Renames the product page cards: "Product Contents" → "Contents" and "Product Details" → "Details", including the loading skeleton. The cards live on the product page, so the prefix was redundant.

Left "Product Title" in the creation form unchanged — it is a form field label, not a card title.

| <img width="1158" height="427" alt="image" src="https://github.com/user-attachments/assets/e1b0e8ca-71f5-4c82-a4d1-9d73bdf151ae" /> |
|:--:|
| _Before_ |


| <img width="1155" height="429" alt="image" src="https://github.com/user-attachments/assets/6c2c75a2-67d0-48eb-9508-1701b4bb0f5f" /> |
|:--:|
| _After_ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)