### PR TITLE
feat(object-browser): show last modified time for files

### DIFF
--- a/src/components/core/MonoText.tsx
+++ b/src/components/core/MonoText.tsx
@@ -1,10 +1,13 @@
 import { Text } from '@radix-ui/themes';
-import type { ComponentProps } from 'react';
+import { forwardRef, type ComponentProps } from 'react';
 
 type MonoTextProps = ComponentProps<typeof Text>;
 
-export function MonoText(props: MonoTextProps) {
-  return (
-    <Text {...props} style={{ fontFamily: 'var(--code-font-family)', ...props.style }} />
-  );
-} 
+// forwardRef so Radix primitives (Tooltip, etc.) can anchor to it.
+export const MonoText = forwardRef<HTMLSpanElement, MonoTextProps>(
+  function MonoText(props, ref) {
+    return (
+      <Text ref={ref} {...props} style={{ fontFamily: 'var(--code-font-family)', ...props.style }} />
+    );
+  }
+);

--- a/src/components/features/products/object-browser/DirectoryRow.test.tsx
+++ b/src/components/features/products/object-browser/DirectoryRow.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import { Theme } from "@radix-ui/themes";
+import { DirectoryRow } from "./DirectoryRow";
+import type { Product } from "@/types";
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: jest.fn() }),
+}));
+jest.mock("@/components/features/uploader", () => ({
+  useUploadManager: () => ({
+    cancelUpload: jest.fn(),
+    retryUpload: jest.fn(),
+    getUploadsForScope: () => [],
+    deleteObject: jest.fn(),
+    deletePrefix: jest.fn(),
+  }),
+  useS3Credentials: () => ({ getCredentials: () => null }),
+}));
+
+const product = {
+  account_id: "cholmes",
+  product_id: "overture",
+} as Product;
+
+const renderRow = (item: Parameters<typeof DirectoryRow>[0]["item"]) =>
+  render(
+    <Theme>
+      <DirectoryRow
+        item={item}
+        index={0}
+        itemsLength={1}
+        itemHeight={40}
+        product={product}
+      />
+    </Theme>
+  );
+
+describe("DirectoryRow last modified", () => {
+  it("shows a relative time with the UTC timestamp as its title", () => {
+    renderRow({
+      name: "catalog.json",
+      path: "catalog.json",
+      size: 1234,
+      updated_at: new Date(Date.now() - 21 * 24 * 3600 * 1000).toISOString(),
+      isDirectory: false,
+    });
+    expect(screen.getByText("3 weeks ago")).toHaveAttribute(
+      "title",
+      expect.stringContaining("UTC")
+    );
+  });
+
+  it("omits it for directories, whose mtime is synthetic", () => {
+    renderRow({
+      name: "tiles",
+      path: "tiles/",
+      size: 0,
+      updated_at: new Date().toISOString(),
+      isDirectory: true,
+    });
+    expect(screen.queryByText(/ago$/)).toBeNull();
+  });
+});

--- a/src/components/features/products/object-browser/DirectoryRow.tsx
+++ b/src/components/features/products/object-browser/DirectoryRow.tsx
@@ -24,7 +24,7 @@ import { useRouter } from "next/navigation";
 import { MonoText } from "@/components/core";
 import type { FileNode } from "./utils";
 import type { Product } from "@/types";
-import { formatBytes } from "@/lib/format";
+import { formatBytes, formatDate, formatRelativeTime } from "@/lib/format";
 import { objectUrl } from "@/lib/urls";
 import styles from "./ObjectBrowser.module.css";
 import { useState } from "react";
@@ -211,6 +211,23 @@ export function DirectoryRow({
                 <MonoText color="gray" size="1" style={{ flexShrink: 0 }}>
                   {formatBytes(item.size)}
                 </MonoText>
+              )}
+
+              {/* Last modified — directories have no real mtime, so files only.
+                  suppressHydrationWarning: "now" differs between server and
+                  client render, so a just-uploaded file can disagree by seconds. */}
+              {!item.isDirectory && item.updated_at && (
+                <Tooltip content={formatDate(item.updated_at, true)}>
+                  <MonoText
+                    color="gray"
+                    size="1"
+                    title={formatDate(item.updated_at, true)}
+                    suppressHydrationWarning
+                    style={{ flexShrink: 0, whiteSpace: "nowrap" }}
+                  >
+                    {formatRelativeTime(item.updated_at)}
+                  </MonoText>
+                </Tooltip>
               )}
 
               {/* Upload control buttons */}

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,0 +1,21 @@
+import { formatRelativeTime } from "./format";
+
+describe("formatRelativeTime", () => {
+  const now = new Date("2024-06-15T12:00:00Z");
+  const ago = (ms: number) => new Date(now.getTime() - ms).toISOString();
+
+  it.each([
+    [ago(30_000), "30 seconds ago"],
+    [ago(5 * 60_000), "5 minutes ago"],
+    [ago(3 * 3600_000), "3 hours ago"],
+    [ago(2 * 24 * 3600_000), "2 days ago"],
+    [ago(21 * 24 * 3600_000), "3 weeks ago"],
+    [ago(400 * 24 * 3600_000), "last year"],
+  ])("%s -> %s", (date, expected) => {
+    expect(formatRelativeTime(date, now)).toBe(expected);
+  });
+
+  it("returns empty string for an unparseable date", () => {
+    expect(formatRelativeTime("not a date", now)).toBe("");
+  });
+});

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -25,6 +25,34 @@ export function formatDateSSR(date: string): string {
   return `${day} ${month} ${year}`;
 }
 
