### PR TITLE
feat(analytics): rename product analytics card to "Analytics"

### DIFF
--- a/src/app/(app)/[account_id]/[product_id]/(product)/-/analytics/page.tsx
+++ b/src/app/(app)/[account_id]/[product_id]/(product)/-/analytics/page.tsx
@@ -80,7 +80,7 @@ export default async function ProductAnalyticsPage({
 
       <Card size="2">
         <SectionHeader
-          title="Product Analytics"
+          title="Analytics"
           rightButton={
             <Flex gap="1">
               {USAGE_WINDOWS.map((days) => (

--- a/src/components/features/analytics/UsageCard.tsx
+++ b/src/components/features/analytics/UsageCard.tsx
@@ -27,7 +27,7 @@ export async function UsageCard({ accountId, productId }: UsageCardProps) {
     // (Radix Card is overflow:hidden).
     <Card size={{ initial: "2", sm: "1" }} style={{ flexShrink: 0 }}>
       <SectionHeader
-        title="Product Analytics"
+        title="Analytics"
         rightButton={
           <MonoLabel help={HELP.window}>{usage.days.length} days</MonoLabel>
         }

--- a/src/components/features/analytics/UsageCardSkeleton.tsx
+++ b/src/components/features/analytics/UsageCardSkeleton.tsx
@@ -10,7 +10,7 @@ import { SectionHeader } from "@/components/core/SectionHeader";
 export function UsageCardSkeleton() {
   return (
     <Card size={{ initial: "2", sm: "1" }} style={{ flexShrink: 0 }}>
-      <SectionHeader title="Product Analytics">
+      <SectionHeader title="Analytics">
         <Skeleton width="120px" height="16px" />
         <Flex gap="3" mt="3">
           <Skeleton width="80px" height="40px" />


### PR DESCRIPTION
Renames the card title from "Product Analytics" to "Analytics" on the product page card, the analytics tab view, and the loading skeleton — consistent with the shorter card titles from #430.

🤖 Generated with [Claude Code](https://claude.com/claude-code)