### PR TITLE
feat(credentials): add OS selector for env var format

### DIFF
--- a/src/components/features/uploader/ViewCredentialsDialog.tsx
+++ b/src/components/features/uploader/ViewCredentialsDialog.tsx
@@ -11,6 +11,7 @@ import {
   IconButton,
   Tooltip,
   DataList,
+  SegmentedControl,
 } from "@radix-ui/themes";
 import { CopyIcon, CheckIcon } from "@radix-ui/react-icons";
 import React, { useState } from "react";
@@ -41,13 +42,20 @@ export function ViewCredentialsDialog({
     2
   );
 
+  const [envShell, setEnvShell] = useState<"sh" | "ps">("sh");
   const envFormat = [
-    `export AWS_ACCESS_KEY_ID="${credentials.accessKeyId}"`,
-    `export AWS_SECRET_ACCESS_KEY="${credentials.secretAccessKey}"`,
-    `export AWS_SESSION_TOKEN="${credentials.sessionToken}"`,
-    `export AWS_DEFAULT_REGION="${credentials.region}"`,
-    `export AWS_ENDPOINT_URL="${credentials.endpoint}"`,
-  ].join("\n");
+    ["AWS_ACCESS_KEY_ID", credentials.accessKeyId],
+    ["AWS_SECRET_ACCESS_KEY", credentials.secretAccessKey],
+    ["AWS_SESSION_TOKEN", credentials.sessionToken],
+    ["AWS_DEFAULT_REGION", credentials.region],
+    ["AWS_ENDPOINT_URL", credentials.endpoint],
+  ]
+    .map(([name, value]) =>
+      envShell === "sh"
+        ? `export ${name}="${value}"`
+        : `$env:${name}="${value}"`
+    )
+    .join("\n");
 
   const iniFormat = [
     `[source-coop]`,
@@ -83,6 +91,20 @@ export function ViewCredentialsDialog({
               value="env"
               title="For terminal/shell usage"
               content={envFormat}
+              controls={
+                <SegmentedControl.Root
+                  size="1"
+                  value={envShell}
+                  onValueChange={(value) => setEnvShell(value as "sh" | "ps")}
+                >
+                  <SegmentedControl.Item value="sh">
+                    macOS / Linux
+                  </SegmentedControl.Item>
+                  <SegmentedControl.Item value="ps">
+                    Windows (PowerShell)
+                  </SegmentedControl.Item>
+                </SegmentedControl.Root>
+              }
             />
 
             <CredentialsTabContent
@@ -193,19 +215,24 @@ interface CredentialsTabContentProps {
   value: string;
   title: string;
   content: string;
+  controls?: React.ReactNode;
 }
 
 function CredentialsTabContent({
   value,
   title,
   content,
+  controls,
 }: CredentialsTabContentProps) {
   return (
     <Tabs.Content value={value}>
       <Flex direction="column" gap="2">
-        <Text size="1" weight="regular" color="gray">
-          {title}
-        </Text>
+        <Flex align="center" justify="between" gap="2">
+          <Text size="1" weight="regular" color="gray">
+            {title}
+          </Text>
+          {controls}
+        </Flex>
         <Box style={{ position: "relative" }}>
           <Box
             style={{


### PR DESCRIPTION
## Summary
The **Environment Variables** tab in the View Credentials dialog only showed POSIX `export VAR=...` syntax, which doesn't work on Windows. This adds a small segmented control to the tab that toggles between:

- **macOS / Linux**: `export AWS_ACCESS_KEY_ID="..."`
- **Windows (PowerShell)**: `$env:AWS_ACCESS_KEY_ID="..."`

The copy button copies whichever format is selected. JSON and INI tabs are unchanged (those formats are OS-agnostic).

Skipped cmd.exe (`set VAR=...`) — PowerShell is the default shell on modern Windows; add if users ask.

## Testing
- `npm run type-check` passes
- `next lint` on the file passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

closes #434