### PR TITLE
perf: drop globe texture preload hints from landing page

### DIFF
--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -43,9 +43,6 @@ export default async function Landing() {
 
   return (
     <>
-      {/* ponytail: no texture preload — LiveGlobe is dynamic({ ssr: false }), so it
-          mounts after hydration anyway. Preloading pulled 6.5MB into the critical
-          window ahead of the render-blocking CSS that gates first paint. */}
       <Box className={styles.landing} px={{ sm: "6", lg: "9" }}>
         <Box className={styles.landingInner} mx="auto" maxWidth="1400px">
           <Navigation />

--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -43,9 +43,9 @@ export default async function Landing() {
 
   return (
     <>
-      {/* Preload globe textures so they're cached before the client component mounts */}
-      <link rel="preload" href="/img/earth-blue-marble.jpg" as="image" />
-      <link rel="preload" href="/img/clouds.png" as="image" />
+      {/* ponytail: no texture preload — LiveGlobe is dynamic({ ssr: false }), so it
+          mounts after hydration anyway. Preloading pulled 6.5MB into the critical
+          window ahead of the render-blocking CSS that gates first paint. */}
       <Box className={styles.landing} px={{ sm: "6", lg: "9" }}>
         <Box className={styles.landingInner} mx="auto" maxWidth="1400px">
           <Navigation />


### PR DESCRIPTION
Part of #471.

## What

Deletes the two `<link rel="preload">` hints for the WebGL globe textures in `src/app/(marketing)/page.tsx`.

## Why

The hints pulled **6.5 MB** of textures into the critical window, ahead of the render-blocking stylesheet that gates first paint. On a real-throttled 4G profile, `_next/static/css/1e5913857760d7aa.css` was requested at 682 ms but did not arrive until **5901 ms** — and FCP tracks that arrival exactly.

The preloads had no upside to weigh against that cost. The original comment said they warmed the cache "before the client component mounts", but `LiveGlobe` is `dynamic(..., { ssr: false })` — it mounts after hydration and requests the textures itself either way. The preload only changed *when* the bytes competed for bandwidth, not whether they were fetched.

## Measured impact

Lighthouse 13.4.1, mobile, `--throttling-method=devtools`:

| Metric | Before | After |
|---|---|---|
| FCP | 6.1 s | **5.3 s** |
| LCP | 6.1 s | **5.3 s** |
| Blocking CSS arrives | 5901 ms | 5094 ms |

Note that Lighthouse's *default* simulated throttling shows no change here — Lantern de-prioritizes `Low`-priority images out of the critical path and hides the contention. Re-measure with `--throttling-method=devtools`.

This is the first of several fixes; the textures are still oversized at 4096×2048, which #471 tracks separately.

## Risk

Low. Deletes two JSX lines, no behavior change — the globe loads its own textures on mount as before.

## Verification

- `npm run type-check` — 14 errors, identical to the count on clean `main` (all pre-existing, in `analytics/` files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)