### PR TITLE
refactor(data-connections): single definition of the product/connection rule

### DIFF
--- a/src/lib/actions/products.test.ts
+++ b/src/lib/actions/products.test.ts
@@ -184,6 +184,10 @@ describe("createProduct", () => {
     const result = await createProduct(undefined, buildFormData());
 
     expect(result.success).toBe(false);
+    expect(result.message).toBe(
+      "You are not permitted to use the selected data connection"
+    );
+    expect(result.fieldErrors).toEqual({});
     expect(productsTable.create).not.toHaveBeenCalled();
   });
 
@@ -210,7 +214,10 @@ describe("createProduct", () => {
     );
 
     expect(result.success).toBe(false);
-    expect(result.fieldErrors.data_connection_id).toBeDefined();
+    expect(result.message).toBe("Invalid data connection for this account");
+    expect(result.fieldErrors.data_connection_id).toEqual([
+      "Selected data connection is not available for this account",
+    ]);
     expect(productsTable.create).not.toHaveBeenCalled();
   });
 

--- a/src/lib/actions/products.ts
+++ b/src/lib/actions/products.ts
@@ -12,6 +12,7 @@ import {
 import { getPageSession, LOGGER } from "@/lib";
 import { FormState } from "@/components/core/DynamicForm";
 import { isAuthorized, isAdmin } from "../api/authz";
+import { denyDataConnectionFor } from "@/lib/data-connections";
 import { revalidatePath } from "next/cache";
 import { productUrl, editProductDetailsUrl, accountUrl } from "@/lib/urls";
 import { getProxyCredentials } from "@/lib/actions/proxy-credentials";
@@ -171,33 +172,33 @@ export async function createProduct(
     };
   }
 
-  // Enforce that the user may create products against this connection. This
-  // covers read-only connections and connections gated behind an account flag.
-  if (!isAuthorized(session, dataConnection, Actions.UseDataConnection)) {
-    return {
-      fieldErrors: {},
-      data: formData,
-      message: "You are not permitted to use the selected data connection",
-      success: false,
-    };
-  }
-
-  // Enforce that the connection is available for the product's account. An
-  // owned connection may only be used by the account that owns it.
-  if (
-    dataConnection.owner &&
-    dataConnection.owner !== validatedFields.data.account_id
+  // Enforce that this connection may back a product under this account, and
+  // report each denial reason as its own field error.
+  switch (
+    denyDataConnectionFor(
+      session,
+      dataConnection,
+      validatedFields.data.account_id
+    )
   ) {
-    return {
-      fieldErrors: {
-        data_connection_id: [
-          "Selected data connection is not available for this account",
-        ],
-      },
-      data: formData,
-      message: "Invalid data connection for this account",
-      success: false,
-    };
+    case "not-usable":
+      return {
+        fieldErrors: {},
+        data: formData,
+        message: "You are not permitted to use the selected data connection",
+        success: false,
+      };
+    case "wrong-account":
+      return {
+        fieldErrors: {
+          data_connection_id: [
+            "Selected data connection is not available for this account",
+          ],
+        },
+        data: formData,
+        message: "Invalid data connection for this account",
+        success: false,
+      };
   }
 
   // Enforce the connection's allowed visibilities. Even though the form only

--- a/src/lib/data-connections.test.ts
+++ b/src/lib/data-connections.test.ts
@@ -1,6 +1,7 @@
 import {
   canManageDataConnection,
   canUseDataConnectionFor,
+  denyDataConnectionFor,
   listUsableDataConnections,
 } from "./data-connections";
 import { isAdmin, canManageAccountDataConnections } from "@/lib/api/authz";
@@ -159,6 +160,61 @@ describe("listUsableDataConnections (issue #461)", () => {
     expect(
       ids(await listUsableDataConnections(sessions["organization-owner-user"]))
     ).toEqual([]);
+  });
+});
+
+// The single definition of which connections may back a product owned by a
+// given account, and why not when they may not. `createProduct` switches on the
+// reason to pick a field error. Uses the real `isAuthorized`.
+describe("denyDataConnectionFor", () => {
+  const user = sessions["regular-user"];
+
+  test("allows a system-level (unowned) connection", () => {
+    expect(
+      denyDataConnectionFor(user, connection({ owner: undefined }), "acme")
+    ).toBeNull();
+  });
+
+  test("allows a connection the account owns", () => {
+    expect(
+      denyDataConnectionFor(user, connection({ owner: "acme" }), "acme")
+    ).toBeNull();
+  });
+
+  test("reports wrong-account for a connection another account owns", () => {
+    expect(
+      denyDataConnectionFor(user, connection({ owner: "rival" }), "acme")
+    ).toBe("wrong-account");
+  });
+
+  test("reports not-usable for a read-only connection", () => {
+    expect(
+      denyDataConnectionFor(
+        user,
+        connection({ owner: "acme", read_only: true }),
+        "acme"
+      )
+    ).toBe("not-usable");
+  });
+
+  test("reports not-usable for a flag-gated connection the caller lacks the flag for", () => {
+    expect(
+      denyDataConnectionFor(
+        user,
+        connection({ required_flag: AccountFlags.CREATE_DATA_CONNECTIONS }),
+        "acme"
+      )
+    ).toBe("not-usable");
+  });
+
+  test("reports not-usable ahead of wrong-account when both apply", () => {
+    expect(
+      denyDataConnectionFor(
+        user,
+        connection({ owner: "rival", read_only: true }),
+        "acme"
+      )
+    ).toBe("not-usable");
   });
 });
 

--- a/src/lib/data-connections.ts
+++ b/src/lib/data-connections.ts
@@ -39,27 +39,44 @@ export async function canManageDataConnection(
   return canManageAccountDataConnections(session, ownerAccount);
 }
 
