### PR TITLE
fix: don't disable product search/tags inputs during navigation

### DIFF
--- a/src/components/features/products/ProductsFilters.tsx
+++ b/src/components/features/products/ProductsFilters.tsx
@@ -96,7 +96,6 @@ export function ProductsFilters() {
         placeholder="Search products..."
         value={searchInput}
         onChange={(e) => setSearchInput(e.target.value)}
-        disabled={isPending}
       />
 
       <TextField.Root
@@ -105,7 +104,6 @@ export function ProductsFilters() {
         placeholder="Filter by tags (comma-separated)"
         value={tagsInput}
         onChange={(e) => setTagsInput(e.target.value)}
-        disabled={isPending}
       />
 
       <Button


### PR DESCRIPTION
## Summary
- Removes `disabled={isPending}` from the product search and tags text inputs in `ProductsFilters.tsx`, which was causing the fields to lose focus every time the debounced URL update fired (i.e. whenever the user paused typing).

Closes #467

Generated with [Claude Code](https://claude.ai/code)