### PR TITLE
fix(analytics): stop unique IPs shrinking as the window widens

### DIFF
--- a/src/components/features/analytics/AdminBreakdownChart.tsx
+++ b/src/components/features/analytics/AdminBreakdownChart.tsx
@@ -255,7 +255,7 @@ export function AdminBreakdownChart({
           />
           <Stat
             label="Unique IPs"
-            help={HELP.uniqueIps}
+            help={HELP.uniqueIpsSampled}
             value={plain.format(totals.uniqueIps)}
             divider
           />

--- a/src/components/features/analytics/AdminBreakdownChart.tsx
+++ b/src/components/features/analytics/AdminBreakdownChart.tsx
@@ -484,9 +484,9 @@ export function AdminBreakdownChart({
         ))}
       </Flex>
       <Text as="div" size="1" color="gray" mt="2">
-        Times are UTC. Values are estimates — Analytics Engine samples
-        high-volume traffic. Click a bar (or drag across several) to zoom in;
-        the browser back button zooms out.
+        Times are UTC. Values are estimates — high-volume traffic is measured
+        from a sample. Click a bar (or drag across several) to zoom in; the
+        browser back button zooms out.
       </Text>
     </Box>
   );

--- a/src/components/features/analytics/panels.tsx
+++ b/src/components/features/analytics/panels.tsx
@@ -198,11 +198,11 @@ export function UsersContent({ users }: { users: UsageUsers }) {
         <Stat
           label="Registered"
           help={HELP.registered}
-          value={numberFormat.format(users.registered)}
+          value={compactFormat.format(Math.round(users.registered)).toLowerCase()}
           divider
         />
         <Stat
-          label="Anon requests"
+          label="Anon downloads"
           help={HELP.anon}
           value={compactFormat.format(Math.round(users.anonRequests)).toLowerCase()}
           divider

--- a/src/components/features/analytics/style.ts
+++ b/src/components/features/analytics/style.ts
@@ -12,9 +12,15 @@ export const HELP = {
   requests: "Successful data requests (GET, status 200/206).",
   countries: "Distinct countries requests originated from.",
   dailyAvg: "Average downloads per day over the period.",
-  uniqueIps: "Distinct IP addresses that downloaded data in this period.",
-  registered: "Distinct signed-in users who downloaded data in this period.",
-  anon: "Download requests made without a signed-in user.",
+  uniqueIps:
+    "Distinct IP addresses that downloaded data in this period. A lower bound — Analytics Engine samples very high-volume traffic before we see it.",
+  // The admin explorer usually scans every index value at once, which is the
+  // worst case for Analytics Engine's resolution picker — so unlike the
+  // per-product stat, this one is not sliced back to full resolution.
+  uniqueIpsSampled:
+    "Distinct IP hashes surviving Analytics Engine sampling — a lower bound that shrinks as the range widens.",
+  registered: "Downloads by signed-in users.",
+  anon: "Downloads with no signed-in user.",
   distribution:
     "Unique IP addresses per download-count band; the line accumulates IPs with that many downloads or fewer, toward 100%. Band edges are log-spaced — the tail spans orders of magnitude.",
 };

--- a/src/components/features/analytics/style.ts
+++ b/src/components/features/analytics/style.ts
@@ -3,26 +3,29 @@
 // and client-module exports can't be invoked across the RSC boundary.
 import type { CSSProperties } from "react";
 
+// Reader-facing copy: plain language, no internals. These tooltips are read
+// by people publishing data, not by people who know how the numbers are
+// collected — the caveats are stated as what to expect, not as mechanics.
 export const HELP = {
   downloads: "Number of successful downloads.",
   window:
-    "Dates are UTC calendar days: the window covers the most recent full days plus the in-progress UTC day.",
-  served: "Total bytes downloaded.",
-  bandwidth: "Data served divided by the elapsed time in the range.",
-  requests: "Successful data requests (GET, status 200/206).",
-  countries: "Distinct countries requests originated from.",
+    "Dates are UTC days. The range covers the most recent full days plus today so far.",
+  served: "Total amount of data downloaded.",
+  bandwidth: "Average rate that data was downloaded over this range.",
+  requests: "Requests that successfully returned data.",
+  countries: "How many different countries downloads came from.",
   dailyAvg: "Average downloads per day over the period.",
   uniqueIps:
-    "Distinct IP addresses that downloaded data in this period. A lower bound — Analytics Engine samples very high-volume traffic before we see it.",
-  // The admin explorer usually scans every index value at once, which is the
-  // worst case for Analytics Engine's resolution picker — so unlike the
-  // per-product stat, this one is not sliced back to full resolution.
+    "How many different IP addresses downloaded data. Everyone sharing a network — an office, a university, a cloud provider — counts once, and very busy products may count a little low.",
+  // Product-page uniques are counted in weekly slices to keep them exact;
+  // the admin explorer usually scans everything at once, so its number is
+  // measured from a sample and undercounts more the wider the range gets.
   uniqueIpsSampled:
-    "Distinct IP hashes surviving Analytics Engine sampling — a lower bound that shrinks as the range widens.",
+    "How many different IP addresses appear in this range. Busy ranges are measured from a sample, so this undercounts — the wider the range, the more it undercounts.",
   registered: "Downloads by signed-in users.",
   anon: "Downloads with no signed-in user.",
   distribution:
-    "Unique IP addresses per download-count band; the line accumulates IPs with that many downloads or fewer, toward 100%. Band edges are log-spaced — the tail spans orders of magnitude.",
+    "How many IP addresses downloaded once, twice, and so on. The line adds them up left to right, so at any bar it shows the share that downloaded that many times or fewer.",
 };
 
 export const mono = (extra?: CSSProperties): CSSProperties => ({

--- a/src/lib/clients/analytics/index.test.ts
+++ b/src/lib/clients/analytics/index.test.ts
@@ -8,6 +8,7 @@ import {
   getAdminBreakdown,
   getProductBreakdowns,
   USAGE_DAYS,
+  USAGE_WINDOWS,
 } from "./index";
 import { CONFIG } from "@/lib/config";
 
@@ -65,33 +66,71 @@ describe("getUsage", () => {
   it("queries with sampling weights and served-bytes filters", async () => {
     await getUsage("acct", "prod");
 
-    const [seriesSql, windowSql, ipsSql, registeredSql] = sentSql();
-    for (const sql of [seriesSql, windowSql, ipsSql, registeredSql]) {
+    const [seriesSql, windowSql, ...ipSqls] = sentSql();
+    for (const sql of sentSql()) {
       // Float literals: AE 422s on Double-vs-Integer comparisons.
       expect(sql).toContain("blob4 = 'GET' AND double2 IN (200.0, 206.0)");
       expect(sql).toContain("blob1 = 'acct'");
       expect(sql).toContain("blob2 = 'prod'");
-      // Day-aligned window: today (partial) + USAGE_DAYS-1 full UTC days,
-      // identical for series, totals, and breakdowns.
+      expect(sql).toContain("FROM test_dataset");
+    }
+    // Day-aligned window: today (partial) + USAGE_DAYS-1 full UTC days,
+    // identical for series and totals.
+    for (const sql of [seriesSql, windowSql]) {
       expect(sql).toContain(
         `timestamp >= toStartOfDay(NOW() - INTERVAL '${USAGE_DAYS - 1}' DAY)`,
       );
-      expect(sql).toContain("FROM test_dataset");
     }
     expect(seriesSql).toContain("toStartOfDay(timestamp)");
     expect(seriesSql).toContain("SUM(_sample_interval * double1) AS bytes");
     expect(seriesSql).toContain("SUM(_sample_interval) AS requests");
     expect(windowSql).toContain("COUNT(DISTINCT blob6) AS countries");
     expect(windowSql).toContain("sumIf(_sample_interval, blob5 = '') AS anon_requests");
+    // Registered usage is a sample-weighted sum, not COUNT(DISTINCT blob5):
+    // distinct counts see only the rows that survived sampling, so they
+    // shrink as the scan widens.
+    expect(windowSql).toContain(
+      "sumIf(_sample_interval, blob5 != '') AS registered_requests",
+    );
     expect(windowSql).not.toContain("GROUP BY");
-    expect(ipsSql).toContain("blob8 != ''");
-    expect(ipsSql).toContain("GROUP BY ip");
-    expect(registeredSql).toContain("COUNT(DISTINCT blob5) AS registered");
-    expect(registeredSql).toContain("blob5 != ''");
+    expect(sentSql().join(" ")).not.toContain("COUNT(DISTINCT blob5)");
+    for (const sql of ipSqls) {
+      expect(sql).toContain("blob8 != ''");
+      expect(sql).toContain("GROUP BY ip");
+    }
 
     const [, options] = fetchMock.mock.calls[0];
     expect(options.headers.Authorization).toBe("Bearer cf-token");
   });
+
+  it.each(USAGE_WINDOWS)(
+    "tiles the %id window with week-wide per-IP slices, no gap or overlap",
+    async (days) => {
+      await getUsage("acct", "prod", undefined, days);
+
+      // Series + window query, then one slice query per week.
+      const ipSqls = sentSql().slice(2);
+      expect(ipSqls).toHaveLength(days / 7);
+
+      const bound = (sql: string, op: string) =>
+        sql.match(
+          new RegExp(
+            `timestamp ${op} toStartOfDay\\(NOW\\(\\) - INTERVAL '(\\d+)' DAY\\)`,
+          ),
+        )?.[1];
+
+      // Slice 0 stays open-ended so it keeps the in-progress UTC day.
+      expect(bound(ipSqls[0], "<")).toBeUndefined();
+      // Each slice starts where the next-older one ends, so no day is counted
+      // twice (which would inflate an IP's downloads) or skipped entirely.
+      ipSqls.forEach((sql, i) => {
+        expect(bound(sql, ">=")).toBe(String(7 * (i + 1) - 1));
+        if (i > 0) expect(bound(sql, "<")).toBe(bound(ipSqls[i - 1], ">="));
+      });
+      // The oldest slice reaches exactly as far back as the window itself.
+      expect(bound(ipSqls[ipSqls.length - 1], ">=")).toBe(String(days - 1));
+    },
+  );
 
   it("escapes quotes, backslashes, and control chars in values", async () => {
     await getUsage("a'; DROP--", "pr\\od", "dir/we'ird\u0000.txt");
@@ -117,8 +156,11 @@ describe("getUsage", () => {
         ]),
       )
       .mockResolvedValueOnce(
-        jsonResponse([{ countries: 2, anon_requests: "5" }]),
+        jsonResponse([
+          { countries: 2, anon_requests: "5", registered_requests: "2" },
+        ]),
       )
+      // One response per week-wide slice of the window.
       .mockResolvedValueOnce(
         jsonResponse([
           { ip: "h1", requests: 1 },
@@ -129,7 +171,15 @@ describe("getUsage", () => {
           { ip: "h5", requests: 0.4 },
         ]),
       )
-      .mockResolvedValueOnce(jsonResponse([{ registered: "2" }]));
+      // h1 recurs in an older slice: one IP, requests summed across slices.
+      .mockResolvedValueOnce(
+        jsonResponse([
+          { ip: "h1", requests: 1 },
+          { ip: "h6", requests: 5 },
+        ]),
+      )
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(jsonResponse([]));
 
     const usage = await getUsage("acct", "prod");
 
@@ -140,16 +190,16 @@ describe("getUsage", () => {
     // Every earlier day is zero-filled
     expect(usage!.days[0]).toMatchObject({ bytes: 0, requests: 0 });
     expect(usage!.totals).toEqual({ bytes: 1024, requests: 7, countries: 2 });
-    // Quasi-log bins: the 0.4 sampled fraction floors into "1" alongside
-    // the exact-1 IP; 3 → "3–5", 7 → "6–10", 25 → "11–25"; the rest zero.
+    // Quasi-log bins: the 0.4 sampled fraction floors into "1"; h1 sums to
+    // 1+1=2 across slices; 3 and 5 → "3–5", 7 → "6–10", 25 → "11–25".
     expect(usage!.users).toEqual({
-      uniqueIps: 5,
+      uniqueIps: 6,
       registered: 2,
       anonRequests: 5,
       distribution: [
-        { label: "1", ips: 2 },
-        { label: "2", ips: 0 },
-        { label: "3–5", ips: 1 },
+        { label: "1", ips: 1 },
+        { label: "2", ips: 1 },
+        { label: "3–5", ips: 2 },
         { label: "6–10", ips: 1 },
         { label: "11–25", ips: 1 },
         { label: "26–50", ips: 0 },

--- a/src/lib/clients/analytics/index.ts
+++ b/src/lib/clients/analytics/index.ts
@@ -13,8 +13,13 @@
  *                            double3: duration_ms
  *
  * Analytics Engine samples writes, so every count/sum must be weighted by
- * `_sample_interval`; COUNT(DISTINCT …) is the best available estimate for
- * uniques. It has no parameterized queries — every interpolated string goes
+ * `_sample_interval`. Distinct counts are NOT correctable that way — sampling
+ * drops whole rows, so COUNT(DISTINCT …) and row counts alike see only the
+ * survivors, and both shrink as a query's scan widens. Cloudflare documents
+ * this: unique counts of fields outside the index are not accurate. Prefer a
+ * sample-weighted sum wherever one answers the question; where it can't (the
+ * unique-IP stat), slice the scan so it stays at full resolution — see
+ * CHUNK_DAYS. It has no parameterized queries — every interpolated string goes
  * through sqlQuote(), and windows/buckets/columns come from whitelists only.
  *
  * Server-only: queries run over the SQL API with an account-level token.
@@ -64,9 +69,13 @@ export const FREQUENCY_BINS = [
 ] as const;
 
 export interface UsageUsers {
-  /** Distinct client IP hashes (blob8) that downloaded in the window */
+  /**
+   * Distinct client IP hashes (blob8) that downloaded in the window, unioned
+   * across CHUNK_DAYS-wide slices. A lower bound: ingest-level sampling drops
+   * events on very high-volume products before any query sees them.
+   */
   uniqueIps: number;
-  /** Distinct signed-in users (blob5) that downloaded in the window */
+  /** Sample-weighted requests from a signed-in user */
   registered: number;
   /** Sample-weighted requests with no signed-in user */
   anonRequests: number;
@@ -261,6 +270,41 @@ const USAGE_AGGREGATES = `
   COUNT(DISTINCT blob6) AS countries`;
 
 /**
+ * Width of one per-IP query slice. Analytics Engine picks a data resolution
+ * per query from the rows it estimates it will scan — time range dominating
+ * — so a whole-window `GROUP BY blob8` gets a coarsely sampled copy while
+ * week-wide slices of the same span get the full-resolution one. Every
+ * USAGE_WINDOWS value is a multiple of this, so the slices tile exactly.
+ */
+const CHUNK_DAYS = 7;
+
+/** Number of CHUNK_DAYS-wide slices that tile `days`. */
+const chunkCount = (days: UsageWindow): number => days / CHUNK_DAYS;
+
+/**
+ * Time bounds for the whole window, or for slice `chunk` of it (0 = the most
+ * recent CHUNK_DAYS days, counting back). Bounds are day offsets from today
+ * rather than absolute dates, so a given slice's SQL is byte-identical across
+ * windows — and since unstable_cache keys on the SQL, the 91d view only pays
+ * for the slices 7d/28d have not already warmed.
+ */
+function timeFilters(days: UsageWindow, chunk?: number): string[] {
+  if (chunk === undefined) {
+    return [`timestamp >= toStartOfDay(NOW() - INTERVAL '${days - 1}' DAY)`];
+  }
+  const filters = [
+    `timestamp >= toStartOfDay(NOW() - INTERVAL '${CHUNK_DAYS * (chunk + 1) - 1}' DAY)`,
+  ];
+  // Slice 0 is open-ended so it keeps the in-progress UTC day.
+  if (chunk > 0) {
+    filters.push(
+      `timestamp < toStartOfDay(NOW() - INTERVAL '${CHUNK_DAYS * chunk - 1}' DAY)`,
+    );
+  }
+  return filters;
+}
+
+/**
  * Shared FROM/WHERE for the usage queries. The window is day-aligned in SQL
  * — today (partial) plus days-1 full UTC days — so the day grid, headline
  * totals, and the country/file breakdowns all cover the identical span. (A
@@ -272,10 +316,11 @@ function usageFrom(
   productId: string,
   objectPath: string | undefined,
   days: UsageWindow,
+  chunk?: number,
 ): string {
   const filters = [
     SERVED_FILTER,
-    `timestamp >= toStartOfDay(NOW() - INTERVAL '${days - 1}' DAY)`,
+    ...timeFilters(days, chunk),
     `blob1 = ${sqlQuote(accountId)}`,
     `blob2 = ${sqlQuote(productId)}`,
   ];
@@ -301,24 +346,26 @@ export async function getUsage(
   const from = usageFrom(accountId, productId, objectPath, days);
 
   try {
-    const [seriesRows, windowRows, ipRows, registeredRows] = await Promise.all([
+    const [seriesRows, windowRows, ipChunks] = await Promise.all([
       usageQuery(
         `SELECT toStartOfDay(timestamp) AS day, ${USAGE_AGGREGATES} ${from} GROUP BY day ORDER BY day`,
       ),
       // Separate query: window-wide DISTINCT can't be summed from days.
       usageQuery(
-        `SELECT COUNT(DISTINCT blob6) AS countries, sumIf(_sample_interval, blob5 = '') AS anon_requests ${from}`,
+        `SELECT COUNT(DISTINCT blob6) AS countries, sumIf(_sample_interval, blob5 = '') AS anon_requests, sumIf(_sample_interval, blob5 != '') AS registered_requests ${from}`,
       ),
       // Sample-weighted request count per unique client IP hash, for the
-      // download-frequency histogram (blob8 is empty when the IP is unknown).
-      // ponytail: capped at AE's ~10k response rows — a product with more
-      // unique IPs in the window gets an (arbitrary, roughly unbiased)
-      // sample; the histogram is labeled an estimate anyway.
-      usageQuery(
-        `SELECT blob8 AS ip, SUM(_sample_interval) AS requests ${from} AND blob8 != '' GROUP BY ip`,
-      ),
-      usageQuery(
-        `SELECT COUNT(DISTINCT blob5) AS registered ${from} AND blob5 != ''`,
+      // unique-IP headline and the download-frequency histogram (blob8 is
+      // empty when the IP is unknown). Sliced into weeks and unioned below:
+      // Analytics Engine samples a whole-window GROUP BY hard enough that it
+      // returns FEWER distinct IPs for a wider window, and distinct counts —
+      // unlike the sample-weighted SUMs — cannot be corrected after the fact.
+      Promise.all(
+        Array.from({ length: chunkCount(days) }, (_, chunk) =>
+          usageQuery(
+            `SELECT blob8 AS ip, SUM(_sample_interval) AS requests ${usageFrom(accountId, productId, objectPath, days, chunk)} AND blob8 != '' GROUP BY ip`,
+          ),
+        ),
       ),
     ]);
 
@@ -348,13 +395,24 @@ export async function getUsage(
       { bytes: 0, requests: 0, countries: num(windowRows[0]?.countries) },
     );
 
+    // Union the slices: an IP active in several weeks is one IP, with its
+    // requests summed. The hashes are stable, so this is a real distinct
+    // count rather than a sum of per-slice counts (which would double-count).
+    const requestsByIp = new Map<string, number>();
+    for (const rows of ipChunks) {
+      for (const row of rows) {
+        const ip = str(row.ip);
+        requestsByIp.set(ip, (requestsByIp.get(ip) ?? 0) + num(row.requests));
+      }
+    }
+
     const distribution = FREQUENCY_BINS.map(({ label }) => ({
       label,
       ips: 0,
     }));
-    for (const row of ipRows) {
+    for (const requests of requestsByIp.values()) {
       // Sampling makes per-IP counts fractional estimates; round, floor 1.
-      const downloads = Math.max(1, Math.round(num(row.requests)));
+      const downloads = Math.max(1, Math.round(requests));
       distribution[
         FREQUENCY_BINS.findIndex((bin) => downloads <= bin.max)
       ].ips += 1;
@@ -365,8 +423,8 @@ export async function getUsage(
       totals,
       users: {
         // Same population as the histogram, so headline and bars agree.
-        uniqueIps: ipRows.length,
-        registered: num(registeredRows[0]?.registered),
+        uniqueIps: requestsByIp.size,
+        registered: num(windowRows[0]?.registered_requests),
         anonRequests: num(windowRows[0]?.anon_requests),
         distribution,
       },


### PR DESCRIPTION
## The bug

Someone noticed the product analytics panel reports **more** unique IPs for 7 days (384) than for 28 days (110) — even though the 28-day window strictly contains the 7-day one.

| | 7d | 28d |
|---|---|---|
| Unique IPs | 384 | **110** ⬇️ |
| Anon requests | 742 | 1.2k ⬆️ |

## Why

Analytics Engine stores each dataset at several resolutions (100% / 10% / 1%) and picks one **per query**, based on the rows it estimates it will scan — with time range the dominant input. Every retained row carries `_sample_interval`, the number of real events it stands for.

Sample-weighted `SUM`s absorb that correctly, which is why anon requests rose as expected. Distinct counts do not. `uniqueIps: ipRows.length` counted rows that *survived* sampling, so a wider scan returned fewer of them and the number went down.

This is documented: Cloudflare states you [may not get accurate unique counts of fields that are not in your index](https://developers.cloudflare.com/analytics/analytics-engine/sampling/), and their sampling-correction table covers only `count`/`sum`/`avg`/`quantile` — distinct counting is absent because no row weighting can recover it. **Swapping in `COUNT(DISTINCT blob8)` would not have helped**; it counts the same survivors.

### The histogram was the giveaway

The 28d "IPs by download count" chart had **zero** IPs in the `1`, `2`, and `3–5` bins and ~100 piled into `6–10`. That's not a possible download population — the 7d chart shows the real shape, a spike of ~185 one-time downloaders. It's exactly what you get at ~1:10 sampling: an IP that downloaded once contributes one row with `_sample_interval ≈ 10`, and gets scored as 10 downloads.

## The fix

Slice the per-IP query into **week-wide chunks** and union the hashes in JS. Each slice scans little enough to get the full-resolution copy, and `blob8` is a stable hash, so the union is a genuine distinct count with per-IP requests summed across slices.

Two properties worth calling out:

- **Slice bounds are day offsets from today, not absolute dates.** So a given slice's SQL is byte-identical across windows, and since `unstable_cache` keys on the SQL string, the 91d view only pays for the slices 7d/28d haven't already warmed.
- **Cost is a non-issue.** AE bills per read query with no complexity surcharge, 1M/month included. 13 queries at 91d is noise, and they're already inside `Promise.all` behind a 4h cache.

This fixes the headline stat, the histogram, and monotonicity together.

### `registered` had the same bug

`COUNT(DISTINCT blob5)` — identical failure mode, unnoticed because it currently reads 0. It becomes `sumIf(_sample_interval, blob5 != '')`, which is correct, monotonic, and folds into the **existing** window query, deleting a round-trip rather than adding four. The tab now reads as a clean registered-vs-anonymous downloads split, so the label goes `Anon requests` → `Anon downloads` (the row was mixing "requests" and "downloads" vocabulary for the same thing).

`countries` (`COUNT(DISTINCT blob6)`) is deliberately left alone: ~200 possible values each with many rows means survival probability is ~1.

## Two comments removed as unfounded

- **"capped at AE's ~10k response rows"** — traced to `c77f4fc7`, a comment-only commit with no measurement behind it. The figure appears nowhere in Cloudflare's docs.
- **"the histogram is labeled an estimate anyway"** — that label only ever existed on the admin surface (`AdminBreakdownChart.tsx:487`), never on the product page the comment was defending.

## What this does *not* fix

**Ingest-level sampling** is untouched — those rows were never written, so no query can recover them. It only bites products exceeding roughly 100 datapoints/sec on their index, and the proxy indexes on `account/product` (`data.source.coop/src/analytics.rs:32`), so per-product sampling is already fair. The unique-IP tooltip says so in plain terms, without naming the mechanism.

**The admin explorer's unique-IP stat** (`index.ts:638`) stays a `COUNT(DISTINCT)`. It usually scans *every* index value at once, which Cloudflare calls the worst case for resolution, and slicing barely helps. It gets honest tooltip copy instead of the product page's.

If a truly exact count over 91 days ever becomes a requirement, the next step is the proxy writing a second, low-volume dataset of first-seen `(product, day, ip_hash)` rows — dedup guarded by a bounded isolate-local `HashSet`, which needn't even be correct since it's only a volume reducer. ~70 LOC cross-repo, $0. Deliberately not doing that now. Durable Objects, HyperLogLog sketches, and a DynamoDB table were all considered and priced out as over-engineered — HLL in particular strictly *contains* the DO complexity, since merging sketches needs a DO to own each one.

## Tooltip copy

The stat tooltips are read by publishers, not by people who know how the numbers are collected, so this branch also rewrites them in plain language — dropping "Analytics Engine", "sampling", "distinct IP hashes", "log-spaced band edges", and "GET, status 200/206" in favour of what a reader can actually act on. The unique-IP note leads with the caveat that skews the number most for a typical product (everyone behind one office, university, or cloud network counts once) before the undercount.

The admin explorer keeps a blunter tooltip, since its uniques genuinely aren't sliced back to full resolution. The "Analytics Engine SQL" dialog title stays as-is — that dialog shows raw SQL, so naming the system is the point.

## Testing

- `npx jest src/lib/clients/analytics` — **27 pass**, including 3 new cases asserting the slices tile each window (7d/28d/91d) with no gap or overlap: slice 0 stays open-ended to keep the in-progress UTC day, each slice starts where the next-older one ends, and the oldest reaches exactly as far back as the window itself. A double-counted day would inflate an IP's downloads and shift it into the wrong histogram bin, so that's the check worth having.
- The frequency test now feeds an IP across two slices to cover the union and the summing.
- `npm run lint` — clean for the touched files.

**Pre-existing failures, verified identical on `main` in this worktree and unrelated to this change:** `DropdownSection.integration.test.tsx`, the two analytics RTL suites (duplicate React resolved through the shared `node_modules`), and `next build`'s type-check step failing on recharts typings in `AdminBreakdownChart.tsx:382`. `tsc --noEmit` reports the same 15 errors before and after this diff. Webpack compiles successfully; only the type-check trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

