### PR TITLE
fix(uploader): include endpoint_url in INI credentials format

### DIFF
--- a/src/components/features/uploader/ViewCredentialsDialog.tsx
+++ b/src/components/features/uploader/ViewCredentialsDialog.tsx
@@ -54,6 +54,7 @@ export function ViewCredentialsDialog({
     `aws_access_key_id = ${credentials.accessKeyId}`,
     `aws_secret_access_key = ${credentials.secretAccessKey}`,
     `aws_session_token = ${credentials.sessionToken}`,
+    `endpoint_url = ${credentials.endpoint}`,
   ].join("\n");
 
   return (


### PR DESCRIPTION
The INI tab of the View Credentials dialog omitted the endpoint, so a profile pasted into `~/.aws/credentials` would hit the default AWS endpoint and 403. Adds `endpoint_url = …` to the profile, matching the JSON and env formats (both AWS CLI and boto3 honor `endpoint_url` in profile settings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)