### PR TITLE
feat(nav): drop dash icons, divide "New product" in account dropdown

### DIFF
--- a/src/components/layout/AccountDropdown.tsx
+++ b/src/components/layout/AccountDropdown.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useState, type CSSProperties } from "react";
 import { Flex, DropdownMenu, Text, Box } from "@radix-ui/themes";
-import { ChevronDownIcon, PlusIcon, DashIcon } from "@radix-ui/react-icons";
+import { ChevronDownIcon, PlusIcon } from "@radix-ui/react-icons";
 import styles from "./Navigation.module.css";
 import {
   accountUrl,
@@ -132,10 +132,7 @@ export function AccountDropdown({
                 ? products.slice(0, 20).map((product) => ({
                     href: productUrl(account.account_id, product.product_id),
                     children: (
-                      <>
-                        <DashIcon style={{ color: "var(--gray-a10)" }} />
-                        <span style={entityNameStyle}>{product.title}</span>
-                      </>
+                      <span style={entityNameStyle}>{product.title}</span>
                     ),
                   }))
                 : [
@@ -145,8 +142,10 @@ export function AccountDropdown({
                       disabled: true,
                     },
                   ]),
-              // Create a product for this account, at the bottom of its list.
+              // Create a product for this account, at the bottom of its list,
+              // set off from the products above by a divider.
               {
+                separator: true,
                 href: canCreateProduct
                   ? newProductUrl(account.account_id)
                   : undefined,

--- a/src/components/layout/DropdownSection.tsx
+++ b/src/components/layout/DropdownSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { DropdownMenu, Tooltip } from "@radix-ui/themes";
 import Link from "next/link";
-import { CSSProperties, ReactNode } from "react";
+import { CSSProperties, Fragment, ReactNode } from "react";
 
 // Used by Links rendered AS a menu item (Radix `asChild`). The Link inherits
 // the item's padding/layout/highlight from Radix, so we only neutralize the
@@ -24,6 +24,8 @@ export interface DropdownItem {
   condition?: boolean;
   /** Shown on hover when the item is disabled (e.g. why an action is blocked). */
   tooltip?: ReactNode;
+  /** Render a separator immediately before this item. */
+  separator?: boolean;
 }
 
 // Render a list of menu items, honoring each item's `condition`. Shared by the
@@ -36,8 +38,8 @@ function DropdownItems({ items }: { items: DropdownItem[] }) {
     // let React reconcile the wrong node.
     .map((item, index) => ({ item, index }))
     .filter(({ item: { condition = true } }) => condition)
-    .map(({ item, index }) =>
-      item.disabled && item.tooltip ? (
+    .map(({ item, index }) => {
+      const rendered = item.disabled && item.tooltip ? (
         // Blocked action: a real (disabled) menu item keeps the menu's padding,
         // wrapped in a span so pointer-events stay alive for the tooltip to fire.
         <Tooltip key={index} content={item.tooltip}>
@@ -71,8 +73,16 @@ function DropdownItems({ items }: { items: DropdownItem[] }) {
         >
           {item.children}
         </DropdownMenu.Item>
-      )
-    );
+      );
+      return item.separator ? (
+        <Fragment key={index}>
+          <DropdownMenu.Separator />
+          {rendered}
+        </Fragment>
+      ) : (
+        rendered
+      );
+    });
 }
 
 const visibleCount = (items: DropdownItem[]) =>


### PR DESCRIPTION
## What

In the account/org submenu of the account dropdown:

- **Remove the dash icon** (`DashIcon`) that prefixed each product in the Products list.
- **Divide the "New product" action** from the product list above it with a separator.

## How

Adds a small reusable `separator?: boolean` flag to `DropdownItem` — when set, a `DropdownMenu.Separator` is rendered immediately before that item. The "New product" action uses it.

## Notes

- One pre-existing integration test (`renders asChild link items without throwing React.Children.only`) fails on `main` already; unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)