### PR TITLE
feat(profiles): add "New product" link to profile products list

### DIFF
--- a/src/app/(app)/[account_id]/IndividualProfilePage.tsx
+++ b/src/app/(app)/[account_id]/IndividualProfilePage.tsx
@@ -41,16 +41,22 @@ export async function IndividualProfilePage({
     )
   ).filter(isOrganizationalAccount);
 
+  const isOwner = session?.account?.account_id === account.account_id;
+
   // For individual accounts
   return (
     <IndividualProfile
       account={account as IndividualAccount}
-      isOwner={session?.account?.account_id === account.account_id}
+      isOwner={isOwner}
       ownedProducts={products}
       contributedProducts={[]}
       organizations={organizations}
       showWelcome={showWelcome}
       canEdit={isAuthorized(session, account, Actions.PutAccountProfile)}
+      // Products can only be created under your own individual account.
+      canCreateProduct={
+        isOwner && isAuthorized(session, "*", Actions.CreateRepository)
+      }
     />
   );
 }

--- a/src/app/(app)/[account_id]/IndividualProfilePage.tsx
+++ b/src/app/(app)/[account_id]/IndividualProfilePage.tsx
@@ -4,7 +4,7 @@ import {
   membershipsTable,
   productsTable,
 } from "@/lib/clients/database";
-import { type IndividualAccount, Actions } from "@/types";
+import { type IndividualAccount, type Product, Actions } from "@/types";
 import { getPageSession } from "@/lib/api/utils";
 import { isAuthorized } from "@/lib/api/authz";
 import { IndividualProfile } from "@/components/features/profiles/IndividualProfile";
@@ -41,22 +41,23 @@ export async function IndividualProfilePage({
     )
   ).filter(isOrganizationalAccount);
 
-  const isOwner = session?.account?.account_id === account.account_id;
-
   // For individual accounts
   return (
     <IndividualProfile
       account={account as IndividualAccount}
-      isOwner={isOwner}
+      isOwner={session?.account?.account_id === account.account_id}
       ownedProducts={products}
       contributedProducts={[]}
       organizations={organizations}
       showWelcome={showWelcome}
       canEdit={isAuthorized(session, account, Actions.PutAccountProfile)}
-      // Products can only be created under your own individual account.
-      canCreateProduct={
-        isOwner && isAuthorized(session, "*", Actions.CreateRepository)
-      }
+      canCreateProduct={isAuthorized(
+        session,
+        // Same partial-product check the create action runs, so the link only
+        // appears when the create would actually be allowed.
+        { account_id: account.account_id } as Product,
+        Actions.CreateRepository
+      )}
     />
   );
 }

