### PR TITLE
ci: keep the Vercel deploy token out of the CLI install's environment

### DIFF
--- a/.github/workflows/prod-deploy.yaml
+++ b/.github/workflows/prod-deploy.yaml
@@ -39,15 +39,17 @@ jobs:
     environment:
       name: Production
       url: https://source.coop
-    env:
-      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     steps:
       - uses: actions/checkout@v4.2.2
       - uses: actions/setup-node@v4.4.0
         with:
           node-version: 22
-      - run: npm install -g vercel
+      # Installed before the credentials exist: a postinstall in the vercel
+      # package tree must not run with the deploy token in the environment.
+      - run: npm install -g vercel@59
       - name: Deploy to Vercel
-        run: vercel deploy --prod --token=$VERCEL_TOKEN
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: vercel deploy --prod --token="$VERCEL_TOKEN"

--- a/.github/workflows/staging-deploy.yaml
+++ b/.github/workflows/staging-deploy.yaml
@@ -40,15 +40,17 @@ jobs:
     environment:
       name: Staging
       url: https://staging.source.coop
-    env:
-      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     steps:
       - uses: actions/checkout@v4.2.2
       - uses: actions/setup-node@v4.4.0
         with:
           node-version: 22
-      - run: npm install -g vercel
+      # Installed before the credentials exist: a postinstall in the vercel
+      # package tree must not run with the deploy token in the environment.
+      - run: npm install -g vercel@59
       - name: Deploy to Vercel
-        run: vercel deploy --target=staging --token=$VERCEL_TOKEN
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: vercel deploy --target=staging --token="$VERCEL_TOKEN"


### PR DESCRIPTION
`deploy-vercel` declared `VERCEL_TOKEN`, `VERCEL_ORG_ID` and `VERCEL_PROJECT_ID` in a **job-level** `env:` block, so they were in the environment of every step in that job — including `npm install -g vercel`. A postinstall script anywhere in that package tree ran with a **production deploy token** available to it: enough to deploy, roll back, or delete `source.coop`. Same shape in staging, which fires on every push to `main`.

Credentials now sit on the deploy step only. The install runs before they exist.

### Also pinned the CLI

`npm install -g vercel` was unpinned, so each run installed whatever was latest. Now `vercel@59` — the current major (59.1.4 at time of writing), so no behaviour change today, but an unattended major bump can no longer alter what executes in this job.

### Not changed

`deploy-cdk` in both files is already clean: it uses AWS OIDC via `role-to-assume` and holds no long-lived credential. Worth noting the asymmetry — the AWS half of these workflows never had this problem, and Vercel offers no OIDC equivalent for deploys, so a static token is unavoidable there.

### Verification

I wrote a checker that parses the workflow and asserts no secret sits in a workflow- or job-level `env:`, and that no credentialed step also installs or builds. Against these two files **before** the change:

```
FAIL prod-deploy.yaml
       JOB-level secret VERCEL_TOKEN in 'deploy-vercel' alongside 1 install/build step(s): ['npm install -g vercel']
FAIL staging-deploy.yaml
       JOB-level secret VERCEL_TOKEN in 'deploy-vercel' alongside 1 install/build step(s): ['npm install -g vercel']
```

and after:

```
ok   prod-deploy.yaml
ok   staging-deploy.yaml
```

**Real verification is the staging deploy**, which runs automatically on merge to `main`. Confirm https://staging.source.coop serves the new deployment and the run is green before cutting a release that exercises the prod path. `workflow_dispatch` is available on both if you want a dry run first.

### Follow-up, not in this PR

This repo's `Production`, `Production-Infra`, `Staging`, `Staging-Infra` and `Preview` environments all have **zero protection rules**, so the environment names are organisational labels rather than controls. Adding required reviewers to `Production` would mean the prod token is not reachable by anything that can merely run a workflow here. Separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)