### PR TITLE
feat(nav): omit disabled products, polish account-dropdown product links

### DIFF
--- a/src/app/(app)/edit/product/[account_id]/[product_id]/layout.tsx
+++ b/src/app/(app)/edit/product/[account_id]/[product_id]/layout.tsx
@@ -56,8 +56,8 @@ export default async function ProductLayout({
   let { products: manageableProducts } = await productsTable.listByAccount(
     account_id
   );
-  manageableProducts = manageableProducts.filter((p) =>
-    isAuthorized(session, p, Actions.PutRepository)
+  manageableProducts = manageableProducts.filter(
+    (p) => !p.disabled && isAuthorized(session, p, Actions.PutRepository)
   );
 
   const canEditProduct = isAuthorized(session, product, Actions.PutRepository);

--- a/src/components/features/settings/ProductSelector.tsx
+++ b/src/components/features/settings/ProductSelector.tsx
@@ -67,7 +67,7 @@ function ProductDisplay({
   selected?: boolean;
 }) {
   return (
-    <Text size="2" color="gray" weight={selected ? "bold" : "regular"}>
+    <Text size="2" color="gray" weight={selected ? "bold" : "medium"}>
       {product.title}
     </Text>
   );

--- a/src/components/features/settings/ProductSelector.tsx
+++ b/src/components/features/settings/ProductSelector.tsx
@@ -67,7 +67,7 @@ function ProductDisplay({
   selected?: boolean;
 }) {
   return (
-    <Text size="2" color="gray" weight={selected ? "bold" : "medium"}>
+    <Text size="2" color="gray" weight={selected ? "bold" : "regular"}>
       {product.title}
     </Text>
   );

--- a/src/components/layout/AccountDropdown.tsx
+++ b/src/components/layout/AccountDropdown.tsx
@@ -132,7 +132,9 @@ export function AccountDropdown({
                 ? products.slice(0, 20).map((product) => ({
                     href: productUrl(account.account_id, product.product_id),
                     children: (
-                      <span style={entityNameStyle}>{product.title}</span>
+                      <span style={{ ...entityNameStyle, fontWeight: 500 }}>
+                        {product.title}
+                      </span>
                     ),
                   }))
                 : [

--- a/src/components/layout/AccountDropdown.tsx
+++ b/src/components/layout/AccountDropdown.tsx
@@ -112,7 +112,7 @@ export function AccountDropdown({
             label={
               <Flex align="center" gap="2">
                 <ProfileAvatar account={account} size="1" />
-                <span style={entityNameStyle}>{account.name}</span>
+                <Text style={entityNameStyle}>{account.name}</Text>
                 {isSelf && (
                   <Text size="1" color="gray">
                     you
@@ -132,9 +132,9 @@ export function AccountDropdown({
                 ? products.slice(0, 20).map((product) => ({
                     href: productUrl(account.account_id, product.product_id),
                     children: (
-                      <span style={{ ...entityNameStyle, fontWeight: 500 }}>
+                      <Text style={entityNameStyle} weight="medium">
                         {product.title}
-                      </span>
+                      </Text>
                     ),
                   }))
                 : [
@@ -207,7 +207,7 @@ export function AccountDropdown({
               ? pendingInvitations.slice(0, 20).map((invitation) => ({
                   href: invitation.href,
                   children: (
-                    <span style={entityNameStyle}>{invitation.label}</span>
+                    <Text style={entityNameStyle}>{invitation.label}</Text>
                   ),
                 }))
               : [

--- a/src/components/layout/AccountDropdown.tsx
+++ b/src/components/layout/AccountDropdown.tsx
@@ -132,7 +132,11 @@ export function AccountDropdown({
                 ? products.slice(0, 20).map((product) => ({
                     href: productUrl(account.account_id, product.product_id),
                     children: (
-                      <Text style={entityNameStyle} weight="medium">
+                      <Text
+                        className={styles.productName}
+                        style={entityNameStyle}
+                        weight="medium"
+                      >
                         {product.title}
                       </Text>
                     ),

--- a/src/components/layout/MobileMenu.tsx
+++ b/src/components/layout/MobileMenu.tsx
@@ -7,7 +7,6 @@ import {
   Cross1Icon,
   ChevronDownIcon,
   PlusIcon,
-  DashIcon,
 } from "@radix-ui/react-icons";
 import styles from "./Navigation.module.css";
 import {
@@ -132,7 +131,6 @@ export function MobileMenu({
                     href={productUrl(account.account_id, p.product_id)}
                     onNavigate={close}
                     indent
-                    icon={<DashIcon style={{ color: "var(--gray-a10)" }} />}
                   >
                     {p.title}
                   </Row>

--- a/src/components/layout/Navigation.module.css
+++ b/src/components/layout/Navigation.module.css
@@ -105,3 +105,12 @@
   border-radius: 50%;
   background: var(--red-9);
 } 
+/* Product links sit a step lighter (gray-11) to offset their medium weight,
+   but revert to the highlighted item's contrast color so they stay legible on
+   the solid hover/keyboard-highlight background. */
+.productName {
+  color: var(--gray-11);
+}
+:global(.rt-BaseMenuItem):where([data-highlighted], :hover) .productName {
+  color: inherit;
+}

--- a/src/components/layout/Navigation.module.css.d.ts
+++ b/src/components/layout/Navigation.module.css.d.ts
@@ -11,6 +11,7 @@ declare const styles: {
   readonly mobileRowChevron: string;
   readonly mobileRowChevronOpen: string;
   readonly mobileDot: string;
+  readonly productName: string;
 };
 
 export default styles;


### PR DESCRIPTION
## Summary

Navigation-menu cleanup for the account/org dropdown and its product lists.

## Changes

- **Omit disabled products** from the org product selector in the edit-product settings header — filter added alongside the existing authorization filter in the settings layout.
- **Drop the dash icon** on mobile product links, mirroring the desktop change in #442.
- **Account dropdown product links**: bump to font-weight 500 (`weight="medium"`) and soften the resting text color to `var(--gray-11)` to offset the heavier weight. The color reverts to `inherit` (white) when the row is highlighted, so it stays legible on the solid hover/keyboard-highlight background.
- **Use Radix `Text` instead of raw `<span>`** for the account/product/invitation entity names in the account dropdown (Radix `Text` renders a `<span>` by default).

## Notes

- The account dropdown uses the default **solid** `DropdownMenu.Content` variant, so highlighted rows already render white text — no variant change needed.
- Added `productName` to the hand-maintained `Navigation.module.css.d.ts` (typed CSS modules aren't auto-generated here).
- `tsc --noEmit` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)