### PR TITLE
feat(admin): view the app as another user (#443)

### DIFF
--- a/src/app/(app)/[account_id]/IndividualProfilePage.tsx
+++ b/src/app/(app)/[account_id]/IndividualProfilePage.tsx
@@ -6,7 +6,7 @@ import {
 } from "@/lib/clients/database";
 import { type IndividualAccount, Actions } from "@/types";
 import { getPageSession } from "@/lib/api/utils";
-import { isAuthorized } from "@/lib/api/authz";
+import { isAdmin, isAuthorized } from "@/lib/api/authz";
 import { IndividualProfile } from "@/components/features/profiles/IndividualProfile";
 
 interface IndividualProfilePageProps {
@@ -51,6 +51,12 @@ export async function IndividualProfilePage({
       organizations={organizations}
       showWelcome={showWelcome}
       canEdit={isAuthorized(session, account, Actions.PutAccountProfile)}
+      // Admins (never an already-impersonated session, whose account is the
+      // non-admin target) can view the app as this user, unless it's their own.
+      canImpersonate={
+        isAdmin(session) &&
+        session?.account?.account_id !== account.account_id
+      }
     />
   );
 }

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -3,6 +3,7 @@ import { Box, Container, Flex } from "@radix-ui/themes";
 import { Navigation, Footer } from "@/components";
 import { VerificationBanner } from "@/components/features/auth/VerificationBanner";
 import { StepUpGuard } from "@/components/features/auth/StepUpGuard";
+import { ImpersonationBanner } from "@/components/features/admin/ImpersonationBanner";
 
 interface AppLayoutProps {
   children: React.ReactNode;
@@ -27,6 +28,9 @@ export default function AppLayout({ children }: AppLayoutProps) {
            */}
           <Suspense fallback={null}>
             <VerificationBanner />
+          </Suspense>
+          <Suspense fallback={null}>
+            <ImpersonationBanner />
           </Suspense>
           {children}
         </Container>

--- a/src/app/(app)/logout/route.tsx
+++ b/src/app/(app)/logout/route.tsx
@@ -1,6 +1,7 @@
 import { CONFIG, LOGGER } from "@/lib";
 import { NextRequest, NextResponse } from "next/server";
 import { PROXY_CREDS_COOKIE_NAME } from "@/lib/services/proxy-credentials-shared";
+import { IMPERSONATION_COOKIE_NAME } from "@/lib/services/impersonation";
 
 export async function GET(request: NextRequest) {
   const returnTo = new URL(request.url).origin;
@@ -40,6 +41,14 @@ export async function GET(request: NextRequest) {
   // proxy-credentials-cache.ts — on HTTPS a clearing Set-Cookie that omits
   // `secure` can be ignored, leaving the cookie alive until its own maxAge.
   res.cookies.set(PROXY_CREDS_COOKIE_NAME, "", {
+    path: "/",
+    maxAge: 0,
+    httpOnly: true,
+    secure: true,
+    sameSite: "lax",
+  });
+  // Also drop any active impersonation so the next session starts as itself.
+  res.cookies.set(IMPERSONATION_COOKIE_NAME, "", {
     path: "/",
     maxAge: 0,
     httpOnly: true,

--- a/src/components/features/admin/ImpersonationBanner.tsx
+++ b/src/components/features/admin/ImpersonationBanner.tsx
@@ -1,0 +1,38 @@
+import { Box, Button, Callout, Flex } from "@radix-ui/themes";
+import { EyeOpenIcon, ExitIcon } from "@radix-ui/react-icons";
+import { getPageSession } from "@/lib/api/utils";
+import { stopImpersonation } from "@/lib/actions/admin";
+
+/**
+ * Always-on warning shown while an admin is viewing the app as another user.
+ * Renders nothing for a normal session. The session it reads is already the
+ * impersonated target (see `applyImpersonation`); `impersonator` carries the
+ * real admin so we can name who is really driving and offer an exit.
+ */
+export async function ImpersonationBanner() {
+  const session = await getPageSession();
+  if (!session?.impersonator) return null;
+
+  return (
+    <Box mb="4">
+      <Callout.Root color="amber" role="alert">
+        <Flex align="center" justify="between" gap="3" wrap="wrap">
+          <Flex align="center" gap="2">
+            <Callout.Icon>
+              <EyeOpenIcon />
+            </Callout.Icon>
+            <Callout.Text>
+              You are viewing the app as <strong>{session.account?.name}</strong>
+              . Actions you take are performed as this user.
+            </Callout.Text>
+          </Flex>
+          <form action={stopImpersonation}>
+            <Button type="submit" variant="solid" color="amber" size="1">
+              <ExitIcon /> Exit
+            </Button>
+          </form>
+        </Flex>
+      </Callout.Root>
+    </Box>
+  );
+}

--- a/src/components/features/admin/ViewAsButton.tsx
+++ b/src/components/features/admin/ViewAsButton.tsx
@@ -1,0 +1,20 @@
+import { Button } from "@radix-ui/themes";
+import { EyeOpenIcon } from "@radix-ui/react-icons";
+import { startImpersonation } from "@/lib/actions/admin";
+
+/**
+ * Admin control (shown next to a user's profile Edit button) that starts
+ * viewing the app as that user. Rendering is gated by the caller — only an
+ * admin viewing someone else's profile sees it. The server action re-checks
+ * admin, so it is safe even if the button leaks into other renders.
+ */
+export function ViewAsButton({ targetAccountId }: { targetAccountId: string }) {
+  return (
+    <form action={startImpersonation}>
+      <input type="hidden" name="account_id" value={targetAccountId} />
+      <Button type="submit" variant="soft" size="2">
+        <EyeOpenIcon /> View as user
+      </Button>
+    </form>
+  );
+}

--- a/src/components/features/profiles/IndividualProfile.tsx
+++ b/src/components/features/profiles/IndividualProfile.tsx
@@ -17,6 +17,7 @@ import { ProductsList } from "../products/ProductsList";
 import { WebsiteLink } from "./WebsiteLink";
 import { EmailVerificationStatus } from "./EmailVerificationStatus";
 import { AvatarLinkCompact, EditButton } from "@/components/core";
+import { ViewAsButton } from "@/components/features/admin/ViewAsButton";
 import { WelcomeCallout } from "./WelcomeCallout";
 
 interface IndividualProfileProps {
@@ -27,6 +28,7 @@ interface IndividualProfileProps {
   organizations: OrganizationalAccount[];
   showWelcome?: boolean;
   canEdit: boolean;
+  canImpersonate?: boolean;
 }
 
 export function IndividualProfile({
@@ -37,6 +39,7 @@ export function IndividualProfile({
   organizations,
   showWelcome = false,
   canEdit,
+  canImpersonate = false,
 }: IndividualProfileProps) {
   const primaryEmail = account.emails?.find((email) => email.is_primary);
   return (
@@ -61,9 +64,14 @@ export function IndividualProfile({
               )}
             </Box>
           </Flex>
-          {canEdit && (
-            <EditButton href={editAccountProfileUrl(account.account_id)} />
-          )}
+          <Flex gap="2" align="center">
+            {canImpersonate && (
+              <ViewAsButton targetAccountId={account.account_id} />
+            )}
+            {canEdit && (
+              <EditButton href={editAccountProfileUrl(account.account_id)} />
+            )}
+          </Flex>
         </Flex>
       </Box>
 

--- a/src/lib/actions/admin.ts
+++ b/src/lib/actions/admin.ts
@@ -1,12 +1,17 @@
 "use server";
 
 import { z } from "zod";
+import { redirect } from "next/navigation";
 import { LOGGER } from "@/lib/logging";
 import { isAdmin } from "../api/authz";
 import { getOryIdentityIdByEmail, getPageSession } from "../api/utils";
-import { accountsTable } from "../clients";
+import { accountsTable, isIndividualAccount } from "../clients";
 import { FormState } from "@/components/core/DynamicForm";
 import { accountUrl } from "@/lib/urls";
+import {
+  setImpersonationTarget,
+  clearImpersonationTarget,
+} from "@/lib/services/impersonation";
 
 const LookupSchema = z.object({
   email: z.string().trim().email("Enter a valid email address"),
@@ -85,4 +90,29 @@ export async function lookupUserByEmail(
     success: true,
     redirectTo: accountUrl(account.account_id),
   };
+}
+
+/**
+ * Admin-only: start viewing the app as another (individual) user. Sets the
+ * impersonation cookie that `getPageSession` honors, then reloads onto the
+ * target's profile. `getPageSession()` here resolves the REAL admin (the
+ * cookie isn't set yet), so the `isAdmin` gate can't be bypassed by an
+ * already-impersonated session.
+ */
+export async function startImpersonation(formData: FormData): Promise<void> {
+  const session = await getPageSession();
+  if (!isAdmin(session)) return; // button is admin-only; ignore stray posts
+
+  const account_id = String(formData.get("account_id") ?? "");
+  const target = await accountsTable.fetchById(account_id);
+  if (!target || target.disabled || !isIndividualAccount(target)) return;
+
+  await setImpersonationTarget(account_id);
+  redirect(accountUrl(account_id));
+}
+
+/** Stop impersonating and return home. Safe for anyone — just clears a cookie. */
+export async function stopImpersonation(): Promise<void> {
+  await clearImpersonationTarget();
+  redirect("/");
 }

--- a/src/lib/api/utils.ts
+++ b/src/lib/api/utils.ts
@@ -42,6 +42,7 @@ import md5 from "md5";
 import { authenticateWithOidcToken } from "./oidc";
 import { CONFIG } from "@/lib/config";
 import { LOGGER } from "@/lib/logging";
+import { applyImpersonation } from "@/lib/services/impersonation";
 
 /**
  * Retrieves the current user session from the request context.
@@ -117,13 +118,14 @@ export async function getPageSession(): Promise<UserSession | null> {
     ),
   );
 
-  // Return the user session
-  return {
+  // Return the user session — swapped to the target when an admin is viewing
+  // the app as another user (no-op for everyone else).
+  return applyImpersonation({
     identity_id,
     orySession,
     account,
     memberships: filteredMemberships,
-  };
+  });
 }
 
 /**

--- a/src/lib/services/impersonation.test.ts
+++ b/src/lib/services/impersonation.test.ts
@@ -1,0 +1,105 @@
+/**
+ * @jest-environment node
+ */
+
+const mockGet = jest.fn();
+jest.mock("next/headers", () => ({
+  cookies: jest.fn().mockResolvedValue({
+    get: (...args: unknown[]) => mockGet(...args),
+    set: jest.fn(),
+    delete: jest.fn(),
+  }),
+}));
+
+const mockFetchById = jest.fn();
+const mockListByUser = jest.fn();
+jest.mock("@/lib/clients/database", () => ({
+  accountsTable: { fetchById: (...a: unknown[]) => mockFetchById(...a) },
+  membershipsTable: { listByUser: (...a: unknown[]) => mockListByUser(...a) },
+  isIndividualAccount: (acc: { type?: string }) => acc?.type === "individual",
+}));
+
+const mockIsAdmin = jest.fn();
+jest.mock("@/lib/api/authz", () => ({
+  isAdmin: (...a: unknown[]) => mockIsAdmin(...a),
+  isAuthorized: () => true,
+}));
+
+import { applyImpersonation, IMPERSONATION_COOKIE_NAME } from "./impersonation";
+import { encryptJson } from "./encrypted-cookie";
+import type { UserSession } from "@/types";
+
+const adminSession = (): UserSession => ({
+  identity_id: "admin-ory-id",
+  orySession: { id: "sess" } as never,
+  account: { account_id: "admin", name: "Admin", type: "individual" } as never,
+  memberships: [],
+});
+
+const target = {
+  account_id: "alice",
+  name: "Alice",
+  type: "individual",
+  identity_id: "alice-ory-id",
+  disabled: false,
+};
+
+async function cookieFor(account_id: string) {
+  return { value: await encryptJson({ account_id }) };
+}
+
+describe("applyImpersonation", () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockFetchById.mockReset();
+    mockListByUser.mockReset().mockResolvedValue([]);
+    mockIsAdmin.mockReset();
+  });
+
+  test("swaps identity, account, and sets impersonator when admin + valid cookie", async () => {
+    mockIsAdmin.mockReturnValue(true);
+    mockGet.mockReturnValue(await cookieFor("alice"));
+    mockFetchById.mockResolvedValue(target);
+
+    const result = await applyImpersonation(adminSession());
+
+    expect(mockGet).toHaveBeenCalledWith(IMPERSONATION_COOKIE_NAME);
+    expect(result?.identity_id).toBe("alice-ory-id"); // full-identity swap
+    expect(result?.account?.account_id).toBe("alice");
+    expect(result?.impersonator).toEqual({ account_id: "admin", name: "Admin" });
+  });
+
+  test("returns the real session unchanged for a non-admin (forged cookie is inert)", async () => {
+    mockIsAdmin.mockReturnValue(false);
+    mockGet.mockReturnValue(await cookieFor("alice"));
+
+    const real = { ...adminSession(), account: undefined };
+    const result = await applyImpersonation(real);
+
+    expect(result).toBe(real);
+    expect(mockGet).not.toHaveBeenCalled(); // short-circuits before reading cookie
+    expect(mockFetchById).not.toHaveBeenCalled();
+  });
+
+  test("returns the real session when admin but no cookie", async () => {
+    mockIsAdmin.mockReturnValue(true);
+    mockGet.mockReturnValue(undefined);
+
+    const real = adminSession();
+    expect(await applyImpersonation(real)).toBe(real);
+  });
+
+  test("ignores a cookie pointing at a non-individual (organization) account", async () => {
+    mockIsAdmin.mockReturnValue(true);
+    mockGet.mockReturnValue(await cookieFor("acme"));
+    mockFetchById.mockResolvedValue({
+      account_id: "acme",
+      name: "Acme",
+      type: "organization",
+      disabled: false,
+    });
+
+    const real = adminSession();
+    expect(await applyImpersonation(real)).toBe(real);
+  });
+});

--- a/src/lib/services/impersonation.ts
+++ b/src/lib/services/impersonation.ts
@@ -1,0 +1,98 @@
+import "server-only";
+
+import { cookies } from "next/headers";
+import { Actions, type UserSession } from "@/types";
+import {
+  accountsTable,
+  membershipsTable,
+  isIndividualAccount,
+} from "@/lib/clients/database";
+import { isAdmin, isAuthorized } from "@/lib/api/authz";
+import { encryptJson, decryptJson } from "@/lib/services/encrypted-cookie";
+import { LOGGER } from "@/lib/logging";
+
+/** Encrypted HTTP-only cookie naming the account an admin is viewing as. */
+export const IMPERSONATION_COOKIE_NAME = "sc_impersonate";
+
+interface ImpersonationCookie {
+  account_id: string;
+}
+
+/**
+ * Admin-only. Set/clear from a server action (action phase); a Server
+ * Component render cannot write cookies. Not gated here — callers verify the
+ * real session is an admin first.
+ */
+export async function setImpersonationTarget(account_id: string): Promise<void> {
+  const jar = await cookies();
+  jar.set(
+    IMPERSONATION_COOKIE_NAME,
+    await encryptJson({ account_id } satisfies ImpersonationCookie),
+    { httpOnly: true, secure: true, sameSite: "lax", path: "/" },
+  );
+}
+
+export async function clearImpersonationTarget(): Promise<void> {
+  const jar = await cookies();
+  jar.delete(IMPERSONATION_COOKIE_NAME);
+}
+
+/**
+ * If the real session is an admin and an impersonation cookie is present,
+ * returns a session that fully assumes the target individual account —
+ * `identity_id`, `account`, and `memberships` all swapped, `impersonator` set
+ * so the UI can render a banner. Otherwise returns `realSession` unchanged.
+ *
+ * The gate is `isAdmin(realSession)`: a forged cookie from a non-admin is
+ * inert, so the encryption is defense-in-depth, not the security boundary.
+ * Only individual accounts are assumable — they alone have an Ory identity for
+ * the data proxy to mint credentials against.
+ */
+export async function applyImpersonation(
+  realSession: UserSession | null,
+): Promise<UserSession | null> {
+  if (!realSession || !isAdmin(realSession)) return realSession;
+
+  const jar = await cookies();
+  const token = jar.get(IMPERSONATION_COOKIE_NAME)?.value;
+  if (!token) return realSession;
+
+  const decoded = await decryptJson<ImpersonationCookie>(token);
+  if (!decoded?.account_id) return realSession;
+
+  const target = await accountsTable.fetchById(decoded.account_id);
+  if (!target || target.disabled || !isIndividualAccount(target)) {
+    return realSession;
+  }
+
+  const principal: UserSession = {
+    orySession: realSession.orySession,
+    account: target,
+    identity_id: target.identity_id,
+  };
+  const memberships = (
+    await membershipsTable.listByUser(target.account_id)
+  ).filter((membership) =>
+    isAuthorized(principal, membership, Actions.GetMembership),
+  );
+
+  LOGGER.info("Admin viewing app as another user", {
+    operation: "applyImpersonation",
+    context: "impersonation",
+    metadata: {
+      admin: realSession.account?.account_id,
+      target: target.account_id,
+    },
+  });
+
+  return {
+    identity_id: target.identity_id,
+    account: target,
+    memberships,
+    orySession: realSession.orySession,
+    impersonator: {
+      account_id: realSession.account!.account_id,
+      name: realSession.account!.name,
+    },
+  };
+}

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -18,4 +18,11 @@ export interface UserSession {
   account?: Account;
   memberships?: Membership[];
   orySession?: Session;
+  /**
+   * Present only when an admin is viewing the app as another user. Holds the
+   * real admin's identity so the UI can surface a banner; every other field on
+   * this session belongs to the impersonated target. See
+   * `src/lib/services/impersonation.ts`.
+   */
+  impersonator?: { account_id: string; name: string };
 }


### PR DESCRIPTION
Closes #443 — admin QA: view the product as a specified user.

## What
An admin can open any individual user's profile and click **View as user**. The whole app then renders and behaves as that user. An always-on amber banner names the target and offers **Exit**.

## How
The one seam is `getPageSession()` — the single server-side identity resolver every server component, server action, and cookie-based API call flows through. `applyImpersonation()` runs at the end and, **only when the real resolved account is an admin** and an encrypted `sc_impersonate` cookie is present, returns a session that fully assumes the target individual account:

- `identity_id`, `account`, and `memberships` all swapped to the target
- `impersonator` set to the real admin (for the banner + audit log line)
- the admin's real `orySession` kept

Because it's a **full identity swap**, every one of the ~148 authz call sites and the data-proxy STS credential minting act as the target with no other changes. `isAdmin()` reads the swapped account, so the admin **correctly loses admin powers** while impersonating — you see exactly what the target sees.

## Security
- **Gate is `isAdmin(realSession)`.** A forged cookie from a non-admin is inert, so the AES-GCM encryption (reusing the existing `encrypted-cookie` service) is defense-in-depth, not the boundary.
- **Start** re-resolves the real admin session before setting the cookie, so an already-impersonated session can't chain into another user.
- Only **individual** accounts (which have an Ory identity for the proxy to mint against) are assumable.
- Cookie is `httpOnly`, `secure`, `sameSite=lax`; cleared on **Exit** and on **/logout**.
- Blast radius is **browser/cookie requests only** — public `/api/v1` Bearer auth never touches `getPageSession()`, so token clients can't be impersonated.
- Self-healing data plane: proxy-cred cookies are bound to `identity_id`, so entering/exiting impersonation re-mints cleanly with no stale-cred leakage.

## Decisions baked in (per design discussion)
- **Full identity** (data plane included), not account-only.
- **Full interaction** (mutations allowed, bounded by the target's own permissions); the always-on banner is the guardrail.
- Entry point: **profile-page button**, admin-only.

## Tests
`impersonation.test.ts` covers the four branches: admin+valid cookie → full swap; non-admin → inert (short-circuits before reading the cookie); admin+no cookie → unchanged; org target → ignored. `tsc` clean, existing admin/page-session suites pass.

## Deliberately skipped (add when needed)
- Read-only mode (block mutations while impersonating)
- Audit-log table (currently a single `LOGGER.info` line)
- Cookie TTL / auto-expiry

🤖 Generated with [Claude Code](https://claude.com/claude-code)