### PR TITLE
refactor(mirrors): drop denormalized ProductMirror.storage_type

### DIFF
--- a/src/app/(app)/edit/product/[account_id]/[product_id]/data-connections/page.tsx
+++ b/src/app/(app)/edit/product/[account_id]/[product_id]/data-connections/page.tsx
@@ -56,6 +56,7 @@ export default async function ProductDataConnectionsPage({
       {
         name: c.name,
         bucket: "bucket" in c.details ? c.details.bucket : c.details.container_name,
+        provider: c.details.provider,
       },
     ])
   );

--- a/src/components/features/data-connections/ProductMirrorsManager.tsx
+++ b/src/components/features/data-connections/ProductMirrorsManager.tsx
@@ -35,8 +35,11 @@ interface ProductMirrorsManagerProps {
   // Connection ids owned by the product owner; their admin form is reachable
   // even by non-admins, so we render the link for them.
   ownedConnectionIds: string[];
-  /** Display name and bare bucket/container per connection id, per card. */
-  connectionInfo: Record<string, { name: string; bucket: string }>;
+  /** Display name, provider, and bare bucket/container per connection id, per card. */
+  connectionInfo: Record<
+    string,
+    { name: string; bucket: string; provider: string }
+  >;
   // Connection ids whose mirror prefix this user may edit (needs both product
   // and connection management). Others render the prefix read-only.
   editablePrefixConnectionIds: string[];
@@ -231,7 +234,9 @@ export function ProductMirrorsManager({
                 </Flex>
                 <Flex gap="5" wrap="wrap">
                   <Field label="Type">
-                    <Text size="2">{mirror.storage_type}</Text>
+                    <Text size="2">
+                      {connectionInfo[mirror.connection_id]?.provider}
+                    </Text>
                   </Field>
                   {connectionInfo[mirror.connection_id] && (
                     <Field label="Bucket">

--- a/src/lib/actions/product-mirrors.test.ts
+++ b/src/lib/actions/product-mirrors.test.ts
@@ -70,7 +70,6 @@ function formDataFor(fields: Record<string, string>): FormData {
 
 function mirror(overrides: Partial<ProductMirror>): ProductMirror {
   return {
-    storage_type: "s3",
     connection_id: "conn",
     prefix: "acct/prod/",
     is_primary: false,
@@ -140,7 +139,6 @@ describe("addProductMirror", () => {
     const updated = mockProductsTable.update.mock.calls[0][0];
     expect(updated.metadata.primary_mirror).toBe("conn-a");
     expect(updated.metadata.mirrors["conn-a"]).toMatchObject({
-      storage_type: "s3",
       connection_id: "conn-a",
       prefix: "acct/prod/",
       is_primary: true,
@@ -190,27 +188,6 @@ describe("addProductMirror", () => {
 
     const updated = mockProductsTable.update.mock.calls[0][0];
     expect(updated.metadata.mirrors["conn-a"].prefix).toBe("");
-  });
-
-  test("derives a mirror's storage_type from the connection provider", async () => {
-    mockProductsTable.fetchById.mockResolvedValue(productWith({}, ""));
-    mockDataConnectionsTable.fetchById.mockResolvedValue({
-      data_connection_id: "conn-a",
-      prefix_template: "{{repository.account_id}}/{{repository.repository_id}}/",
-      details: { provider: "gcs" },
-    } as DataConnection);
-
-    await addProductMirror(
-      FORM_STATE,
-      formDataFor({
-        account_id: "acct",
-        product_id: "prod",
-        connection_id: "conn-a",
-      })
-    );
-
-    const updated = mockProductsTable.update.mock.calls[0][0];
-    expect(updated.metadata.mirrors["conn-a"].storage_type).toBe("gcs");
   });
 
   test("a second mirror does not become primary", async () => {

--- a/src/lib/actions/product-mirrors.ts
+++ b/src/lib/actions/product-mirrors.ts
@@ -100,10 +100,6 @@ export async function addProductMirror(
     const isFirst = Object.keys(product.metadata.mirrors).length === 0;
 
     const mirror: ProductMirror = {
-      // provider values are the backend storage vocabulary; the cast bridges
-      // TS's nominal string-enum → literal-union gap (see DataProvider).
-      storage_type: connection.details
-        .provider as ProductMirror["storage_type"],
       connection_id: connectionId,
       prefix,
       is_primary: isFirst,

--- a/src/lib/actions/products.test.ts
+++ b/src/lib/actions/products.test.ts
@@ -117,7 +117,6 @@ describe("createProduct", () => {
     const created = (productsTable.create as jest.Mock).mock.calls[0][0];
     expect(created.metadata.primary_mirror).toBe("conn-x");
     expect(created.metadata.mirrors["conn-x"]).toMatchObject({
-      storage_type: "s3",
       connection_id: "conn-x",
       prefix: "alice/my-product/",
       is_primary: true,

--- a/src/lib/actions/products.ts
+++ b/src/lib/actions/products.ts
@@ -6,7 +6,6 @@ import {
   ProductCreationRequestSchema,
   type Product,
   type ProductCreationRequest,
-  type ProductMirror,
   type ProductVisibility,
   resolveMirrorPrefix,
 } from "@/types";
@@ -229,10 +228,6 @@ export async function createProduct(
       primary_mirror: dataConnection.data_connection_id,
       mirrors: {
         [dataConnection.data_connection_id]: {
-          // provider values are the backend storage vocabulary; the cast bridges
-          // TS's nominal string-enum → literal-union gap (see DataProvider).
-          storage_type: dataConnection.details
-            .provider as ProductMirror["storage_type"],
           connection_id: dataConnection.data_connection_id,
           prefix: resolveMirrorPrefix(
             dataConnection.prefix_template,

--- a/src/lib/clients/database/data-connections.test.ts
+++ b/src/lib/clients/database/data-connections.test.ts
@@ -1,5 +1,5 @@
 import { normalizeConnection } from "./data-connections";
-import { DataConnection, DataProvider, ProductMirrorSchema } from "@/types";
+import { DataConnection, DataProvider } from "@/types";
 
 const base = {
   data_connection_id: "conn-a",
@@ -31,20 +31,5 @@ describe("normalizeConnection (legacy provider read-shim)", () => {
       details: { provider: DataProvider.S3, bucket: "b", base_prefix: "", region: "us-east-1" },
     } as DataConnection;
     expect(normalizeConnection(conn)).toBe(conn);
-  });
-});
-
-// Guards the `details.provider as storage_type` casts in products/product-mirrors:
-// every DataProvider value must be a valid ProductMirror storage_type.
-describe("DataProvider ⊆ ProductMirror storage_type", () => {
-  test.each(Object.values(DataProvider))("%s is a valid storage_type", (provider) => {
-    expect(() =>
-      ProductMirrorSchema.parse({
-        storage_type: provider,
-        connection_id: "c",
-        prefix: "",
-        is_primary: true,
-      })
-    ).not.toThrow();
   });
 });

--- a/src/lib/clients/database/data-connections.ts
+++ b/src/lib/clients/database/data-connections.ts
@@ -15,8 +15,7 @@ import { BaseTable } from "./base";
 
 // Rows persisted before DataProvider was aligned to the backend storage
 // vocabulary carry the old provider values. Normalize them on read so old
-// connections surface (and downstream, derive `storage_type`) with current
-// values.
+// connections surface with current values the data proxy accepts.
 // ponytail: read-time shim; drop once all rows are backfilled to canonical values.
 const LEGACY_PROVIDER_ALIASES: Record<string, DataProvider> = {
   az: DataProvider.Azure,

--- a/src/types/data-connection.ts
+++ b/src/types/data-connection.ts
@@ -24,11 +24,11 @@ import { ProductVisibility } from "./product";
 extendZodWithOpenApi(z);
 
 /**
- * Storage backend a data connection targets. Values are drawn from the backend
- * wire vocabulary (`ProductMirror.storage_type` in {@link module:types/product}),
- * so a mirror's `storage_type` is just the connection's `provider` — no
- * translation. `Azure`/`GCS` were once `"az"`/`"gcp"`; legacy rows are
- * normalized on read (see the data-connections DynamoDB client).
+ * Storage backend a data connection targets. Values are the provider strings the
+ * data proxy matches on to build a storage client, so nothing between a
+ * connection and its product mirror needs translation. `Azure`/`GCS` were once
+ * `"az"`/`"gcp"`; legacy rows are normalized on read (see the data-connections
+ * DynamoDB client).
  */
 export enum DataProvider {
   S3 = "s3",

--- a/src/types/product.test.ts
+++ b/src/types/product.test.ts
@@ -3,7 +3,6 @@ import { ProductMetadataSchema } from "./product";
 const baseMetadata = {
   mirrors: {
     "primary-data-connection": {
-      storage_type: "s3" as const,
       connection_id: "primary-data-connection",
       prefix: "account/product/",
       is_primary: true,

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -9,7 +9,6 @@ extendZodWithOpenApi(z);
 // it is the primary mirror.
 export const ProductMirrorSchema = z
   .object({
-    storage_type: z.enum(["s3", "azure", "gcs", "minio", "ceph"]),
     connection_id: z.string(), // Reference to storage connection config
     prefix: z.string(), // Format: "{account_id}/{product_id}/"
     // Mirror-specific settings


### PR DESCRIPTION
**Stacked on #453** (base is `fix/gcs-provider-alignment`) — review/merge that first; GitHub will retarget this to `main` once it lands.

## Why
Nothing branched on `storage_type`: the data proxy keys off the connection's `details.provider`, and the only source.coop consumer was a display label. It was a denormalized copy of the provider, bridged by a cast. This removes the field entirely — dissolving the "two vocabularies" problem rather than just aligning it.

## Changes
- Drop `storage_type` from `ProductMirrorSchema`; stop writing it in `createProduct` / `addProductMirror` (removes both provider→storage_type casts and the invariant test they needed).
- Mirror "Type" label now reads the provider from `connectionInfo` (sourced from the connection's `details.provider` on the edit page).
- **No migration:** `ProductMirrorSchema` is a plain `z.object`, so existing records still carrying `storage_type` parse fine (unknown key stripped).

## Verification
`tsc` clean · `jest` affected suites **116/116** · lint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)