### PR TITLE
fix(data-connections): target GCS, align DataProvider with storage_type

### DIFF
--- a/src/components/features/data-connections/DataConnectionForm.tsx
+++ b/src/components/features/data-connections/DataConnectionForm.tsx
@@ -28,11 +28,11 @@ interface DataConnectionFormProps {
   ownerAccountId?: string;
 }
 
-// Storage providers limited to those with a `details` schema (S3, Azure, GCP).
+// Storage providers limited to those with a `details` schema (S3, Azure, GCS).
 const providerOptions: Array<{ value: DataProvider; label: string }> = [
   { value: DataProvider.S3, label: "S3 / S3-compatible (R2, MinIO)" },
   { value: DataProvider.Azure, label: "Azure" },
-  { value: DataProvider.GCP, label: "GCP (GCS)" },
+  { value: DataProvider.GCS, label: "Google Cloud Storage" },
 ];
 
 const s3AuthTypes = [
@@ -50,7 +50,7 @@ const gcpAuthTypes = [DataConnectionAuthenticationType.GcpWorkloadIdentity];
 const authTypesByProvider: Record<string, DataConnectionAuthenticationType[]> = {
   [DataProvider.S3]: s3AuthTypes,
   [DataProvider.Azure]: azureAuthTypes,
-  [DataProvider.GCP]: gcpAuthTypes,
+  [DataProvider.GCS]: gcpAuthTypes,
 };
 
 const AUTH_TYPE_LABELS: Record<DataConnectionAuthenticationType, string> = {
@@ -481,7 +481,7 @@ export function DataConnectionForm({
           </>
         )}
 
-        {provider === DataProvider.GCP && (
+        {provider === DataProvider.GCS && (
           <>
             <Field
               label="Bucket"
@@ -494,7 +494,7 @@ export function DataConnectionForm({
                 name="bucket"
                 defaultValue={
                   (state.data.get("bucket") as string) ||
-                  (dataConnection?.details.provider === DataProvider.GCP
+                  (dataConnection?.details.provider === DataProvider.GCS
                     ? dataConnection.details.bucket
                     : "")
                 }
@@ -513,7 +513,7 @@ export function DataConnectionForm({
                 name="base_prefix"
                 defaultValue={
                   (state.data.get("base_prefix") as string) ||
-                  (dataConnection?.details.provider === DataProvider.GCP
+                  (dataConnection?.details.provider === DataProvider.GCS
                     ? dataConnection.details.base_prefix
                     : "")
                 }

--- a/src/components/features/data-connections/DataConnectionForm.tsx
+++ b/src/components/features/data-connections/DataConnectionForm.tsx
@@ -30,7 +30,7 @@ interface DataConnectionFormProps {
 
 // Storage providers limited to those with a `details` schema (S3, Azure, GCS).
 const providerOptions: Array<{ value: DataProvider; label: string }> = [
-  { value: DataProvider.S3, label: "S3 / S3-compatible (R2, MinIO)" },
+  { value: DataProvider.S3, label: "AWS S3 / S3-compatible (R2, MinIO)" },
   { value: DataProvider.Azure, label: "Azure Blob Storage" },
   { value: DataProvider.GCS, label: "Google Cloud Storage" },
 ];

--- a/src/components/features/data-connections/DataConnectionForm.tsx
+++ b/src/components/features/data-connections/DataConnectionForm.tsx
@@ -31,7 +31,7 @@ interface DataConnectionFormProps {
 // Storage providers limited to those with a `details` schema (S3, Azure, GCS).
 const providerOptions: Array<{ value: DataProvider; label: string }> = [
   { value: DataProvider.S3, label: "S3 / S3-compatible (R2, MinIO)" },
-  { value: DataProvider.Azure, label: "Azure" },
+  { value: DataProvider.Azure, label: "Azure Blob Storage" },
   { value: DataProvider.GCS, label: "Google Cloud Storage" },
 ];
 

--- a/src/components/features/data-connections/DataConnectionsTable.tsx
+++ b/src/components/features/data-connections/DataConnectionsTable.tsx
@@ -12,7 +12,7 @@ const PROVIDER_BADGE: Record<
 > = {
   [DataProvider.S3]: { label: "S3", color: "orange" },
   [DataProvider.Azure]: { label: "Azure", color: "blue" },
-  [DataProvider.GCP]: { label: "GCP", color: "green" },
+  [DataProvider.GCS]: { label: "GCS", color: "green" },
 };
 
 interface DataConnectionsTableProps {

--- a/src/components/features/products/object-browser/ObjectSummary.tsx
+++ b/src/components/features/products/object-browser/ObjectSummary.tsx
@@ -28,7 +28,7 @@ export function ObjectSummary({
   const details = connectionDetails?.dataConnection.details;
   const prefix = connectionDetails?.primaryMirror.prefix;
   const cloudUri =
-    details?.provider === "az"
+    details?.provider === "azure"
       ? `https://${details.account_name}.blob.core.windows.net/${details.container_name}/${prefix}${objectInfo.path}`
       : details?.provider === "s3"
       ? `s3://${details.bucket}/${prefix}${objectInfo.path}`

--- a/src/lib/actions/data-connections.test.ts
+++ b/src/lib/actions/data-connections.test.ts
@@ -294,13 +294,13 @@ describe("createDataConnection", () => {
     ).toBe(false);
   });
 
-  test("creates a GCP (GCS) connection with workload-identity auth", async () => {
+  test("creates a GCS connection with workload-identity auth", async () => {
     const result = await createDataConnection(
       FORM_STATE,
       formDataFor({
         data_connection_id: "gcs-connection",
         name: "GCS Connection",
-        provider: DataProvider.GCP,
+        provider: DataProvider.GCS,
         bucket: "my-gcs-bucket",
         base_prefix: "",
         visibility_public: "on",
@@ -313,7 +313,7 @@ describe("createDataConnection", () => {
 
     expect(result.success).toBe(true);
     expect(mockTable.create.mock.calls[0][0].details).toMatchObject({
-      provider: DataProvider.GCP,
+      provider: DataProvider.GCS,
       bucket: "my-gcs-bucket",
     });
     expect(mockTable.create.mock.calls[0][0].authentication).toMatchObject({

--- a/src/lib/actions/data-connections.ts
+++ b/src/lib/actions/data-connections.ts
@@ -499,9 +499,9 @@ function buildDataConnectionFromForm(
       // Omit when blank so AWS S3 connections have no endpoint field.
       ...(endpoint ? { endpoint } : {}),
     };
-  } else if (provider === DataProvider.GCP) {
+  } else if (provider === DataProvider.GCS) {
     details = {
-      provider: DataProvider.GCP,
+      provider: DataProvider.GCS,
       bucket: formData.get("bucket") as string,
       base_prefix: (formData.get("base_prefix") as string) || "",
     };

--- a/src/lib/actions/product-mirrors.test.ts
+++ b/src/lib/actions/product-mirrors.test.ts
@@ -192,12 +192,12 @@ describe("addProductMirror", () => {
     expect(updated.metadata.mirrors["conn-a"].prefix).toBe("");
   });
 
-  test("maps a GCP connection to the gcs storage type", async () => {
+  test("derives a mirror's storage_type from the connection provider", async () => {
     mockProductsTable.fetchById.mockResolvedValue(productWith({}, ""));
     mockDataConnectionsTable.fetchById.mockResolvedValue({
       data_connection_id: "conn-a",
       prefix_template: "{{repository.account_id}}/{{repository.repository_id}}/",
-      details: { provider: "gcp" },
+      details: { provider: "gcs" },
     } as DataConnection);
 
     await addProductMirror(

--- a/src/lib/actions/product-mirrors.ts
+++ b/src/lib/actions/product-mirrors.ts
@@ -4,12 +4,7 @@ import { LOGGER } from "@/lib/logging";
 import { isAdmin, isAuthorized } from "../api/authz";
 import { getPageSession } from "../api/utils";
 import { productsTable, dataConnectionsTable } from "../clients";
-import {
-  Actions,
-  DataProvider,
-  ProductMirror,
-  resolveMirrorPrefix,
-} from "@/types";
+import { Actions, ProductMirror, resolveMirrorPrefix } from "@/types";
 import { FormState } from "@/components/core/DynamicForm";
 import { revalidatePath } from "next/cache";
 import { editProductDataConnectionsUrl } from "@/lib/urls";
@@ -104,17 +99,11 @@ export async function addProductMirror(
 
     const isFirst = Object.keys(product.metadata.mirrors).length === 0;
 
-    const storageTypeByProvider: Record<
-      DataProvider,
-      ProductMirror["storage_type"]
-    > = {
-      [DataProvider.S3]: "s3",
-      [DataProvider.Azure]: "azure",
-      [DataProvider.GCP]: "gcs",
-    };
-
     const mirror: ProductMirror = {
-      storage_type: storageTypeByProvider[connection.details.provider],
+      // provider values are the backend storage vocabulary; the cast bridges
+      // TS's nominal string-enum → literal-union gap (see DataProvider).
+      storage_type: connection.details
+        .provider as ProductMirror["storage_type"],
       connection_id: connectionId,
       prefix,
       is_primary: isFirst,

--- a/src/lib/actions/products.ts
+++ b/src/lib/actions/products.ts
@@ -3,7 +3,6 @@
 import { productsTable, membershipsTable, dataConnectionsTable } from "@/lib/clients/database";
 import {
   Actions,
-  DataProvider,
   ProductCreationRequestSchema,
   type Product,
   type ProductCreationRequest,
@@ -19,16 +18,6 @@ import { productUrl, editProductDetailsUrl, accountUrl } from "@/lib/urls";
 import { getProxyCredentials } from "@/lib/actions/proxy-credentials";
 import { readProxyCredentials } from "@/lib/services/proxy-credentials-read";
 import { getStorageClient } from "@/lib/clients/storage";
-
-// Map a data connection's storage provider to the product mirror's storage_type.
-const STORAGE_TYPE_BY_PROVIDER: Record<
-  DataProvider,
-  ProductMirror["storage_type"]
-> = {
-  [DataProvider.S3]: "s3",
-  [DataProvider.Azure]: "azure",
-  [DataProvider.GCP]: "gcs",
-};
 
 export interface PaginatedProductsResult {
   products: Product[];
@@ -240,8 +229,10 @@ export async function createProduct(
       primary_mirror: dataConnection.data_connection_id,
       mirrors: {
         [dataConnection.data_connection_id]: {
-          storage_type:
-            STORAGE_TYPE_BY_PROVIDER[dataConnection.details.provider],
+          // provider values are the backend storage vocabulary; the cast bridges
+          // TS's nominal string-enum → literal-union gap (see DataProvider).
+          storage_type: dataConnection.details
+            .provider as ProductMirror["storage_type"],
           connection_id: dataConnection.data_connection_id,
           prefix: resolveMirrorPrefix(
             dataConnection.prefix_template,

--- a/src/lib/clients/database/data-connections.test.ts
+++ b/src/lib/clients/database/data-connections.test.ts
@@ -1,0 +1,50 @@
+import { normalizeConnection } from "./data-connections";
+import { DataConnection, DataProvider, ProductMirrorSchema } from "@/types";
+
+const base = {
+  data_connection_id: "conn-a",
+  name: "Conn",
+  read_only: true,
+  allowed_visibilities: [],
+} as const;
+
+describe("normalizeConnection (legacy provider read-shim)", () => {
+  test('remaps legacy "gcp" to gcs', () => {
+    const out = normalizeConnection({
+      ...base,
+      details: { provider: "gcp", bucket: "b", base_prefix: "" },
+    } as unknown as DataConnection);
+    expect(out.details.provider).toBe(DataProvider.GCS);
+  });
+
+  test('remaps legacy "az" to azure', () => {
+    const out = normalizeConnection({
+      ...base,
+      details: { provider: "az", account_name: "a", container_name: "c", base_prefix: "" },
+    } as unknown as DataConnection);
+    expect(out.details.provider).toBe(DataProvider.Azure);
+  });
+
+  test("leaves canonical values untouched", () => {
+    const conn = {
+      ...base,
+      details: { provider: DataProvider.S3, bucket: "b", base_prefix: "", region: "us-east-1" },
+    } as DataConnection;
+    expect(normalizeConnection(conn)).toBe(conn);
+  });
+});
+
+// Guards the `details.provider as storage_type` casts in products/product-mirrors:
+// every DataProvider value must be a valid ProductMirror storage_type.
+describe("DataProvider ⊆ ProductMirror storage_type", () => {
+  test.each(Object.values(DataProvider))("%s is a valid storage_type", (provider) => {
+    expect(() =>
+      ProductMirrorSchema.parse({
+        storage_type: provider,
+        connection_id: "c",
+        prefix: "",
+        is_primary: true,
+      })
+    ).not.toThrow();
+  });
+});

--- a/src/lib/clients/database/data-connections.ts
+++ b/src/lib/clients/database/data-connections.ts
@@ -1,4 +1,4 @@
-import { DataConnection } from "@/types";
+import { DataConnection, DataProvider } from "@/types";
 import {
   PutItemCommand,
   ResourceNotFoundException,
@@ -12,6 +12,23 @@ import {
 } from "@aws-sdk/lib-dynamodb";
 import { marshall } from "@aws-sdk/util-dynamodb";
 import { BaseTable } from "./base";
+
+// Rows persisted before DataProvider was aligned to the backend storage
+// vocabulary carry the old provider values. Normalize them on read so old
+// connections surface (and downstream, derive `storage_type`) with current
+// values.
+// ponytail: read-time shim; drop once all rows are backfilled to canonical values.
+const LEGACY_PROVIDER_ALIASES: Record<string, DataProvider> = {
+  az: DataProvider.Azure,
+  gcp: DataProvider.GCS,
+};
+
+export function normalizeConnection(item: DataConnection): DataConnection {
+  const canonical = LEGACY_PROVIDER_ALIASES[item.details?.provider as string];
+  return canonical
+    ? { ...item, details: { ...item.details, provider: canonical } as DataConnection["details"] }
+    : item;
+}
 
 /**
  * Class for managing data connection operations in DynamoDB
@@ -30,7 +47,8 @@ export class DataConnectionsTable extends BaseTable {
           },
         })
       );
-      return (result.Items?.[0] as DataConnection) ?? null;
+      const item = result.Items?.[0] as DataConnection | undefined;
+      return item ? normalizeConnection(item) : null;
     } catch (error) {
       if (error instanceof ResourceNotFoundException) return null;
 
@@ -49,7 +67,7 @@ export class DataConnectionsTable extends BaseTable {
       );
       // Unsorted: callers order as they need (e.g. the admin page sorts by
       // provider then name). Sorting here would express no useful intent.
-      return (result.Items ?? []) as DataConnection[];
+      return ((result.Items ?? []) as DataConnection[]).map(normalizeConnection);
     } catch (error) {
       this.logError("listAll", error);
       throw error;

--- a/src/types/data-connection.test.ts
+++ b/src/types/data-connection.test.ts
@@ -290,13 +290,13 @@ describe("DataConnectionDetails (S3-compatible + GCP variants)", () => {
     ).toThrow();
   });
 
-  test("parses a GCP (GCS) connection", () => {
+  test("parses a GCS connection", () => {
     const details = DataConnnectionDetailsSchema.parse({
-      provider: "gcp",
+      provider: "gcs",
       bucket: "my-gcs-bucket",
       base_prefix: "data/",
     });
-    expect(details.provider).toBe(DataProvider.GCP);
+    expect(details.provider).toBe(DataProvider.GCS);
     expect(details).toMatchObject({ bucket: "my-gcs-bucket" });
   });
 
@@ -318,7 +318,7 @@ describe("DataConnectionDetails (S3-compatible + GCP variants)", () => {
   test("rejects a URI-style Azure container name", () => {
     expect(() =>
       DataConnnectionDetailsSchema.parse({
-        provider: "az",
+        provider: "azure",
         account_name: "acct",
         container_name: "https://acct.blob.core.windows.net/container",
         base_prefix: "",
@@ -327,13 +327,13 @@ describe("DataConnectionDetails (S3-compatible + GCP variants)", () => {
     ).toThrow();
   });
 
-  test("parses a full GCP connection with workload-identity auth", () => {
+  test("parses a full GCS connection with workload-identity auth", () => {
     const dc = DataConnectionSchema.parse({
       data_connection_id: "gcs-conn",
       name: "GCS",
       read_only: false,
       allowed_visibilities: [],
-      details: { provider: "gcp", bucket: "my-gcs-bucket", base_prefix: "" },
+      details: { provider: "gcs", bucket: "my-gcs-bucket", base_prefix: "" },
       authentication: {
         type: "gcp_workload_identity",
         workload_identity_provider:
@@ -341,7 +341,7 @@ describe("DataConnectionDetails (S3-compatible + GCP variants)", () => {
         service_account: "sa@my-project.iam.gserviceaccount.com",
       },
     });
-    expect(dc.details.provider).toBe(DataProvider.GCP);
+    expect(dc.details.provider).toBe(DataProvider.GCS);
     expect(dc.authentication?.type).toBe(
       DataConnectionAuthenticationType.GcpWorkloadIdentity
     );
@@ -361,7 +361,7 @@ describe("DataConnection provider ↔ authentication cross-validation", () => {
     base_prefix: "",
     region: "us-west-2",
   };
-  const gcpDetails = { provider: "gcp", bucket: "example-bucket", base_prefix: "" };
+  const gcpDetails = { provider: "gcs", bucket: "example-bucket", base_prefix: "" };
   const s3WebIdentityAuth = {
     type: "s3_web_identity_role",
     role_arn: "arn:aws:iam::123456789012:role/source-coop",

--- a/src/types/data-connection.ts
+++ b/src/types/data-connection.ts
@@ -23,10 +23,17 @@ import { ProductVisibility } from "./product";
 
 extendZodWithOpenApi(z);
 
+/**
+ * Storage backend a data connection targets. Values are drawn from the backend
+ * wire vocabulary (`ProductMirror.storage_type` in {@link module:types/product}),
+ * so a mirror's `storage_type` is just the connection's `provider` — no
+ * translation. `Azure`/`GCS` were once `"az"`/`"gcp"`; legacy rows are
+ * normalized on read (see the data-connections DynamoDB client).
+ */
 export enum DataProvider {
   S3 = "s3",
-  Azure = "az",
-  GCP = "gcp",
+  Azure = "azure",
+  GCS = "gcs",
 }
 
 export enum S3Regions {
@@ -236,23 +243,23 @@ export const AzureDataConnectionSchema = z
  * (the `gcp_workload_identity` authentication variant), so no region/endpoint is
  * needed to address the bucket.
  */
-export const GcpDataConnectionSchema = z
+export const GcsDataConnectionSchema = z
   .object({
-    provider: z.literal(DataProvider.GCP),
+    provider: z.literal(DataProvider.GCS),
     bucket: BucketNameSchema,
     base_prefix: z.string(),
   })
-  .openapi("GcpDataConnection");
+  .openapi("GcsDataConnection");
 
 export type S3DataConnection = z.infer<typeof S3DataConnectionSchema>;
 export type AzureDataConnection = z.infer<typeof AzureDataConnectionSchema>;
-export type GcpDataConnection = z.infer<typeof GcpDataConnectionSchema>;
+export type GcsDataConnection = z.infer<typeof GcsDataConnectionSchema>;
 
 export const DataConnnectionDetailsSchema = z
   .discriminatedUnion("provider", [
     S3DataConnectionSchema,
     AzureDataConnectionSchema,
-    GcpDataConnectionSchema,
+    GcsDataConnectionSchema,
   ])
   .openapi("DataConnectionDetails");
 
@@ -279,7 +286,7 @@ const PROVIDER_AUTH_TYPES: Record<
     DataConnectionAuthenticationType.AzureWorkloadIdentity,
     DataConnectionAuthenticationType.AzureSasToken,
   ],
-  [DataProvider.GCP]: [DataConnectionAuthenticationType.GcpWorkloadIdentity],
+  [DataProvider.GCS]: [DataConnectionAuthenticationType.GcpWorkloadIdentity],
 };
 
 /**


### PR DESCRIPTION
## Problem
Creating a GCP data connection persisted `details.provider: "gcp"`, but the backend (data.source.coop) addresses Google Cloud Storage as `"gcs"`. The same latent mismatch existed for Azure (`"az"` vs `"azure"`).

Root cause: `DataProvider` and a mirror's storage type were two vocabularies bridged by a hand-written `STORAGE_TYPE_BY_PROVIDER` map **duplicated** in `products.ts` and `product-mirrors.ts`.

## Change — align `DataProvider` values to the backend vocabulary
```
enum DataProvider { S3 = "s3", Azure = "azure" /* was "az" */, GCS = "gcs" /* was GCP="gcp" */ }
```
- Both translation maps deleted; a mirror's storage type is just the connection's provider.
- Member `GCP`→`GCS`, schema/type `Gcp*`→`Gcs*`. Auth type stays `gcp_workload_identity` (WIF is a GCP-*platform* feature, not storage). Form label → **"Google Cloud Storage"**.

## Migration (legacy `az`/`gcp` rows)
DynamoDB reads bypass Zod, so `normalizeConnection` in the data-connections client remaps `"az"→"azure"` / `"gcp"→"gcs"` on `fetchById`/`listAll`. Marked `ponytail:` — drop after backfill.

## Backend compatibility (verified against data.source.coop)
- **S3** unchanged. **Azure** accepts both `"az"` and `"azure"` → compatible during rollout. **GCS**: old `"gcp"` never worked (hit the error arm); `"gcs"` is accepted. This is the fix, not a regression.
- ⚠️ Making GCS actually connect needs a separate backend change (enable the multistore `gcp` feature + a wasm-compatible signing path) — tracked in data.source.coop.

## Verification
`tsc` clean · `jest` affected suites pass · lint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)