### PR TITLE
fix(products): enforce lowercase-only product IDs

### DIFF
--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -1,6 +1,7 @@
 import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
 import { z } from "zod";
 import { AccountSchema } from "@/types/account";
+import { MIN_ID_LENGTH, MAX_ID_LENGTH, ID_REGEX } from "@/types/shared";
 
 extendZodWithOpenApi(z);
 
@@ -53,7 +54,15 @@ export const ProductVisibilitySchema = z.nativeEnum(ProductVisibility).openapi("
 // Product is the main product entity, including metadata and optional account
 export const ProductSchema = z
   .object({
-    product_id: z.string(), // Partition Key
+    product_id: z
+      .string()
+      .min(MIN_ID_LENGTH, `Product ID must be at least ${MIN_ID_LENGTH} characters`)
+      .max(MAX_ID_LENGTH, `Product ID must not exceed ${MAX_ID_LENGTH} characters`)
+      .toLowerCase()
+      .regex(
+        ID_REGEX,
+        "Product ID may not begin or end with a hyphen OR contain consecutive hyphens"
+      ), // Partition Key
     account_id: z.string(), // Sort Key
     title: z.string(),
     description: z.string(),


### PR DESCRIPTION
## What I'm changing

Ensures product IDs cannot be created with uppercase characters by applying the shared `ID_REGEX` validation to the `product_id` field in `ProductSchema`.

## How I did it

Imported `MIN_ID_LENGTH`, `MAX_ID_LENGTH`, and `ID_REGEX` from `@/types/shared` into `product.ts` and applied the same Zod validation chain used by `account_id` in the account schema: length bounds, `.toLowerCase()` coercion, and the regex constraint. `ProductCreationRequestSchema` inherits this automatically via `.omit()`.

## How you can test it

Attempt to create a product via the API with an uppercase `product_id` (e.g. `"MyProduct"`). The request should be rejected (or the ID lowercased) rather than stored with uppercase characters.