### PR TITLE
perf: preconnect to cross-origin hosts on the critical path

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,10 +23,6 @@ export default async function RootLayout({ children }: RootLayoutProps) {
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={ibmPlexSans.variable} suppressHydrationWarning>
-        {/* ponytail: cross-origin hosts on the critical path. Both are discovered
-            late — the fonts only once globals.css parses — so the handshake
-            otherwise starts cold. crossOrigin on the font host only: fonts are
-            fetched in CORS mode, the Ory session request is credentialed. */}
         <link
           rel="preconnect"
           href="https://assets.radiant.earth"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import NextTopLoader from "nextjs-toploader";
 import { IBM_Plex_Sans } from "next/font/google";
 import { S3CredentialsProvider, UploadProvider } from "@/components";
 import { metadata } from "./metadata";
+import { CONFIG } from "@/lib/config";
 const ibmPlexSans = IBM_Plex_Sans({
   subsets: ["latin"],
   weight: ["400", "500", "600", "700"],
@@ -22,6 +23,18 @@ export default async function RootLayout({ children }: RootLayoutProps) {
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={ibmPlexSans.variable} suppressHydrationWarning>
+        {/* ponytail: cross-origin hosts on the critical path. Both are discovered
+            late — the fonts only once globals.css parses — so the handshake
+            otherwise starts cold. crossOrigin on the font host only: fonts are
+            fetched in CORS mode, the Ory session request is credentialed. */}
+        <link
+          rel="preconnect"
+          href="https://assets.radiant.earth"
+          crossOrigin=""
+        />
+        {CONFIG.auth.api.backendUrl && (
+          <link rel="preconnect" href={CONFIG.auth.api.backendUrl} />
+        )}
         <ThemeProvider
           attribute="class"
           enableSystem={true}


### PR DESCRIPTION
Part of #471.

## What

Adds two `preconnect` hints in the root layout. The app currently has no `preconnect` or `dns-prefetch` anywhere.

## Why

Neither origin is known to the browser until late in the load:

- **`assets.radiant.earth`** serves the four Berkeley Mono `@font-face` URLs declared in `src/styles/globals.css`. The browser can't discover them until that render-blocking stylesheet parses — **5247 ms** into a real-throttled 4G load — so the TCP + TLS handshake starts cold at the worst possible moment.
- **Ory session host** (`/sessions/whoami`) is flagged by Lighthouse as a preconnect candidate worth **272 ms of LCP**.

## Details worth reviewing

**`crossOrigin` is set on the font host only.** Fonts are fetched in CORS mode and need an anonymous socket; a preconnect without `crossorigin` would open the wrong kind of connection and the font would pay for a second handshake. The Ory session request is credentialed, so it needs the normal (non-anonymous) socket — adding `crossorigin` there would be the same mistake in reverse.

**The auth hint is conditional.** `CONFIG.auth.api.backendUrl` is empty in dev, where middleware serves auth pages locally, and `<link rel="preconnect" href="">` would resolve to the page's own origin. I used `backendUrl` rather than `frontendUrl` because `/sessions/whoami` is a Ory backend/SDK call. Env is read via `CONFIG` per the project convention rather than `process.env` directly.

The href is passed whole — `preconnect` uses the origin of the given URL, so no parsing is needed even if the value carries a path.

## Follow-up

The real fix for the font is self-hosting it via `next/font/local`, which would put it on the same connection and allow a genuine preload. That's blocked on a licensing decision (Berkeley Mono is commercially licensed and this is a public repo) — tracked in #471. `preconnect` is the safe interim step.

## Verification

- `npm run type-check` — 14 errors, identical to the count on clean `main` (all pre-existing, in `analytics/` files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)