+export type DataConnectionDenial = "not-usable" | "wrong-account";
+
 /**
- * Whether `connection` may back a product owned by `accountId`: the connection
- * itself must permit the caller (`UseDataConnection` covers read-only and
- * flag-gated connections) and must be available to that account — either
- * system-level (unowned) or owned by it.
+ * Why `connection` may not back a product owned by `accountId`, or null if it
+ * may. Two rules: the connection itself must permit the caller
+ * (`not-usable` — `UseDataConnection` covers read-only and flag-gated
+ * connections), and it must be available to that account — either system-level
+ * (unowned) or owned by it (`wrong-account`).
+ *
+ * The reason is returned rather than a bare boolean so `createProduct` can
+ * surface each rule as its own form field error; callers that only need a
+ * yes/no use `canUseDataConnectionFor`.
  *
  * This is only the connection half of associating the two; the caller side is
  * each call site's own gate — `canManageAccount` on the owning account for the
- * mirror actions, `Actions.CreateRepository` for `createProduct` (which applies
- * the same two connection rules inline, to report them as distinct field
- * errors).
+ * mirror actions, `Actions.CreateRepository` for `createProduct`.
  */
+export function denyDataConnectionFor(
+  session: UserSession | null,
+  connection: DataConnection,
+  accountId: string
+): DataConnectionDenial | null {
+  if (!isAuthorized(session, connection, Actions.UseDataConnection)) {
+    return "not-usable";
+  }
+  if (connection.owner && connection.owner !== accountId) {
+    return "wrong-account";
+  }
+  return null;
+}
+
+/** Boolean form of {@link denyDataConnectionFor}. */
 export function canUseDataConnectionFor(
   session: UserSession | null,
   connection: DataConnection,
   accountId: string
 ): boolean {
-  return (
-    isAuthorized(session, connection, Actions.UseDataConnection) &&
-    (!connection.owner || connection.owner === accountId)
-  );
+  return denyDataConnectionFor(session, connection, accountId) === null;
 }
 
 /**


### PR DESCRIPTION
## What was duplicated

`createProduct` (`src/lib/actions/products.ts`) reimplemented inline the same two
rules that `canUseDataConnectionFor` (`src/lib/data-connections.ts`) already
encoded, as two separate `if` blocks:

1. the connection must permit the caller — `isAuthorized(session, connection, Actions.UseDataConnection)`, which is what covers read-only connections and connections gated behind an account flag;
2. the connection must be available to the product's account — either system-level (unowned) or owned by that account.

Two copies of the same security rule that have to be kept in sync by hand.

## Why the duplication existed

`canUseDataConnectionFor` returns a bare boolean, and `createProduct` needs to
report the two rules as *distinct* form errors — rule 1 as a form-level message
with empty `fieldErrors`, rule 2 as a `data_connection_id` field error. A boolean
can't carry which rule failed, so the call site open-coded both.

## The change

- New `denyDataConnectionFor(session, connection, accountId): DataConnectionDenial | null` in `src/lib/data-connections.ts`, returning `"not-usable"`, `"wrong-account"`, or `null`. It is now the single definition of the rule.
- `canUseDataConnectionFor` is kept exported (other callers: `src/lib/actions/product-mirrors.ts`, `src/app/(app)/edit/product/[account_id]/[product_id]/data-connections/page.tsx`) and becomes the boolean wrapper: `denyDataConnectionFor(...) === null`. Its doc comment moved to the new function and the now-stale sentence about `createProduct` applying the rules inline was dropped.
- `createProduct` calls `denyDataConnectionFor` once and `switch`es on the reason.

**Messages preserved verbatim.** Both strings and the `fieldErrors` shape are
byte-identical to before:

- `"not-usable"` → `message: "You are not permitted to use the selected data connection"`, `fieldErrors: {}`
- `"wrong-account"` → `message: "Invalid data connection for this account"`, `fieldErrors.data_connection_id: ["Selected data connection is not available for this account"]`

Evaluation order is also unchanged: `"not-usable"` is checked and reported ahead
of `"wrong-account"`. The `allowed_visibilities` check that follows is a
different, non-duplicated rule and was not touched.

## Tests

- New `denyDataConnectionFor` describe block in `src/lib/data-connections.test.ts` (same style as the file, real `isAuthorized` via `jest.requireActual`): unowned → `null`, owned by the account → `null`, owned by another account → `"wrong-account"`, read-only → `"not-usable"`, flag-gated the caller lacks → `"not-usable"`, plus one asserting `"not-usable"` wins when both rules fail. The existing `canUseDataConnectionFor` tests are unchanged and still pass.
- `src/lib/actions/products.test.ts` already had a test per denial path but asserted only `success: false` / `fieldErrors.data_connection_id` being *defined*. Both now assert the exact `message` and the exact `fieldErrors` contents, so the strings are pinned against future drift.

## Verification

- `npx tsc --noEmit -p tsconfig.typecheck.json` — 14 errors, identical before and after this change (all pre-existing, in `src/components/features/analytics/AdminBreakdownChart.tsx` and `panels.tsx`). No new errors.
- `npx jest --forceExit` — **5 failed, 486 passed, 491 total; 3 failed suites, 53 passed, 56 total.** That matches the `origin/main` baseline exactly: `DropdownSection.integration.test.tsx` plus 4 analytics card tests, all pre-existing and unrelated (jsdom/recharts). No new failures. The touched suites (`data-connections.test.ts`, `actions/products.test.ts`, `actions/product-mirrors.test.ts`) are 71/71 passing.
- `npm run lint` — exit 0. Diffed against baseline: output is identical apart from four line numbers shifting by 1 in `products.ts` from the added import. No new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
