### PR TITLE
fix(data-connections): stop listing other accounts' connections on product create

### DIFF
--- a/src/app/(app)/products/new/page.tsx
+++ b/src/app/(app)/products/new/page.tsx
@@ -51,12 +51,17 @@ export default async function NewProductPage({
     )),
   ];
 
-  // Strip credentials before handing connections to the client component.
-  const dataConnections = (await listUsableDataConnections(session)).map(
-    (connection) =>
-      DataConnectionObjectSchema.omit({ authentication: true }).parse(
-        connection
-      )
+  // Only connections usable by an account this user can create products under —
+  // an owned connection exposes its account's bucket names and prefixes, so the
+  // form's owner filter must not be the only one. Strip credentials before
+  // handing what remains to the client component.
+  const dataConnections = (
+    await listUsableDataConnections(
+      session,
+      potentialOwnerAccounts.map((account) => account.account_id)
+    )
+  ).map((connection) =>
+    DataConnectionObjectSchema.omit({ authentication: true }).parse(connection)
   );
 
   return (

--- a/src/lib/data-connections.test.ts
+++ b/src/lib/data-connections.test.ts
@@ -137,7 +137,9 @@ describe("listUsableDataConnections (issue #461)", () => {
   test("offers an org's own connection to an org owner", async () => {
     listing([orgConnection]);
     expect(
-      ids(await listUsableDataConnections(sessions["organization-owner-user"]))
+      ids(await listUsableDataConnections(sessions["organization-owner-user"], [
+        "organization",
+      ]))
     ).toEqual(["organization--byob"]);
   });
 
@@ -150,15 +152,36 @@ describe("listUsableDataConnections (issue #461)", () => {
 
     listing([orgConnection]);
     expect(
-      ids(await listUsableDataConnections(sessions["organization-owner-user"]))
+      ids(await listUsableDataConnections(sessions["organization-owner-user"], [
+        "organization",
+      ]))
     ).toEqual(["organization--byob"]);
   });
 
   test("keeps a read-only connection out of the list", async () => {
     listing([{ ...orgConnection, read_only: true } as DataConnection]);
     expect(
-      ids(await listUsableDataConnections(sessions["organization-owner-user"]))
+      ids(await listUsableDataConnections(sessions["organization-owner-user"], [
+        "organization",
+      ]))
     ).toEqual([]);
+  });
+
+  // The owner filter has to happen here, not in ProductCreationForm: an owned
+  // connection carries its account's bucket name and prefixes, so a client-side
+  // filter would still have shipped them to every user's browser.
+  test("withholds another account's connection from the listing", async () => {
+    listing([orgConnection]);
+    expect(
+      ids(await listUsableDataConnections(sessions["regular-user"], ["regular"]))
+    ).toEqual([]);
+  });
+
+  test("still offers system-level connections to any account", async () => {
+    listing([{ ...orgConnection, owner: undefined } as DataConnection]);
+    expect(
+      ids(await listUsableDataConnections(sessions["regular-user"], ["regular"]))
+    ).toEqual(["organization--byob"]);
   });
 });
 
@@ -205,3 +228,4 @@ describe("canUseDataConnectionFor", () => {
     ).toBe(false);
   });
 });
+

--- a/src/lib/data-connections.ts
+++ b/src/lib/data-connections.ts
@@ -63,20 +63,31 @@ export function canUseDataConnectionFor(
 }
 
 /**
- * List the data connections a user is permitted to use when creating a product.
+ * List the data connections a user is permitted to use when creating a product
+ * under one of `ownerAccountIds` (the accounts they may create products for).
  *
- * A connection is usable when the session is authorized both to read it
- * (`GetDataConnection`) and to create products against it (`UseDataConnection`).
+ * A connection is usable when it is available to one of those accounts —
+ * system-level (unowned) or owned by it — and the session is authorized both to
+ * read it (`GetDataConnection`) and to create products against it
+ * (`UseDataConnection`).
+ *
+ * The owner filter belongs here rather than at the call site: an owned
+ * connection carries its account's bucket names and prefixes, so filtering it
+ * out in the browser would still have shipped it there.
+ *
  * The returned objects are unsanitized (credentials intact); callers that hand
  * these to the client must strip `authentication` first.
  */
 export async function listUsableDataConnections(
-  session: UserSession | null
+  session: UserSession | null,
+  ownerAccountIds: string[]
 ): Promise<DataConnection[]> {
+  const usableBy = new Set(ownerAccountIds);
   const dataConnections = await dataConnectionsTable.listAll();
 
   return dataConnections.filter(
     (dataConnection) =>
+      (!dataConnection.owner || usableBy.has(dataConnection.owner)) &&
       isAuthorized(session, dataConnection, Actions.UseDataConnection) &&
       isAuthorized(session, dataConnection, Actions.GetDataConnection)
   );


### PR DESCRIPTION
Found while investigating why a BYOB connection wasn't appearing on `/products/new`. Not the cause of that — a separate leak on the same path, which #462 did not touch.

## The problem

`listUsableDataConnections` filters only on `UseDataConnection` and `GetDataConnection`. Neither looks at `owner` — `getDataConnection` returns `true` for any non-disabled principal, and `useDataConnection` checks `read_only` and `required_flag` and nothing else.

So `/products/new` serialized **every** account-owned connection in the table into the page for any logged-in user: bucket names, regions, base prefixes and prefix templates. `authentication` is stripped, but the rest is not.

`ProductCreationForm` does filter on `!dc.owner || dc.owner === forAccountId` (`ProductCreationForm.tsx:90-92`) — in the browser. It only ever hid them from view.

Demonstrated before fixing: a plain `regular-user` session received `rival--secret` with `bucket: "rival-private-bucket-name"`.

## The fix

`listUsableDataConnections(session, ownerAccountIds)` applies the owner rule server-side. The page passes `potentialOwnerAccounts`, which it already computes for the owner dropdown, so the set is exactly the accounts the user may create products under.

The filter goes in the helper rather than at the call site so a second caller can't reintroduce the leak — the required parameter makes it unskippable.

No behaviour change for legitimate use: system-level (unowned) connections are still offered to everyone, and an account's own connections are still offered to its members.

## Scope: this does not close the exposure

`GET /api/v1/data-connections` returns **every** connection to **any** caller, including anonymous ones — `getDataConnection` is `principal?.account?.disabled ? false : true`, and for a null principal that expression is falsy, so it returns `true`. `sanitizeDataConnection` strips only *secret-bearing* auth; `details` (bucket, region, base prefix) and federated role ARNs are returned deliberately, per that helper's doc comment.

So account-owned bucket names remain publicly listable through the API regardless of this PR. This change is still worth making — a page shouldn't ship data its own UI then hides — but it should not be read as closing the hole.

Whether the v1 listing should scope account-owned connections to their owners is a policy question worth deciding separately. The ARN exposure looks intentional (the customer's IAM trust policy is the security boundary); the account-owned bucket names look like a consequence of that decision rather than an intended part of it.

## Tests

`npx jest`: 482 passing. The 5 failures (`DropdownSection.integration`, 4 analytics card tests) reproduce identically on clean `origin/main` — verified by running those suites detached at `origin/main`. `tsc` reports no new errors; the pre-existing `AdminBreakdownChart` implicit-any errors are also on `main`.

Two new tests in `data-connections.test.ts`, over the real `isAuthorized`:
- another account's connection is withheld from the listing entirely
- system-level connections are still offered to any account

🤖 Generated with [Claude Code](https://claude.com/claude-code)