### PR TITLE
feat(api): allow cross-origin reads of account and product routes

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -25,10 +25,33 @@ const nextConfig = {
   transpilePackages: ["jose"],
   serverExternalPackages: ["@duckdb/node-api"],
   async headers() {
+    // Read-only API routes other Source Cooperative sites call from the
+    // browser (e.g. the docs policy wizards checking that an account or
+    // product exists). Anonymous access only: without
+    // Access-Control-Allow-Credentials the browser sends no cookies and
+    // refuses to expose a response to credentialed requests, so this grants
+    // cross-origin readers exactly what an unauthenticated curl already gets.
+    // Non-simple methods still fail their preflight — no OPTIONS handler.
+    const corsHeaders = [
+      {
+        source: "/api/v1/accounts/:account_id",
+        headers: [{ key: "Access-Control-Allow-Origin", value: "*" }],
+      },
+      {
+        source: "/api/v1/products/:account_id",
+        headers: [{ key: "Access-Control-Allow-Origin", value: "*" }],
+      },
+      {
+        source: "/api/v1/products/:account_id/:product_id",
+        headers: [{ key: "Access-Control-Allow-Origin", value: "*" }],
+      },
+    ];
+
     if (process.env.STAGE === "prod") {
-      return [];
+      return corsHeaders;
     }
     return [
+      ...corsHeaders,
       {
         source: "/:path*",
         headers: [

--- a/next.config.test.ts
+++ b/next.config.test.ts
@@ -1,5 +1,25 @@
 import nextConfig from "./next.config.js";
 
+const CORS_HEADERS = [
+  {
+    source: "/api/v1/accounts/:account_id",
+    headers: [{ key: "Access-Control-Allow-Origin", value: "*" }],
+  },
+  {
+    source: "/api/v1/products/:account_id",
+    headers: [{ key: "Access-Control-Allow-Origin", value: "*" }],
+  },
+  {
+    source: "/api/v1/products/:account_id/:product_id",
+    headers: [{ key: "Access-Control-Allow-Origin", value: "*" }],
+  },
+];
+
+const NOINDEX = {
+  source: "/:path*",
+  headers: [{ key: "X-Robots-Tag", value: "noindex, nofollow" }],
+};
+
 describe("next.config headers()", () => {
   const originalStage = process.env.STAGE;
 
@@ -14,28 +34,40 @@ describe("next.config headers()", () => {
   test("non-prod stage emits noindex header on all paths", async () => {
     process.env.STAGE = "dev";
     const result = await nextConfig.headers!();
-    expect(result).toEqual([
-      {
-        source: "/:path*",
-        headers: [{ key: "X-Robots-Tag", value: "noindex, nofollow" }],
-      },
-    ]);
+    expect(result).toEqual([...CORS_HEADERS, NOINDEX]);
   });
 
-  test("prod stage emits no header overrides", async () => {
+  test("prod stage emits no noindex override", async () => {
     process.env.STAGE = "prod";
     const result = await nextConfig.headers!();
-    expect(result).toEqual([]);
+    expect(result).toEqual(CORS_HEADERS);
   });
 
   test("missing STAGE defaults to noindex", async () => {
     delete process.env.STAGE;
     const result = await nextConfig.headers!();
-    expect(result).toEqual([
-      {
-        source: "/:path*",
-        headers: [{ key: "X-Robots-Tag", value: "noindex, nofollow" }],
-      },
-    ]);
+    expect(result).toEqual([...CORS_HEADERS, NOINDEX]);
+  });
+
+  // The wizards on docs.source.coop are unauthenticated cross-origin callers:
+  // the API must stay readable to them in production, where the noindex
+  // override is skipped.
+  test("CORS headers apply in every stage, including prod", async () => {
+    for (const stage of ["dev", "staging", "prod"]) {
+      process.env.STAGE = stage;
+      const result = await nextConfig.headers!();
+      for (const cors of CORS_HEADERS) {
+        expect(result).toContainEqual(cors);
+      }
+    }
+  });
+
+  // Allow-Credentials plus a wildcard origin is rejected by browsers, and
+  // would expose authenticated responses if it ever worked.
+  test("never grants credentialed cross-origin access", async () => {
+    process.env.STAGE = "prod";
+    const result = await nextConfig.headers!();
+    const keys = result.flatMap((r) => r.headers.map((h) => h.key.toLowerCase()));
+    expect(keys).not.toContain("access-control-allow-credentials");
   });
 });


### PR DESCRIPTION
## Problem

The IAM policy wizards being added to `docs.source.coop` need to tell a user whether the account/product IDs they typed actually exist on Source Cooperative. No `/api/v1` route sends CORS headers today, so a browser on another origin cannot read any response from this API.

The docs currently work around it by probing `data.source.coop` (the only Source Cooperative endpoint with `Access-Control-Allow-Origin: *`). That workaround has two limits:

- it only answers for a full `account/product` prefix, so an account ID alone cannot be checked at all;
- it reports "this prefix has data", not "this product exists" — a real but empty product looks missing.

## Change

Send `Access-Control-Allow-Origin: *` on the three read routes those callers need:

- `/api/v1/accounts/:account_id`
- `/api/v1/products/:account_id`
- `/api/v1/products/:account_id/:product_id`

The headers are now returned in **every** stage. The `STAGE === "prod"` branch previously returned an empty array, which would have dropped them exactly where they are needed.

## Why this is safe

Anonymous access only. There is no `Access-Control-Allow-Credentials`, so the browser sends no cookies, and it refuses to expose a response to a credentialed request. A cross-origin reader gets precisely what an unauthenticated `curl` already returns today — these routes keep their own authorization checks, unchanged. Non-simple methods (`PUT`, `PATCH`, JSON `POST`) still fail their preflight, since no `OPTIONS` handler exists.

Scope is deliberately narrow: `/api/v1/whoami`, the api-keys routes, and everything else are untouched.

## Verification

- `npx jest next.config.test.ts` — 5 passing, covering header presence per stage and the absence of `Access-Control-Allow-Credentials`.
- Ran `next dev` locally and curled the routes. The three listed routes return `Access-Control-Allow-Origin: *`; `/api/v1/whoami` returns no CORS header. (Routes 500 locally without a database — headers apply at the routing layer, which is the point.)

## Follow-up

Once this ships, the docs wizards can point their existence check at `/api/v1/products/{account}/{product}` instead of the data proxy, and gain account-only checking via `/api/v1/products/{account}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)