### PR TITLE
fix(mirrors): allow empty mirror prefix (connection root)

### DIFF
--- a/src/components/features/data-connections/ProductMirrorsManager.tsx
+++ b/src/components/features/data-connections/ProductMirrorsManager.tsx
@@ -265,7 +265,7 @@ export function ProductMirrorsManager({
                         <input
                           name="prefix"
                           defaultValue={mirror.prefix}
-                          required
+                          placeholder="(connection root)"
                           style={{
                             ...formFieldStyle,
                             flex: 1,

--- a/src/lib/actions/product-mirrors.test.ts
+++ b/src/lib/actions/product-mirrors.test.ts
@@ -454,7 +454,11 @@ describe("updateMirrorPrefix", () => {
     expect(updated.metadata.mirrors["conn-b"].prefix).toBe("acct/prod/");
   });
 
-  test("rejects a blank prefix", async () => {
+  test("accepts a blank prefix, mirroring at the connection root", async () => {
+    mockProductsTable.fetchById.mockResolvedValue(
+      productWith({ "conn-a": mirror({ connection_id: "conn-a" }) }, "conn-a")
+    );
+
     const result = await updateMirrorPrefix(
       FORM_STATE,
       formDataFor({
@@ -465,8 +469,9 @@ describe("updateMirrorPrefix", () => {
       })
     );
 
-    expect(result.success).toBe(false);
-    expect(mockProductsTable.update).not.toHaveBeenCalled();
+    expect(result.success).toBe(true);
+    const updated = mockProductsTable.update.mock.calls[0][0];
+    expect(updated.metadata.mirrors["conn-a"].prefix).toBe("");
   });
 
   test("appends a trailing slash so prefixes are directory boundaries", async () => {

--- a/src/lib/actions/product-mirrors.ts
+++ b/src/lib/actions/product-mirrors.ts
@@ -314,7 +314,7 @@ export async function updateMirrorPrefix(
   const mirrorKey = formData.get("mirror_key") as string;
   const rawPrefix = ((formData.get("prefix") as string) || "").trim();
 
-  if (!accountId || !productId || !mirrorKey || !rawPrefix) {
+  if (!accountId || !productId || !mirrorKey) {
     return {
       fieldErrors: {},
       data: formData,
@@ -338,7 +338,8 @@ export async function updateMirrorPrefix(
       success: false,
     };
   }
-  const prefix = rawPrefix.endsWith("/") ? rawPrefix : `${rawPrefix}/`;
+  const prefix =
+    !rawPrefix || rawPrefix.endsWith("/") ? rawPrefix : `${rawPrefix}/`;
 
   try {
     const product = await productsTable.fetchById(accountId, productId);


### PR DESCRIPTION
## Problem

After #440 we can edit a mirror's prefix, but not clear it — `updateMirrorPrefix` rejected empty input (`!rawPrefix` → "Missing required fields") and the input carried `required`, so a mirror couldn't point at the connection root.

## Fix

- Drop `rawPrefix` from the required-fields guard in `updateMirrorPrefix`.
- Empty prefix stays `""` (no trailing slash appended); non-empty still gets a trailing `/`.
- Remove `required` from the prefix `<input>`, add a `(connection root)` placeholder.
- Flip the "rejects a blank prefix" test to assert an empty prefix is accepted and stored as `""`.

Unsafe-prefix rejection (`..`, leading `/`) and trailing-slash normalization are unchanged.

`jest src/lib/actions/product-mirrors.test.ts` — 20 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)