### PR TITLE
feat(credentials): add callout pointing to Source Coop CLI

### DIFF
--- a/src/components/features/uploader/ViewCredentialsDialog.tsx
+++ b/src/components/features/uploader/ViewCredentialsDialog.tsx
@@ -77,6 +77,7 @@ export function ViewCredentialsDialog({
               href="https://github.com/source-cooperative/source-coop-cli"
               target="_blank"
               rel="noopener noreferrer"
+              weight="bold"
             >
               Source Coop CLI
             </Link>{" "}

--- a/src/components/features/uploader/ViewCredentialsDialog.tsx
+++ b/src/components/features/uploader/ViewCredentialsDialog.tsx
@@ -11,8 +11,10 @@ import {
   IconButton,
   Tooltip,
   DataList,
+  Callout,
+  Link,
 } from "@radix-ui/themes";
-import { CopyIcon, CheckIcon } from "@radix-ui/react-icons";
+import { CopyIcon, CheckIcon, InfoCircledIcon } from "@radix-ui/react-icons";
 import React, { useState } from "react";
 import { MonoText } from "@/components/core";
 
@@ -64,6 +66,23 @@ export function ViewCredentialsDialog({
         <Dialog.Description size="2" mb="4">
           Copy these temporary credentials to use in your applications.
         </Dialog.Description>
+
+        <Callout.Root size="1" mb="4">
+          <Callout.Icon>
+            <InfoCircledIcon />
+          </Callout.Icon>
+          <Callout.Text>
+            Prefer a simpler workflow? The{" "}
+            <Link
+              href="https://github.com/source-cooperative/source-coop-cli"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Source Coop CLI
+            </Link>{" "}
+            handles credentials for you.
+          </Callout.Text>
+        </Callout.Root>
 
         <Tabs.Root defaultValue="json">
           <Tabs.List>

--- a/src/components/features/uploader/ViewCredentialsDialog.tsx
+++ b/src/components/features/uploader/ViewCredentialsDialog.tsx
@@ -77,11 +77,11 @@ export function ViewCredentialsDialog({
               href="https://github.com/source-cooperative/source-coop-cli"
               target="_blank"
               rel="noopener noreferrer"
-              weight="bold"
             >
               Source Coop CLI
             </Link>{" "}
-            handles credentials for you.
+            handles credentials for you, with longer-lived credentials (up to
+            12 hours).
           </Callout.Text>
         </Callout.Root>
 


### PR DESCRIPTION
Adds a short info callout to the View Credentials dialog pointing users to the [Source Coop CLI](https://github.com/source-cooperative/source-coop-cli), which handles temporary credentials automatically.

<img width="621" height="680" alt="image" src="https://github.com/user-attachments/assets/d4b06be0-a6c9-458f-9c6d-c730bf81cd91" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)