+const RELATIVE_UNITS: [Intl.RelativeTimeFormatUnit, number][] = [
+  ['year', 365 * 24 * 3600],
+  ['month', 30 * 24 * 3600],
+  ['week', 7 * 24 * 3600],
+  ['day', 24 * 3600],
+  ['hour', 3600],
+  ['minute', 60],
+  ['second', 1],
+];
+
+/**
+ * Format a date string as a relative time, e.g. "3 weeks ago".
+ * @param date The date string to format
+ * @param now Reference point, for testing
+ * @returns A relative time string, or "" if the date is unparseable
+ */
+export function formatRelativeTime(date: string, now: Date = new Date()): string {
+  const seconds = (new Date(date).getTime() - now.getTime()) / 1000;
+  if (Number.isNaN(seconds)) return '';
+  const [unit, perUnit] =
+    RELATIVE_UNITS.find(([, s]) => Math.abs(seconds) >= s) ??
+    RELATIVE_UNITS[RELATIVE_UNITS.length - 1];
+  return new Intl.RelativeTimeFormat('en', { numeric: 'auto' }).format(
+    Math.round(seconds / perUnit),
+    unit
+  );
+}
+
 /**
  * Format a date string into a human-readable format with optional time
  * @param date The date string to format


### PR DESCRIPTION
Closes #469 (partially — object listing only).

Files in the directory listing now show when they were last modified, between the file size and the download/copy/delete buttons.

- Relative text ("3 weeks ago") via `Intl.RelativeTimeFormat` — no new dependency.
- Exact UTC timestamp in a Radix tooltip *and* the `title` attribute, so it is reachable without a hover.
- Directories are skipped: object stores have no prefix mtime, and the page currently synthesizes `now` for them, which would be misleading.
- `suppressHydrationWarning` on the text: "now" differs between the server and client render, so a just-uploaded file can disagree by a few seconds.

`MonoText` became `forwardRef` so Radix's `Tooltip` can anchor to it.

### Before / after

The `DirectoryList` stories cover these rows, so both shots are the same story — [Features/Object browser/DirectoryList → Default](https://source-coop-ui-git-feat-object-last-modified-radiantearth.vercel.app/?path=/story/features-object-browser-directorylist--default) — with nothing changed but the branch.

**Before** — size, then the row controls:

![Directory listing before: catalog.parquet and README.md show only their size before the download and copy buttons](https://raw.githubusercontent.com/source-cooperative/source.coop/assets/object-last-modified/before.png)

**After** — "6 months ago" sits between the size and the controls, and the two directory rows above it stay bare:

![Directory listing after: the same two files now show "6 months ago" after their size, while the derived and recordings directories show nothing](https://raw.githubusercontent.com/source-cooperative/source.coop/assets/object-last-modified/after.png)

**Hovering** the relative text gives the exact UTC timestamp:

![Tooltip above catalog.parquet reading "12 Mar 2026 00:00 UTC"](https://raw.githubusercontent.com/source-cooperative/source.coop/assets/object-last-modified/tooltip.png)

No story is added or changed: `DirectoryRow` has none of its own, and `DirectoryList.stories.tsx` already renders it with objects carrying an `updated_at`, so the new column appears in every story there.

### Verification
- `src/lib/format.test.ts` — unit tests for `formatRelativeTime` (seconds → years, unparseable input). The file now also holds main's `formatUrl` suite; the rebase below merged the two.
- `src/components/features/products/object-browser/DirectoryRow.test.tsx` — asserts the relative text renders with a UTC `title`, and that directories don't get one.
- `npx jest --ci --forceExit` over both files: 17 passed.
- `npx tsc --noEmit -p tsconfig.typecheck.json` clean apart from the pre-existing `recharts` module-not-found errors, which are unrelated — that dependency isn't installed in this environment. `npm run build` can't be used to verify here, since prerendering the marketing homepage needs AWS credentials.
- Screenshots above taken from the local Storybook on this branch, and from the same story with only these three files reverted to `main`.

### Rebased onto main
This branch was rebased onto `a14311ea` to clear a conflict in `src/lib/format.test.ts`, which main added a `formatUrl` suite to in #531. Both suites are kept, in one file, sharing one import.

### Docs and ADRs
Checked both repositories, neither needs a change. `docs.source.coop` documents flows — creating an account, uploading data, bringing your own bucket — and this changes none of them; it adds a column to a listing the user already sees. The `data.source.coop` ADRs cover authorization, STS credentials and API keys (005, 004, 013); `updated_at` is already in the listing this app receives, so no decision there moves.

### Not included
The issue also asks for a last-modified indicator at the *repo/product* level. That needs a product-level aggregate that isn't computed today, so it is left out here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
