### PR TITLE
fix(products): validate product_id as a lowercase slug

### DIFF
--- a/src/lib/actions/products.test.ts
+++ b/src/lib/actions/products.test.ts
@@ -151,6 +151,47 @@ describe("createProduct", () => {
     expect(productsTable.create).not.toHaveBeenCalled();
   });
 
+  // The product form blocks non-slug ids client-side, but a server action is
+  // just an HTTP endpoint — these cover a caller posting to it directly.
+  test("lowercases a capitalized product ID", async () => {
+    (dataConnectionsTable.fetchById as jest.Mock).mockResolvedValue(
+      connection({
+        prefix_template:
+          "{{repository.account_id}}/{{repository.repository_id}}/",
+      })
+    );
+
+    const result = await createProduct(
+      undefined,
+      buildFormData({ product_id: "MyProduct" })
+    );
+
+    expect(result.success).toBe(true);
+    const created = (productsTable.create as jest.Mock).mock.calls[0][0];
+    expect(created.product_id).toBe("myproduct");
+    // The mirror prefix is derived from the same normalized id.
+    expect(created.metadata.mirrors["conn-x"].prefix).toBe("alice/myproduct/");
+  });
+
+  test.each([
+    ["a space", "my product"],
+    ["an underscore", "my_product"],
+    ["a slash", "my/product"],
+    ["a leading hyphen", "-my-product"],
+    ["consecutive hyphens", "my--product"],
+    ["too few characters", "ab"],
+    ["too many characters", "a".repeat(41)],
+  ])("rejects a product ID with %s", async (_label, productId) => {
+    const result = await createProduct(
+      undefined,
+      buildFormData({ product_id: productId })
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.fieldErrors.product_id).toBeDefined();
+    expect(productsTable.create).not.toHaveBeenCalled();
+  });
+
   test("rejects unauthorized creation before any data connection lookup", async () => {
     (isAuthorized as jest.Mock).mockImplementation(
       (_session, _resource, action) => action !== Actions.CreateRepository

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -1,6 +1,7 @@
 import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
 import { z } from "zod";
 import { AccountSchema } from "@/types/account";
+import { ID_REGEX, MAX_ID_LENGTH, MIN_ID_LENGTH } from "@/types/shared";
 
 extendZodWithOpenApi(z);
 
@@ -23,6 +24,17 @@ export type ProductMirror = z.infer<typeof ProductMirrorSchema>;
 // when rendering links and schema.org identifiers. Pattern from Crossref:
 // https://www.crossref.org/blog/dois-and-matching-regular-expressions/
 const DOI_REGEX = /^10\.\d{4,9}\/[-._;()/:A-Za-z0-9]+$/;
+
+export const ProductIdSchema = z
+  .string()
+  .min(MIN_ID_LENGTH, `Product ID must be at least ${MIN_ID_LENGTH} characters`)
+  .max(MAX_ID_LENGTH, `Product ID must not exceed ${MAX_ID_LENGTH} characters`)
+  .toLowerCase()
+  .regex(
+    ID_REGEX,
+    "Product ID may only contain lowercase letters, numbers and hyphens, and may not begin or end with a hyphen OR contain consecutive hyphens"
+  )
+  .openapi({ example: "product-id" });
 
 export const DoiSchema = z
   .string()
@@ -53,7 +65,12 @@ export const ProductVisibilitySchema = z.nativeEnum(ProductVisibility).openapi("
 // Product is the main product entity, including metadata and optional account
 export const ProductSchema = z
   .object({
-    product_id: z.string(), // Partition Key
+    // Partition Key. Same slug rules as account_id (see BaseAccountSchema), so
+    // `${account_id}/${product_id}` stays a stable, case-insensitive URL path:
+    // DynamoDB keys are case-sensitive, so an uppercase id would only ever be
+    // reachable at its exact spelling. The product form's client-side check
+    // (useProductIdValidation) is UX only — this is the enforcing one.
+    product_id: ProductIdSchema,
     account_id: z.string(), // Sort Key
     title: z.string(),
     description: z.string(),


### PR DESCRIPTION
`product_id` was the only ID in the codebase declared as a bare `z.string()` (`src/types/product.ts:56`). Every other one — account, membership, API key, data connection — runs through `MIN/MAX_ID_LENGTH` + `.toLowerCase()` + `ID_REGEX` from `src/types/shared.ts`. Products alone accepted capitals, spaces, underscores, slashes, and any length.

The product form's client-side check (`useProductIdValidation`) disables the submit button for non-slug IDs, but `createProduct` is a server action — an HTTP endpoint a caller can post to directly — and validated only with `ProductCreationRequestSchema`. The v1 API `POST /products/{account_id}` route is stubbed `501`, so the server action was the whole surface. DynamoDB keys are case-sensitive, so `alice/MyProduct` was only ever reachable at that exact spelling.

## Change

`product_id` now uses the same rules as `account_id`, via a new `ProductIdSchema`. It flows through `ProductCreationRequestSchema` into the create path, and the mirror prefix is derived from the normalized value.

## Tests

Eight new cases in `src/lib/actions/products.test.ts`, exercising the server action rather than the schema, since the action is the boundary that was bypassable. All eight fail on `main` and pass here:

- `MyProduct` → stored as `myproduct`, mirror prefix `alice/myproduct/`
- rejects space, underscore, slash, leading hyphen, consecutive hyphens, <3 chars, >40 chars

## Existing data

Legacy rows with non-conforming IDs are unaffected: reads cast to `Product` rather than parse, and `updateProduct` reads `product_id` from the form without a schema, so such products stay editable and viewable. Worth a table scan to confirm none exist before assuming the invariant holds going forward.

## Verification

`npx jest src/lib/actions/products.test.ts` — 31 passed. Full suite: 489 passed, 5 pre-existing failures in the analytics/recharts and DropdownSection suites (identical with this change stashed). `tsc --noEmit` reports no errors in the changed files (pre-existing errors elsewhere in analytics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
