### PR TITLE
fix(data-connections): stop blocking non-admins from read-only connections

### DIFF
--- a/src/components/features/products/ProductCreationForm.tsx
+++ b/src/components/features/products/ProductCreationForm.tsx
@@ -37,12 +37,17 @@ function regionOf(connection: DataConnection): string | undefined {
 
 // A new product defaults to a us-west-2 connection when one is available — the
 // region we steer unsure users toward — and otherwise to the first option.
+// Read-only connections are never defaulted to: they can back a product, but it
+// would have no upload controls, which is not a choice to make on the user's
+// behalf.
 const DEFAULT_REGION = "us-west-2";
 function pickDefaultConnection(
   connections: DataConnection[]
 ): DataConnection | undefined {
+  const writable = connections.filter((c) => !c.read_only);
+  const preferred = writable.length ? writable : connections;
   return (
-    connections.find((c) => regionOf(c) === DEFAULT_REGION) ?? connections[0]
+    preferred.find((c) => regionOf(c) === DEFAULT_REGION) ?? preferred[0]
   );
 }
 

--- a/src/lib/actions/product-mirrors.ts
+++ b/src/lib/actions/product-mirrors.ts
@@ -107,7 +107,7 @@ export async function addProductMirror(
     }
 
     // The connection must be available to this account: system-level (unowned)
-    // or owned by it, and usable at all (not read-only / flag-gated).
+    // or owned by it, and usable at all (not flag-gated).
     if (!canUseDataConnectionFor(session, connection, accountId)) {
       return {
         fieldErrors: {},

--- a/src/lib/actions/products.ts
+++ b/src/lib/actions/products.ts
@@ -171,8 +171,8 @@ export async function createProduct(
     };
   }
 
-  // Enforce that the user may create products against this connection. This
-  // covers read-only connections and connections gated behind an account flag.
+  // Enforce that the user may create products against this connection
+  // (connections gated behind an account flag).
   if (!isAuthorized(session, dataConnection, Actions.UseDataConnection)) {
     return {
       fieldErrors: {},

--- a/src/lib/api/authz.test.ts
+++ b/src/lib/api/authz.test.ts
@@ -3311,14 +3311,16 @@ describe("Authorization Tests", () => {
       true
     );
 
-    // Test with read_only set to true
+    // read_only does not gate use: it means the platform holds read-only
+    // credentials, so the product is a catalog entry over externally managed
+    // data. What a product exposes is set by its mirror prefix, not this flag.
     dataConnection.read_only = true;
     expect(isAuthorized(sessions["admin"], dataConnection, action)).toBe(true);
     expect(
       isAuthorized(sessions["organization-owner-user"], dataConnection, action)
-    ).toBe(false);
+    ).toBe(true);
     expect(isAuthorized(sessions["regular-user"], dataConnection, action)).toBe(
-      false
+      true
     );
 
     // Test with required_flag

--- a/src/lib/api/authz.test.ts
+++ b/src/lib/api/authz.test.ts
@@ -3311,9 +3311,7 @@ describe("Authorization Tests", () => {
       true
     );
 
-    // read_only does not gate use: it means the platform holds read-only
-    // credentials, so the product is a catalog entry over externally managed
-    // data. What a product exposes is set by its mirror prefix, not this flag.
+    // read_only does not gate use; see #482.
     dataConnection.read_only = true;
     expect(isAuthorized(sessions["admin"], dataConnection, action)).toBe(true);
     expect(

--- a/src/lib/api/authz.ts
+++ b/src/lib/api/authz.ts
@@ -452,10 +452,18 @@ function disableDataConnection(
 }
 
 // Models what the *connection* permits, not whether the caller is
-// authenticated. A connection that is not read-only and carries no
-// required_flag is usable by anyone — including an anonymous principal — so
-// callers (e.g. createProduct, listUsableDataConnections) must apply their own
-// auth guard before relying on this result.
+// authenticated. A connection carrying no required_flag is usable by anyone —
+// including an anonymous principal — so callers (e.g. createProduct,
+// listUsableDataConnections) must apply their own auth guard before relying on
+// this result.
+//
+// `read_only` is deliberately not a gate here. It says the platform holds
+// read-only credentials, so a product on such a connection is a catalog entry
+// over externally managed data — the layout hides the upload controls and
+// deleteProduct never touches the objects. What a product exposes is decided by
+// its mirror prefix, not by this flag: a connection with no prefix_template
+// mirrors at the bucket root (resolveMirrorPrefix) whether or not it is
+// read-only, so refusing read-only connections here prevented nothing.
 function useDataConnection(
   principal: UserSession | null,
   dataConnection: DataConnection
@@ -466,10 +474,6 @@ function useDataConnection(
 
   if (isAdmin(principal)) {
     return true;
-  }
-
-  if (dataConnection.read_only) {
-    return false;
   }
 
   if (dataConnection.required_flag) {

--- a/src/lib/api/authz.ts
+++ b/src/lib/api/authz.ts
@@ -456,14 +456,6 @@ function disableDataConnection(
 // including an anonymous principal — so callers (e.g. createProduct,
 // listUsableDataConnections) must apply their own auth guard before relying on
 // this result.
-//
-// `read_only` is deliberately not a gate here. It says the platform holds
-// read-only credentials, so a product on such a connection is a catalog entry
-// over externally managed data — the layout hides the upload controls and
-// deleteProduct never touches the objects. What a product exposes is decided by
-// its mirror prefix, not by this flag: a connection with no prefix_template
-// mirrors at the bucket root (resolveMirrorPrefix) whether or not it is
-// read-only, so refusing read-only connections here prevented nothing.
 function useDataConnection(
   principal: UserSession | null,
   dataConnection: DataConnection

--- a/src/lib/data-connections.test.ts
+++ b/src/lib/data-connections.test.ts
@@ -154,9 +154,6 @@ describe("listUsableDataConnections (issue #461)", () => {
     ).toEqual(["organization--byob"]);
   });
 
-  // read_only means the platform can't write to the storage, not that the
-  // connection is off-limits — the resulting product is a catalog entry over
-  // data managed outside Source Cooperative.
   test("offers a read-only connection", async () => {
     listing([{ ...orgConnection, read_only: true } as DataConnection]);
     expect(

--- a/src/lib/data-connections.test.ts
+++ b/src/lib/data-connections.test.ts
@@ -154,11 +154,14 @@ describe("listUsableDataConnections (issue #461)", () => {
     ).toEqual(["organization--byob"]);
   });
 
-  test("keeps a read-only connection out of the list", async () => {
+  // read_only means the platform can't write to the storage, not that the
+  // connection is off-limits — the resulting product is a catalog entry over
+  // data managed outside Source Cooperative.
+  test("offers a read-only connection", async () => {
     listing([{ ...orgConnection, read_only: true } as DataConnection]);
     expect(
       ids(await listUsableDataConnections(sessions["organization-owner-user"]))
-    ).toEqual([]);
+    ).toEqual(["organization--byob"]);
   });
 });
 
@@ -185,14 +188,24 @@ describe("canUseDataConnectionFor", () => {
     ).toBe(false);
   });
 
-  test("rejects a read-only connection even when the account owns it", () => {
+  test("accepts a read-only connection the account owns", () => {
     expect(
       canUseDataConnectionFor(
         user,
         connection({ owner: "acme", read_only: true }),
         "acme"
       )
-    ).toBe(false);
+    ).toBe(true);
+  });
+
+  test("accepts a read-only system-level connection", () => {
+    expect(
+      canUseDataConnectionFor(
+        user,
+        connection({ owner: undefined, read_only: true }),
+        "acme"
+      )
+    ).toBe(true);
   });
 
   test("rejects a flag-gated system connection the caller lacks the flag for", () => {

--- a/src/lib/data-connections.ts
+++ b/src/lib/data-connections.ts
@@ -41,8 +41,8 @@ export async function canManageDataConnection(
 
 /**
  * Whether `connection` may back a product owned by `accountId`: the connection
- * itself must permit the caller (`UseDataConnection` covers read-only and
- * flag-gated connections) and must be available to that account — either
+ * itself must permit the caller (`UseDataConnection` covers flag-gated
+ * connections) and must be available to that account — either
  * system-level (unowned) or owned by it.
  *
  * This is only the connection half of associating the two; the caller side is


### PR DESCRIPTION
Follow-on from #461/#462. A user could not select a read-only data connection when creating a product — including a BYOB connection they own — because `useDataConnection` (`authz.ts`) refused any read-only connection to a non-admin.

## Why this gate was wrong

`read_only` records that Source Cooperative holds read-only credentials to the storage. The rest of the app already treats that correctly: the product layout sets `canWriteData` false and hides the data-editing controls (`layout.tsx:53-56`), and `deleteProduct` never deletes the objects — "read-only connections mirror data we don't own" (`products.ts:475-479`). A product on such a connection is a catalog entry over externally managed data, which is a legitimate thing to want, especially for BYOB.

The gate looked like it was protecting against a user pointing a product at data that isn't theirs. It wasn't. What a product exposes is decided by its **mirror prefix**, not by this flag: `resolveMirrorPrefix` returns `""` when a connection has no `prefix_template` (`data-connection.ts:378-386`), so the product mirrors the bucket root — and that is equally true of a *writable* system connection. On a shared writable connection it is worse, since that bucket holds other accounts' product data. Refusing read-only connections prevented nothing that remained possible without the flag.

If we want a guard there, it belongs on the prefix (require a scoping `prefix_template` on unowned connections, or refuse a root prefix for a connection the account doesn't own) and it should apply regardless of `read_only`. That is not this PR.

## Change

Drop the `read_only` branch from `useDataConnection`. `required_flag` still gates flag-restricted connections, the owner rule still confines an owned connection to its own account's products (`canUseDataConnectionFor`), and admins are unaffected.

The product creation picker already labels these "· Read Only" (`ProductCreationForm.tsx:56`), so the choice stays visible to the user. No user-facing copy claimed read-only connections were unusable.

## Tests

`npx jest`: 481 passing. The 5 failures (`DropdownSection.integration`, 4 analytics card tests) reproduce identically on clean `origin/main`. `tsc --noEmit`: 14 errors on this branch and 14 on clean `main` — verified by comparing both — all pre-existing in `AdminBreakdownChart.tsx` and `panels.tsx`. `npm run lint` clean.

Three existing tests encoded the old policy and now assert the new one:
- `authz.test.ts` — a read-only connection is usable by non-admin sessions
- `data-connections.test.ts` — `listUsableDataConnections` offers a read-only connection
- `data-connections.test.ts` — `canUseDataConnectionFor` accepts a read-only connection the account owns, plus a new case for a read-only system-level one

🤖 Generated with [Claude Code](https://claude.com/claude-code)