### PR TITLE
perf: cache un-hashed static assets under /img and /logo

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -25,10 +25,26 @@ const nextConfig = {
   transpilePackages: ["jose"],
   serverExternalPackages: ["@duckdb/node-api"],
   async headers() {
+    // ponytail: un-hashed filenames under public/, so `immutable` is unsafe —
+    // a redeploy has to be able to replace these in place. An hour of freshness
+    // drops the per-navigation revalidation round-trip without stranding a
+    // stale asset for long.
+    const staticAssets = [
+      {
+        source: "/:dir(img|logo)/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=3600, stale-while-revalidate=604800",
+          },
+        ],
+      },
+    ];
     if (process.env.STAGE === "prod") {
-      return [];
+      return staticAssets;
     }
     return [
+      ...staticAssets,
       {
         source: "/:path*",
         headers: [

--- a/next.config.test.ts
+++ b/next.config.test.ts
@@ -1,5 +1,20 @@
 import nextConfig from "./next.config.js";
 
+const STATIC_ASSET_RULE = {
+  source: "/:dir(img|logo)/:path*",
+  headers: [
+    {
+      key: "Cache-Control",
+      value: "public, max-age=3600, stale-while-revalidate=604800",
+    },
+  ],
+};
+
+const NOINDEX_RULE = {
+  source: "/:path*",
+  headers: [{ key: "X-Robots-Tag", value: "noindex, nofollow" }],
+};
+
 describe("next.config headers()", () => {
   const originalStage = process.env.STAGE;
 
@@ -14,28 +29,26 @@ describe("next.config headers()", () => {
   test("non-prod stage emits noindex header on all paths", async () => {
     process.env.STAGE = "dev";
     const result = await nextConfig.headers!();
-    expect(result).toEqual([
-      {
-        source: "/:path*",
-        headers: [{ key: "X-Robots-Tag", value: "noindex, nofollow" }],
-      },
-    ]);
+    expect(result).toEqual([STATIC_ASSET_RULE, NOINDEX_RULE]);
   });
 
-  test("prod stage emits no header overrides", async () => {
+  test("prod stage emits no noindex override", async () => {
     process.env.STAGE = "prod";
     const result = await nextConfig.headers!();
-    expect(result).toEqual([]);
+    expect(result).toEqual([STATIC_ASSET_RULE]);
   });
 
   test("missing STAGE defaults to noindex", async () => {
     delete process.env.STAGE;
     const result = await nextConfig.headers!();
-    expect(result).toEqual([
-      {
-        source: "/:path*",
-        headers: [{ key: "X-Robots-Tag", value: "noindex, nofollow" }],
-      },
-    ]);
+    expect(result).toEqual([STATIC_ASSET_RULE, NOINDEX_RULE]);
+  });
+
+  test("static assets stay cacheable in every stage", async () => {
+    for (const stage of ["prod", "dev"]) {
+      process.env.STAGE = stage;
+      const result = await nextConfig.headers!();
+      expect(result).toContainEqual(STATIC_ASSET_RULE);
+    }
   });
 });


### PR DESCRIPTION
Part of #471.

## What

Adds a `Cache-Control` rule for `/img/*` and `/logo/*` in `next.config.js`, and makes `headers()` apply in prod (it previously returned no rules at all there). The noindex rule stays non-prod only.

```
public, max-age=3600, stale-while-revalidate=604800
```

## Why

These assets are currently served `public, max-age=0, must-revalidate`, so every navigation pays a conditional-request round-trip for each one.

**Calibrating the win honestly:** I verified the revalidation returns `304` with **0 bytes**, so this was never a re-download problem — just latency. It's a modest fix, not a headline one, and it's the smallest item in #471.

## Why not `immutable`

The filenames under `public/` are not content-hashed, so `immutable` would be actively dangerous — a redeploy could never replace them for anyone holding a cached copy. That's not hypothetical: #473 changes the bytes of `clouds.png` at the same filename.

An hour of freshness removes the round-trip while bounding how long a replaced asset can linger, and `stale-while-revalidate` keeps the refresh off the critical path. Content-hashing these filenames would unlock a real `immutable` policy later; noted in #471.

## Verification

- `npx jest next.config.test.ts` — **4 passed**. I updated the three existing tests (the prod case asserted `[]`, which no longer holds) and added one asserting the cache rule applies in every stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)