### PR TITLE
feat(analytics): flag product analytics as a preview

### DIFF
--- a/src/app/(app)/[account_id]/[product_id]/(product)/-/analytics/page.tsx
+++ b/src/app/(app)/[account_id]/[product_id]/(product)/-/analytics/page.tsx
@@ -1,7 +1,17 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import { Box, Button, Card, Flex, Heading, Text } from "@radix-ui/themes";
+import { InfoCircledIcon } from "@radix-ui/react-icons";
+import {
+  Box,
+  Button,
+  Callout,
+  Card,
+  Flex,
+  Heading,
+  Link as RadixLink,
+  Text,
+} from "@radix-ui/themes";
 import { getPageSession } from "@/lib";
 import { isAuthorized } from "@/lib/api/authz";
 import { Actions } from "@/types/shared";
@@ -77,6 +87,21 @@ export default async function ProductAnalyticsPage({
       <Heading size="7" my="4">
         {product.title || product_id}
       </Heading>
+
+      <Callout.Root color="blue" role="status" mb="4">
+        <Callout.Icon>
+          <InfoCircledIcon />
+        </Callout.Icon>
+        <Callout.Text>
+          Analytics is a preview feature. The metrics shown here and who can
+          access them may change in the near future. Let us know what you think
+          at{" "}
+          <RadixLink href="mailto:hello@source.coop">
+            hello@source.coop
+          </RadixLink>
+          .
+        </Callout.Text>
+      </Callout.Root>
 
       <Card size="2">
         <SectionHeader


### PR DESCRIPTION
Adds an informational callout to the product analytics page so owners know the feature is not yet settled, and gives them somewhere to send feedback.

> Analytics is a preview feature. The metrics shown here and who can access them may change in the near future. Let us know what you think at hello@source.coop.

<img width="1157" height="517" alt="image" src="https://github.com/user-attachments/assets/64c19bc7-5b4c-4285-b300-20c66cc8383c" />


## How

- One `Callout.Root color="blue" role="status"` above the analytics `Card` in `src/app/(app)/[account_id]/[product_id]/(product)/-/analytics/page.tsx` — matching the informational-callout convention already used elsewhere in the app (blue + `InfoCircledIcon`).
- The mailto uses `Link as RadixLink` from `@radix-ui/themes`, following the existing convention in `OrganizationProfile.tsx` (the page already imports `next/link` as `Link`).

## Testing

- `tsc --noEmit` clean.
- `next lint` on the changed file: no warnings or errors.
- No new tests: the change is static JSX with no branching or logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)