--- a/src/app/(app)/[account_id]/OrganizationProfilePage.tsx
+++ b/src/app/(app)/[account_id]/OrganizationProfilePage.tsx
@@ -10,6 +10,7 @@ import {
 import {
   type IndividualAccount,
   type OrganizationalAccount,
+  type Product,
   Actions,
   MembershipRole,
   MembershipState,
@@ -106,11 +107,13 @@ export async function OrganizationProfilePage({
           admins={admins}
           members={members}
           canEdit={isAuthorized(session, account, Actions.PutAccountProfile)}
-          // Matches /products/new, which offers every org you're a member of
-          // as a potential owner.
-          canCreateProduct={
-            !!isMember && isAuthorized(session, "*", Actions.CreateRepository)
-          }
+          canCreateProduct={isAuthorized(
+            session,
+            // Same partial-product check the create action runs, so the link
+            // only appears when the create would actually be allowed.
+            { account_id: account.account_id } as Product,
+            Actions.CreateRepository
+          )}
         />
       </Box>
     </Container>

--- a/src/app/(app)/[account_id]/OrganizationProfilePage.tsx
+++ b/src/app/(app)/[account_id]/OrganizationProfilePage.tsx
@@ -106,6 +106,11 @@ export async function OrganizationProfilePage({
           admins={admins}
           members={members}
           canEdit={isAuthorized(session, account, Actions.PutAccountProfile)}
+          // Matches /products/new, which offers every org you're a member of
+          // as a potential owner.
+          canCreateProduct={
+            !!isMember && isAuthorized(session, "*", Actions.CreateRepository)
+          }
         />
       </Box>
     </Container>

--- a/src/components/features/profiles/IndividualProfile.tsx
+++ b/src/components/features/profiles/IndividualProfile.tsx
@@ -125,10 +125,10 @@ export function IndividualProfile({
           <Flex justify="between" align="center" mb="2">
             <Heading size="4">Products</Heading>
             {canCreateProduct && (
-              <RadixLink asChild size="2">
+              <RadixLink asChild size="1">
                 <Link href={newProductUrl(account.account_id)}>
                   <Flex as="span" align="center" gap="1">
-                    <PlusIcon /> New product
+                    <PlusIcon width="12" height="12" /> New product
                   </Flex>
                 </Link>
               </RadixLink>

--- a/src/components/features/profiles/IndividualProfile.tsx
+++ b/src/components/features/profiles/IndividualProfile.tsx
@@ -134,7 +134,13 @@ export function IndividualProfile({
               </RadixLink>
             )}
           </Flex>
-          <ProductsList products={ownedProducts} />
+          {ownedProducts.length > 0 ? (
+            <ProductsList products={ownedProducts} />
+          ) : (
+            <Text as="p" size="2">
+              No products available.
+            </Text>
+          )}
         </Box>
       )}
 

--- a/src/components/features/profiles/IndividualProfile.tsx
+++ b/src/components/features/profiles/IndividualProfile.tsx
@@ -126,7 +126,7 @@ export function IndividualProfile({
           <Flex justify="between" align="center" mb="2">
             <Heading size="4">Products</Heading>
             {canCreateProduct && (
-              <Button asChild size="1" variant="soft">
+              <Button asChild size="1" variant="outline">
                 <Link href={newProductUrl(account.account_id)}>
                   <PlusIcon /> New product
                 </Link>

--- a/src/components/features/profiles/IndividualProfile.tsx
+++ b/src/components/features/profiles/IndividualProfile.tsx
@@ -1,13 +1,11 @@
 import {
   Box,
-  Button,
   Text,
   Grid,
   Heading,
   Flex,
   Link as RadixLink,
 } from "@radix-ui/themes";
-import { PlusIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
 import type {
   IndividualAccount,
@@ -126,11 +124,9 @@ export function IndividualProfile({
           <Flex justify="between" align="center" mb="2">
             <Heading size="4">Products</Heading>
             {canCreateProduct && (
-              <Button asChild size="1" variant="outline">
-                <Link href={newProductUrl(account.account_id)}>
-                  <PlusIcon /> New product
-                </Link>
-              </Button>
+              <RadixLink asChild size="2">
+                <Link href={newProductUrl(account.account_id)}>New product</Link>
+              </RadixLink>
             )}
           </Flex>
           <ProductsList products={ownedProducts} />

--- a/src/components/features/profiles/IndividualProfile.tsx
+++ b/src/components/features/profiles/IndividualProfile.tsx
@@ -1,17 +1,20 @@
 import {
   Box,
+  Button,
   Text,
   Grid,
   Heading,
   Flex,
   Link as RadixLink,
 } from "@radix-ui/themes";
+import { PlusIcon } from "@radix-ui/react-icons";
+import Link from "next/link";
 import type {
   IndividualAccount,
   OrganizationalAccount,
   Product,
 } from "@/types";
-import { editAccountProfileUrl } from "@/lib/urls";
+import { editAccountProfileUrl, newProductUrl } from "@/lib/urls";
 import { ProfileAvatar } from "./ProfileAvatar";
 import { ProductsList } from "../products/ProductsList";
 import { WebsiteLink } from "./WebsiteLink";
@@ -27,6 +30,7 @@ interface IndividualProfileProps {
   organizations: OrganizationalAccount[];
   showWelcome?: boolean;
   canEdit: boolean;
+  canCreateProduct: boolean;
 }
 
 export function IndividualProfile({
@@ -37,6 +41,7 @@ export function IndividualProfile({
   organizations,
   showWelcome = false,
   canEdit,
+  canCreateProduct,
 }: IndividualProfileProps) {
   const primaryEmail = account.emails?.find((email) => email.is_primary);
   return (
@@ -116,11 +121,18 @@ export function IndividualProfile({
         </Box>
       )}
 
-      {ownedProducts.length > 0 && (
+      {(ownedProducts.length > 0 || canCreateProduct) && (
         <Box mb="6">
-          <Heading size="4" mb="2">
-            Products
-          </Heading>
+          <Flex justify="between" align="center" mb="2">
+            <Heading size="4">Products</Heading>
+            {canCreateProduct && (
+              <Button asChild size="1" variant="soft">
+                <Link href={newProductUrl(account.account_id)}>
+                  <PlusIcon /> New product
+                </Link>
+              </Button>
+            )}
+          </Flex>
           <ProductsList products={ownedProducts} />
         </Box>
       )}

--- a/src/components/features/profiles/IndividualProfile.tsx
+++ b/src/components/features/profiles/IndividualProfile.tsx
@@ -6,6 +6,7 @@ import {
   Flex,
   Link as RadixLink,
 } from "@radix-ui/themes";
+import { PlusIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
 import type {
   IndividualAccount,
@@ -125,7 +126,11 @@ export function IndividualProfile({
             <Heading size="4">Products</Heading>
             {canCreateProduct && (
               <RadixLink asChild size="2">
-                <Link href={newProductUrl(account.account_id)}>New product</Link>
+                <Link href={newProductUrl(account.account_id)}>
+                  <Flex as="span" align="center" gap="1">
+                    <PlusIcon /> New product
+                  </Flex>
+                </Link>
               </RadixLink>
             )}
           </Flex>

--- a/src/components/features/profiles/OrganizationProfile.tsx
+++ b/src/components/features/profiles/OrganizationProfile.tsx
@@ -132,7 +132,7 @@ export function OrganizationProfile({
             Products
           </Heading>
           {canCreateProduct && (
-            <Button asChild size="1" variant="soft">
+            <Button asChild size="1" variant="outline">
               <Link href={newProductUrl(account.account_id)}>
                 <PlusIcon /> New product
               </Link>

--- a/src/components/features/profiles/OrganizationProfile.tsx
+++ b/src/components/features/profiles/OrganizationProfile.tsx
@@ -2,14 +2,12 @@
 
 import {
   Box,
-  Button,
   Heading,
   Text,
   Link as RadixLink,
   Flex,
   Grid,
 } from "@radix-ui/themes";
-import { PlusIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
 import type {
   IndividualAccount,
@@ -132,11 +130,9 @@ export function OrganizationProfile({
             Products
           </Heading>
           {canCreateProduct && (
-            <Button asChild size="1" variant="outline">
-              <Link href={newProductUrl(account.account_id)}>
-                <PlusIcon /> New product
-              </Link>
-            </Button>
+            <RadixLink asChild size="2">
+              <Link href={newProductUrl(account.account_id)}>New product</Link>
+            </RadixLink>
           )}
         </Flex>
         {products.length > 0 ? (

--- a/src/components/features/profiles/OrganizationProfile.tsx
+++ b/src/components/features/profiles/OrganizationProfile.tsx
@@ -131,10 +131,10 @@ export function OrganizationProfile({
             Products
           </Heading>
           {canCreateProduct && (
-            <RadixLink asChild size="2">
+            <RadixLink asChild size="1">
               <Link href={newProductUrl(account.account_id)}>
                 <Flex as="span" align="center" gap="1">
-                  <PlusIcon /> New product
+                  <PlusIcon width="12" height="12" /> New product
                 </Flex>
               </Link>
             </RadixLink>

--- a/src/components/features/profiles/OrganizationProfile.tsx
+++ b/src/components/features/profiles/OrganizationProfile.tsx
@@ -8,6 +8,7 @@ import {
   Flex,
   Grid,
 } from "@radix-ui/themes";
+import { PlusIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
 import type {
   IndividualAccount,
@@ -131,7 +132,11 @@ export function OrganizationProfile({
           </Heading>
           {canCreateProduct && (
             <RadixLink asChild size="2">
-              <Link href={newProductUrl(account.account_id)}>New product</Link>
+              <Link href={newProductUrl(account.account_id)}>
+                <Flex as="span" align="center" gap="1">
+                  <PlusIcon /> New product
+                </Flex>
+              </Link>
             </RadixLink>
           )}
         </Flex>

--- a/src/components/features/profiles/OrganizationProfile.tsx
+++ b/src/components/features/profiles/OrganizationProfile.tsx
@@ -2,12 +2,15 @@
 
 import {
   Box,
+  Button,
   Heading,
   Text,
   Link as RadixLink,
   Flex,
   Grid,
 } from "@radix-ui/themes";
+import { PlusIcon } from "@radix-ui/react-icons";
+import Link from "next/link";
 import type {
   IndividualAccount,
   OrganizationalAccount,
@@ -20,7 +23,7 @@ import { OrganizationMembers } from "./OrganizationMembers";
 import { ProfileAvatar } from "./ProfileAvatar";
 import { WebsiteLink } from "./WebsiteLink";
 import { ProfileLocation } from "./ProfileLocation";
-import { editAccountProfileUrl } from "@/lib/urls";
+import { editAccountProfileUrl, newProductUrl } from "@/lib/urls";
 import { EditButton } from "@/components/core";
 
 interface OrganizationProfileProps {
@@ -30,6 +33,7 @@ interface OrganizationProfileProps {
   admins: IndividualAccount[];
   members: IndividualAccount[];
   canEdit: boolean;
+  canCreateProduct: boolean;
 }
 
 export function OrganizationProfile({
@@ -39,6 +43,7 @@ export function OrganizationProfile({
   admins,
   members,
   canEdit,
+  canCreateProduct,
 }: OrganizationProfileProps) {
   return (
     <Box>
@@ -122,9 +127,18 @@ export function OrganizationProfile({
       </Grid>
 
       <Box>
-        <Heading as="h2" size="4" mb="2">
-          Products
-        </Heading>
+        <Flex justify="between" align="center" mb="2">
+          <Heading as="h2" size="4">
+            Products
+          </Heading>
+          {canCreateProduct && (
+            <Button asChild size="1" variant="soft">
+              <Link href={newProductUrl(account.account_id)}>
+                <PlusIcon /> New product
+              </Link>
+            </Button>
+          )}
+        </Flex>
         {products.length > 0 ? (
           <ProductsList products={products} />
         ) : (


### PR DESCRIPTION
Adds a **New product** button in the upper right of the Products section on account profile pages, shown only when the viewer is authorized to create a product for that account.

## Behavior

The gate is a single `isAuthorized(session, { account_id } as Product, Actions.CreateRepository)` call — the same partial-product check `createProduct` runs in `src/lib/actions/products.ts`, so the link appears exactly when the create would succeed. `createRepository` already encodes the full rule: signed in and not disabled, admin bypass, `CREATE_REPOSITORIES` flag, then `account_id` match (your own profile) or an org-wide `Owners`/`Maintainers` membership.

Note this is stricter than the owner list on `/products/new`, which offers every org you hold any `Member`-state membership in — a read-data member would be offered the org and then rejected on submit. This PR does not change that page; it just avoids surfacing a link that would dead-end.

On an individual profile the Products section previously disappeared entirely at zero products; it now renders when you can create one, so the button is reachable on an empty profile.

## Changes

- `IndividualProfile.tsx` / `OrganizationProfile.tsx` — Products heading becomes a `Flex justify="between"` with the button, gated on a new `canCreateProduct` prop.
- `IndividualProfilePage.tsx` / `OrganizationProfilePage.tsx` — compute `canCreateProduct` and pass it down.

## Verification

- `tsc --noEmit` — no errors in the touched files (pre-existing errors remain in `components/features/analytics/*`)
- `npx jest account_id` — 9 suites, 43 tests passing
- `next lint --dir src/components/features/profiles` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)