### PR TITLE
fix(accounts): make account creation a conditional write

### DIFF
--- a/src/lib/actions/account.ts
+++ b/src/lib/actions/account.ts
@@ -2,6 +2,7 @@
 
 import { LOGGER } from "@/lib/logging";
 import {
+  Account,
   AccountCreationRequestSchema,
   Actions,
   AccountCreationRequest,
@@ -104,8 +105,31 @@ export async function createAccount(
     };
   }
 
-  // Create account
-  const account = await accountsTable.create(newAccount);
+  // Create account. `account_id` is caller-supplied and never checked for
+  // availability beforehand, so the conditional write in `create` is what stops
+  // one account being written over another. A collision is an ordinary signup
+  // outcome, not only an attack, so report it on the field rather than letting
+  // it surface as a server error.
+  let account: Account;
+  try {
+    account = await accountsTable.create(newAccount);
+  } catch (error) {
+    if ((error as { name?: string })?.name === "ConditionalCheckFailedException") {
+      LOGGER.warn("Account creation rejected: account_id already taken", {
+        operation: "createAccount",
+        context: "account creation",
+        metadata: { account_id: newAccount.account_id },
+      });
+      return {
+        fieldErrors: { account_id: ["That account ID is already taken."] },
+        data: formData,
+        message: "That account ID is already taken",
+        success: false,
+      };
+    }
+    throw error;
+  }
+
   LOGGER.info("Successfully created account", {
     operation: "createAccount",
     context: "account creation",

--- a/src/lib/clients/database/accounts.create.test.ts
+++ b/src/lib/clients/database/accounts.create.test.ts
@@ -1,0 +1,124 @@
+import { AccountsTable } from "./accounts";
+import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { AccountType, type Account } from "@/types";
+
+jest.mock("@/lib/config", () => ({
+  CONFIG: {
+    environment: { stage: "test" },
+    database: {},
+  },
+}));
+
+jest.mock("@/lib/logging", () => ({
+  LOGGER: {
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+  return {
+    account_id: "victim",
+    type: AccountType.INDIVIDUAL,
+    name: "Victim",
+    identity_id: "ory-identity-victim",
+    disabled: false,
+    flags: [],
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    metadata_public: {},
+    metadata_private: {},
+    ...overrides,
+  } as Account;
+}
+
+/**
+ * A stand-in for DynamoDB that honours `PutItem`'s conditional-write semantics
+ * the way the real service does:
+ *
+ *   - with no `ConditionExpression`, a Put at an existing partition key
+ *     **replaces** the stored item;
+ *   - with `attribute_not_exists(account_id)`, a Put at an existing key fails
+ *     with `ConditionalCheckFailedException` and the store is untouched.
+ *
+ * Asserting on the command's shape would only prove we passed a string. This
+ * models the behaviour that actually protects the row, so the test fails for
+ * the same reason production is exposed.
+ */
+function fakeDynamo(seed: Account[] = []) {
+  const store = new Map<string, Account>(
+    seed.map((account) => [account.account_id, account])
+  );
+
+  const send = jest.fn(async (command: { input: Record<string, unknown> }) => {
+    const item = command.input.Item as Account | undefined;
+    if (!item) return {};
+
+    const condition = command.input.ConditionExpression as string | undefined;
+    const guardsExistence =
+      typeof condition === "string" &&
+      condition.replace(/\s/g, "").includes("attribute_not_exists(account_id)");
+
+    if (guardsExistence && store.has(item.account_id)) {
+      const error = new Error(
+        "The conditional request failed"
+      ) as Error & { name: string };
+      error.name = "ConditionalCheckFailedException";
+      throw error;
+    }
+
+    store.set(item.account_id, item);
+    return {};
+  });
+
+  return {
+    store,
+    client: { send } as unknown as DynamoDBDocumentClient,
+  };
+}
+
+describe("AccountsTable.create", () => {
+  it("refuses to overwrite an account that already exists", async () => {
+    // The victim already holds `victim`, bound to their Ory identity.
+    const victim = makeAccount();
+    const { store, client } = fakeDynamo([victim]);
+    const table = new AccountsTable({ client });
+
+    // An attacker who has registered an Ory identity but not yet created an
+    // account submits the create form naming the victim's account_id. This is
+    // reachable today: `isAuthorized(..., Actions.CreateAccount)` returns true
+    // for precisely this state (no account yet), and `account_id` comes
+    // straight off the form.
+    const attacker = makeAccount({
+      name: "Attacker",
+      identity_id: "ory-identity-attacker",
+    });
+
+    await expect(table.create(attacker)).rejects.toThrow(
+      expect.objectContaining({ name: "ConditionalCheckFailedException" })
+    );
+
+    // The row must still belong to the victim. Without the conditional write
+    // the Put silently replaces it, the account and every product beneath it
+    // transfer to the attacker's identity, and the victim is locked out.
+    expect(store.get("victim")?.identity_id).toBe("ory-identity-victim");
+    expect(store.get("victim")?.name).toBe("Victim");
+  });
+
+  it("still creates an account when the id is unused", async () => {
+    const { store, client } = fakeDynamo([makeAccount()]);
+    const table = new AccountsTable({ client });
+
+    const newcomer = makeAccount({
+      account_id: "newcomer",
+      name: "Newcomer",
+      identity_id: "ory-identity-newcomer",
+    });
+
+    await expect(table.create(newcomer)).resolves.toEqual(newcomer);
+    expect(store.get("newcomer")?.identity_id).toBe("ory-identity-newcomer");
+    expect(store.size).toBe(2);
+  });
+});

--- a/src/lib/clients/database/accounts.ts
+++ b/src/lib/clients/database/accounts.ts
@@ -130,13 +130,34 @@ export class AccountsTable extends BaseTable {
     }
   }
 
+  /**
+   * Creates an account, failing if `account_id` is already taken.
+   *
+   * `account_id` is the table's partition key, so an unconditioned `PutCommand`
+   * would *replace* an existing row rather than fail. `account_id` is chosen by
+   * the caller at signup and never checked for availability beforehand, so the
+   * conditional write is what keeps one account from being written over another
+   * -- including one bound to a different `identity_id`.
+   *
+   * Throws `ConditionalCheckFailedException` when the id is taken; callers that
+   * accept a user-supplied id should catch it and report the collision rather
+   * than surfacing a server error.
+   */
   async create(account: Account): Promise<Account> {
-    await this.client.send(
-      new PutCommand({
-        TableName: this.table,
-        Item: account,
-      })
-    );
+    try {
+      await this.client.send(
+        new PutCommand({
+          TableName: this.table,
+          Item: account,
+          ConditionExpression: "attribute_not_exists(account_id)",
+        })
+      );
+    } catch (error) {
+      if ((error as { name?: string })?.name !== "ConditionalCheckFailedException") {
+        this.logError("create", error, { account_id: account.account_id });
+      }
+      throw error;
+    }
 
     return account;
   }


### PR DESCRIPTION
## What I'm changing

`AccountsTable.create` now issues a conditional write — `attribute_not_exists(account_id)` — so creating an account fails when the id is already taken instead of replacing the stored row.

`createAccount` catches that rejection and returns it as a field error on `account_id`.

## Why

`account_id` is the accounts table's partition key, so an unconditioned `PutCommand` replaces an existing item rather than failing. `account_id` comes straight off the submitted form and nothing checked whether it was already in use, so a create could overwrite an existing account — including its `identity_id`.

Refs GHSA-c58m-r8h6-f76c.

The caller-side handling isn't cosmetic. Nothing validated id availability before, so "that id is taken" has never been a reachable outcome; without it, an ordinary signup collision would surface as a server error rather than a message on the field.

## How I did it

Two commits: the first is a characterization test that fails on `main`, the second is the fix.

The test drives a DynamoDB stand-in that honours `PutItem`'s conditional semantics — a Put with no condition replaces, a Put with `attribute_not_exists(account_id)` raises `ConditionalCheckFailedException` and leaves the store untouched. Asserting on the command's shape would only prove we passed a string; this fails for the same reason production was exposed.

`create` logs unexpected failures through the table's usual `logError` path but leaves a conditional-check failure to the caller, since that one is an expected outcome rather than a fault.

## Test plan

- `npx jest src/lib/clients/database/accounts` — 3 passing, including the two new cases: the create is refused and the victim's row is intact, and an unused id still creates normally.
- `npx tsc --noEmit -p tsconfig.typecheck.json` — no new errors in the touched files. (Pre-existing errors remain in `src/components/features/analytics/*`, untouched here.)

## Notes for review

- A reserved-id denylist is a sensible follow-up but is deliberately not in this PR, which is scoped to the write.
- `fetchByOryId` has the same shape of gap elsewhere: `identity_id` has no uniqueness constraint and collisions resolve by taking the last row returned. Worth a separate look.
