### PR TITLE
refactor(forms): one Field primitive across every form

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,13 +5,18 @@
     "plugin:@typescript-eslint/recommended",
     "next/core-web-vitals"
   ],
-  "plugins": ["@typescript-eslint"],
+  "plugins": [
+    "@typescript-eslint"
+  ],
   "rules": {
     "@typescript-eslint/no-explicit-any": "warn",
-    "@typescript-eslint/no-unused-vars": ["warn", { 
-      "argsIgnorePattern": "^_",
-      "varsIgnorePattern": "^_"
-    }],
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_"
+      }
+    ],
     "@typescript-eslint/no-require-imports": "warn",
     "prefer-const": [
       "error",
@@ -20,5 +25,33 @@
       }
     ]
   },
-  "ignorePatterns": ["node_modules/", ".next/", "public/", "**/*.d.ts"]
+  "overrides": [
+    {
+      "files": [
+        "src/components/**/*.tsx"
+      ],
+      "excludedFiles": [
+        "**/__tests__/**"
+      ],
+      "rules": {
+        "no-restricted-syntax": [
+          "error",
+          {
+            "selector": "JSXOpeningElement[name.name=/^(select|textarea)$/]",
+            "message": "Use Radix Themes Select/TextArea inside a <Field>. A raw control skips the theme (focus ring, disabled state, dark mode)."
+          },
+          {
+            "selector": "JSXOpeningElement[name.name=\"input\"]:not(:has(JSXAttribute[name.name=\"type\"][value.value=/^(hidden|file)$/]))",
+            "message": "Use Radix Themes TextField/Checkbox/Switch inside a <Field>. A raw control skips the theme (focus ring, disabled state, dark mode). type=\"hidden\" and type=\"file\" are exempt."
+          }
+        ]
+      }
+    }
+  ],
+  "ignorePatterns": [
+    "node_modules/",
+    ".next/",
+    "public/",
+    "**/*.d.ts"
+  ]
 }

--- a/src/app/(app)/edit/product/[account_id]/[product_id]/details/page.tsx
+++ b/src/app/(app)/edit/product/[account_id]/[product_id]/details/page.tsx
@@ -14,7 +14,7 @@ import {
   DataConnection,
   DataConnectionObjectSchema,
 } from "@/types";
-import { Box, Separator, Text } from "@radix-ui/themes";
+import { DangerZone } from "@/components/core";
 
 export async function generateMetadata({
   params,
@@ -75,21 +75,18 @@ export default async function DetailsPage({ params }: PageProps) {
       />
 
       {canDelete && (
-        <>
-          <Separator size="4" my="6" />
-          <Box>
-            <Text as="p" size="2" color="gray" mb="3">
-              Deleting this product is permanent and cannot be undone. All
-              associated data, memberships, and records will be removed.
-            </Text>
+        <DangerZone
+          title="Delete this product"
+          description="Permanent. Removes the product record, its memberships and its access records. Whether the underlying objects go too depends on the data connection."
+          action={
             <DeleteProductModal
               accountId={account_id}
               productId={product_id}
               canPreserveData={canPreserveData}
               dataReadOnly={!!connection?.read_only}
             />
-          </Box>
-        </>
+          }
+        />
       )}
     </>
   );

--- a/src/components/core/DangerZone.tsx
+++ b/src/components/core/DangerZone.tsx
@@ -1,0 +1,42 @@
+import { Box, Flex, Text } from "@radix-ui/themes";
+
+interface DangerZoneProps {
+  title: string;
+  description: React.ReactNode;
+  /** The destructive control itself. */
+  action: React.ReactNode;
+}
+
+/**
+ * Where irreversible actions live. Bordered and tinted so a delete control is
+ * never mistaken for the rest of the form.
+ */
+export function DangerZone({ title, description, action }: DangerZoneProps) {
+  return (
+    <Box mt="6">
+      <Text as="p" size="2" weight="bold" color="red" mb="2">
+        Danger zone
+      </Text>
+      <Flex
+        align="start"
+        justify="between"
+        gap="5"
+        p="4"
+        style={{
+          border: "1px solid var(--red-6)",
+          backgroundColor: "var(--red-2)",
+        }}
+      >
+        <Box>
+          <Text as="p" size="2" weight="medium">
+            {title}
+          </Text>
+          <Text as="p" size="1" color="gray" mt="1">
+            {description}
+          </Text>
+        </Box>
+        <Box flexShrink="0">{action}</Box>
+      </Flex>
+    </Box>
+  );
+}

--- a/src/components/core/DynamicForm.tsx
+++ b/src/components/core/DynamicForm.tsx
@@ -1,33 +1,97 @@
 "use client";
 
 import React, { useActionState, startTransition } from "react";
-import { Button, Text, Flex } from "@radix-ui/themes";
+import {
+  Flex,
+  RadioCards,
+  Select,
+  Switch,
+  Text,
+  TextArea,
+  TextField,
+} from "@radix-ui/themes";
 import { useRouter } from "next/navigation";
+import { Field } from "./Field";
+import { FormActions } from "./FormActions";
+import { SectionHeader } from "./SectionHeader";
 
-export interface FormField<T extends Record<string, any>> {
+/** Controls that render purely from a value prop, so they must be controlled. */
+export type ValueDrivenFieldType = "radio-cards" | "switch";
+
+export type StandardFieldType =
+  | "text"
+  | "textarea"
+  | "email"
+  | "url"
+  | "password"
+  | "number"
+  | "tel"
+  | "select"
+  | "custom";
+
+interface BaseFormField<T extends Record<string, any>> {
   label?: string;
   name: keyof T;
-  type:
-    | "text"
-    | "textarea"
-    | "email"
-    | "url"
-    | "password"
-    | "number"
-    | "tel"
-    | "select"
-    | "custom";
   required?: boolean;
   readOnly?: boolean;
   description?: React.ReactNode;
   placeholder?: string;
   isValid?: boolean | null;
   message?: React.ReactNode;
+  customComponent?: React.ReactNode; // Custom component for rendering
+  options?: FormFieldOption[]; // Options for select and radio-cards fields
+  /** Render the value in the code face — for IDs, emails and URLs. */
+  mono?: boolean;
+  /** Live character count. Only set it where a maximum is actually enforced. */
+  maxLength?: number;
+  /**
+   * Groups the field under a heading. Consecutive fields sharing a section are
+   * rendered together beneath one `SectionHeader`.
+   */
+  section?: string;
+  /** Label beside the control, for `switch`. */
+  switchLabel?: string;
+  /**
+   * `switch` only: the switch reads on when the value is "false". For flags
+   * stored as the negative of what the user is being asked (`disabled`), so the
+   * affirmative reading stays on the left.
+   */
+  invert?: boolean;
+}
+
+/**
+ * `radio-cards` and `switch` render entirely from their value prop, so an
+ * uncontrolled one would draw a control that never moves when clicked. The
+ * type makes that unrepresentable rather than leaving it to be discovered.
+ */
+interface ValueDrivenFormField<T extends Record<string, any>>
+  extends BaseFormField<T> {
+  type: ValueDrivenFieldType;
+  controlled: true;
+  value: string;
+  onValueChange: (value: string) => void;
+}
+
+interface StandardFormField<T extends Record<string, any>>
+  extends BaseFormField<T> {
+  type: StandardFieldType;
   controlled?: boolean; // If true, this field will be controlled by the form
   onValueChange?: (value: string) => void; // Callback for controlled fields
   value?: string; // External controlled value
-  customComponent?: React.ReactNode; // Custom component for rendering
-  options?: Array<{ value: string; label: string }>; // Options for select fields
+}
+
+export type FormField<T extends Record<string, any>> =
+  | ValueDrivenFormField<T>
+  | StandardFormField<T>;
+
+export interface FormFieldOption {
+  value: string;
+  label: string;
+  /** Shown under the label. `radio-cards` only — a `select` has no room for it. */
+  description?: React.ReactNode;
+  disabled?: boolean;
+  /** Why the option can't be chosen. Rendered in place of the description. */
+  disabledReason?: React.ReactNode;
 }
 
 export interface FormState<T> {
@@ -55,22 +119,31 @@ interface DynamicFormProps<T extends Record<string, any>> {
   disabled?: boolean;
   initialValues?: Partial<T>; // Initial values for form fields
   onSuccess?: () => void; // Callback when form submission is successful
+  /** Secondary action rendered beside submit (e.g. a dialog's Cancel). */
+  secondaryAction?: React.ReactNode;
 }
 
-// Shared input/select styling for app forms. Exported so bespoke forms (e.g.
-// the data-connection form) render identical fields without copying the rule.
-export const formFieldStyle: React.CSSProperties = {
+const monoStyle: React.CSSProperties = {
   fontFamily: "var(--code-font-family)",
-  width: "100%",
-  padding: "8px 12px",
-  borderRadius: "0",
-  border: "1px solid var(--gray-6)",
-  fontSize: "16px",
-  lineHeight: "1.5",
-  boxSizing: "border-box",
 };
 
-const style = formFieldStyle;
+/** Runs of consecutive fields sharing a `section`, in declaration order. */
+function groupBySection<T extends Record<string, any>>(fields: FormField<T>[]) {
+  const groups: Array<{ key: string; section?: string; fields: FormField<T>[] }> = [];
+  for (const field of fields) {
+    const last = groups[groups.length - 1];
+    if (last && last.section === field.section) {
+      last.fields.push(field);
+    } else {
+      groups.push({
+        key: `${field.section ?? ""}-${String(field.name)}`,
+        section: field.section,
+        fields: [field],
+      });
+    }
+  }
+  return groups;
+}
 
 export function DynamicForm<T extends Record<string, any>>({
   fields,
@@ -81,6 +154,7 @@ export function DynamicForm<T extends Record<string, any>>({
   className,
   initialValues,
   onSuccess,
+  secondaryAction,
 }: DynamicFormProps<T>) {
   const router = useRouter();
   const [state, formAction, pending] = useActionState(action, {
@@ -96,6 +170,27 @@ export function DynamicForm<T extends Record<string, any>>({
       field.onValueChange(value);
     }
   };
+
+  // Value to seed an uncontrolled field with: whatever the last (failed)
+  // submission carried, else the caller's initial value.
+  // Live lengths for fields with a `maxLength`. Without this the counter reads
+  // the seeded value and never moves unless the caller also wires the field up
+  // as controlled — a counter that silently depends on unrelated wiring.
+  const [liveLengths, setLiveLengths] = React.useState<Record<string, number>>(
+    {}
+  );
+  const trackLength = (field: FormField<T>, value: string) => {
+    if (field.maxLength === undefined) return;
+    const name = String(field.name);
+    setLiveLengths((prev) =>
+      prev[name] === value.length ? prev : { ...prev, [name]: value.length }
+    );
+  };
+
+  const defaultValueFor = (field: FormField<T>) =>
+    (state.data.get(String(field.name)) as string) ||
+    (initialValues?.[String(field.name)] as string | undefined) ||
+    "";
 
   // Dispatch the action from onSubmit (in a transition) rather than via the
   // form's `action` prop. React automatically resets a form after an `action`
@@ -130,6 +225,184 @@ export function DynamicForm<T extends Record<string, any>>({
     }
   }, [state.success, state.redirectTo, router]);
 
+  const renderControl = (
+    field: FormField<T>,
+    controlProps: {
+      id: string;
+      "aria-describedby"?: string;
+      "aria-invalid"?: boolean;
+    }
+  ) => {
+    const name = String(field.name);
+    const isDisabled = field.readOnly || disabled;
+
+    if (field.type === "custom") {
+      // customComponent is a ReactNode, so it can never receive controlProps —
+      // which means a <label htmlFor> for it could never resolve. Wrap it so the
+      // label and description reach it as a named group instead.
+      return field.label ? (
+        <div role="group" {...controlProps}>
+          {field.customComponent}
+        </div>
+      ) : (
+        field.customComponent
+      );
+    }
+
+    if (field.type === "textarea") {
+      return (
+        <TextArea
+          {...controlProps}
+          name={name}
+          size="3"
+          rows={4}
+          placeholder={field.placeholder}
+          required={field.required}
+          disabled={isDisabled}
+          style={field.mono ? monoStyle : undefined}
+          {...(field.controlled
+            ? {
+                value: field.value ?? "",
+                onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+                  trackLength(field, e.target.value);
+                  handleControlledChange(name, e.target.value);
+                },
+              }
+            : {
+                defaultValue: defaultValueFor(field),
+                onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                  trackLength(field, e.target.value),
+              })}
+        />
+      );
+    }
+
+    if (field.type === "radio-cards") {
+      // Radix RadioCards is not a form control, so the value rides a hidden
+      // input. Radio cards are for a handful of options that each need a
+      // sentence; anything longer stays a select.
+      const value = field.controlled ? field.value ?? "" : defaultValueFor(field);
+      return (
+        <>
+          <input type="hidden" name={name} value={value} />
+          <RadioCards.Root
+            {...controlProps}
+            size="1"
+            columns={{ initial: "1", sm: String(field.options?.length ?? 1) }}
+            value={value}
+            onValueChange={(next: string) => handleControlledChange(name, next)}
+            disabled={isDisabled}
+          >
+            {field.options?.map((option) => (
+              <RadioCards.Item
+                key={option.value}
+                value={option.value}
+                disabled={option.disabled}
+              >
+                <Flex direction="column" align="start" gap="1">
+                  <Text size="2" weight="medium">
+                    {option.label}
+                  </Text>
+                  {(option.disabled ? option.disabledReason : option.description) && (
+                    <Text size="1" color="gray">
+                      {option.disabled ? option.disabledReason : option.description}
+                    </Text>
+                  )}
+                </Flex>
+              </RadioCards.Item>
+            ))}
+          </RadioCards.Root>
+        </>
+      );
+    }
+
+    if (field.type === "switch") {
+      const raw = (field.controlled ? field.value : defaultValueFor(field)) === "true";
+      const checked = field.invert ? !raw : raw;
+      return (
+        <>
+          <input type="hidden" name={name} value={String(raw)} />
+          <Flex align="center" gap="2">
+            <Switch
+              {...controlProps}
+              size="2"
+              checked={checked}
+              disabled={isDisabled}
+              onCheckedChange={(next: boolean) =>
+                handleControlledChange(name, String(field.invert ? !next : next))
+              }
+            />
+            {field.switchLabel && <Text size="2">{field.switchLabel}</Text>}
+          </Flex>
+        </>
+      );
+    }
+
+    if (field.type === "select") {
+      // Radix Select has no concept of an empty option: an unset value is the
+      // trigger's placeholder, so only pass a value when there is one.
+      const selected = field.controlled
+        ? field.value || undefined
+        : undefined;
+      const initial = field.controlled ? undefined : defaultValueFor(field) || undefined;
+
+      return (
+        <Select.Root
+          name={name}
+          size="3"
+          required={field.required}
+          disabled={isDisabled}
+          {...(field.controlled
+            ? {
+                value: selected,
+                onValueChange: (value: string) =>
+                  handleControlledChange(name, value),
+              }
+            : { defaultValue: initial })}
+        >
+          <Select.Trigger
+            {...controlProps}
+            placeholder={field.placeholder}
+            style={{ width: "100%" }}
+          />
+          <Select.Content>
+            {field.options?.map((option) => (
+              <Select.Item key={option.value} value={option.value}>
+                {option.label}
+              </Select.Item>
+            ))}
+          </Select.Content>
+        </Select.Root>
+      );
+    }
+
+    return (
+      <TextField.Root
+        {...controlProps}
+        type={field.type}
+        name={name}
+        size="3"
+        placeholder={field.placeholder}
+        required={field.required}
+        disabled={isDisabled}
+        style={field.mono ? monoStyle : undefined}
+        {...(field.controlled
+          ? {
+              value: field.value ?? "",
+              onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
+                trackLength(field, e.target.value);
+                handleControlledChange(name, e.target.value);
+              },
+            }
+          : {
+              defaultValue: defaultValueFor(field),
+              onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+                trackLength(field, e.target.value),
+            })}
+      />
+    );
+  };
+
   return (
     <form onSubmit={handleSubmit} className={className}>
       {/* Hidden fields */}
@@ -138,153 +411,69 @@ export function DynamicForm<T extends Record<string, any>>({
       ))}
 
       <Flex direction="column" gap="4">
-        {fields.map((field) => (
-          <div key={String(field.name)}>
-            <Flex direction="column" gap="1">
-              {field.label && (
-                <Text size="3" weight="medium">
-                  {field.label}
-                </Text>
-              )}
+        {groupBySection(fields).map((group) => {
+          const body = group.fields.map((field) => {
+            const name = String(field.name);
+            const currentValue = field.controlled
+              ? field.value
+              : defaultValueFor(field);
 
-              {field.type === "custom" ? (
-                field.customComponent
-              ) : field.type === "textarea" ? (
-                <textarea
-                  name={String(field.name)}
-                  placeholder={field.placeholder}
-                  required={field.required}
-                  disabled={field.readOnly || disabled}
-                  {...(field.controlled
+            return (
+              <Field
+                key={name}
+                label={field.label}
+                // Neither of these has a single labelable control to point at:
+                // RadioCards.Root is a div[role=radiogroup], and a custom
+                // component never receives the id at all.
+                group={field.type === "radio-cards" || field.type === "custom"}
+                required={field.required}
+                help={field.description}
+                errors={state.fieldErrors?.[name]}
+                counter={
+                  field.maxLength
                     ? {
                         value:
-                          field.value ||
-                          (state.data.get(String(field.name)) as string) ||
-                          "",
-                        onChange: (e) =>
-                          handleControlledChange(
-                            String(field.name),
-                            e.target.value
-                          ),
+                          liveLengths[name] ?? currentValue?.length ?? 0,
+                        max: field.maxLength,
                       }
-                    : {
-                        defaultValue:
-                          (state.data.get(String(field.name)) as string) ||
-                          initialValues?.[String(field.name)] ||
-                          "",
-                      })}
-                  style={{
-                    ...style,
-                    height: "7rem",
-                    resize: "none",
-                  }}
-                />
-              ) : field.type === "select" ? (
-                <select
-                  name={String(field.name)}
-                  required={field.required}
-                  disabled={field.readOnly || disabled}
-                  {...(field.controlled
-                    ? {
-                        value: field.value || "",
-                        onChange: (e) =>
-                          handleControlledChange(
-                            String(field.name),
-                            e.target.value
-                          ),
-                      }
-                    : {
-                        defaultValue:
-                          (state.data.get(String(field.name)) as string) ||
-                          initialValues?.[String(field.name)] ||
-                          "",
-                      })}
-                  style={style}
-                >
-                  {field.placeholder && (
-                    <option value="" disabled>
-                      {field.placeholder}
-                    </option>
-                  )}
-                  {field.options?.map(
-                    (option: { value: string; label: string }) => (
-                      <option key={option.value} value={option.value}>
-                        {option.label}
-                      </option>
-                    )
-                  )}
-                </select>
-              ) : (
-                <input
-                  type={field.type}
-                  name={String(field.name)}
-                  placeholder={field.placeholder}
-                  disabled={field.readOnly || disabled}
-                  required={field.required}
-                  {...(field.controlled
-                    ? {
-                        value: field.value || "",
-                        onChange: (e) =>
-                          handleControlledChange(
-                            String(field.name),
-                            e.target.value
-                          ),
-                      }
-                    : {
-                        defaultValue:
-                          (state.data.get(String(field.name)) as string) ||
-                          initialValues?.[String(field.name)] ||
-                          "",
-                      })}
-                  style={style}
-                />
-              )}
+                    : undefined
+                }
+              >
+                {(controlProps) => (
+                  <>
+                    {renderControl(field, controlProps)}
+                    {/* Real-time validation feedback */}
+                    {field.message}
+                  </>
+                )}
+              </Field>
+            );
+          });
 
-              {field.description && (
-                <Text size="1" color="gray">
-                  {field.description}
-                </Text>
-              )}
+          if (!group.section) {
+            return (
+              <React.Fragment key={group.key}>{body}</React.Fragment>
+            );
+          }
 
-              {/* Real-time validation feedback */}
-              {field.message && <div>{field.message}</div>}
-
-              {/* Server-side validation errors */}
-              {state.fieldErrors?.[String(field.name)]?.map(
-                (error: string, index: number) => (
-                  <Text
-                    size="1"
-                    color="red"
-                    key={`${String(field.name)}-${index}`}
-                  >
-                    {error}
-                  </Text>
-                )
-              )}
-            </Flex>
-          </div>
-        ))}
+          return (
+            <SectionHeader key={group.key} title={group.section}>
+              <Flex direction="column" gap="4">
+                {body}
+              </Flex>
+            </SectionHeader>
+          );
+        })}
 
         {!disabled && (
-          <Flex mt="4" justify="end">
-            <Flex direction="column" gap="2">
-              <Button
-                size="3"
-                type="submit"
-                disabled={
-                  pending || fields.some((field) => field.isValid === false)
-                }
-                loading={pending}
-              >
-                {submitButtonText}
-              </Button>
-              {state?.message && (
-                <Text size="1" color={state.success ? "green" : "red"}>
-                  {state.message}
-                </Text>
-              )}
-            </Flex>
-          </Flex>
+          <FormActions
+            submitLabel={submitButtonText}
+            pending={pending}
+            disabled={fields.some((field) => field.isValid === false)}
+            secondary={secondaryAction}
+            message={state?.message}
+            success={state.success}
+          />
         )}
       </Flex>
     </form>

--- a/src/components/core/DynamicForm.tsx
+++ b/src/components/core/DynamicForm.tsx
@@ -15,6 +15,14 @@ import { Field } from "./Field";
 import { FormActions } from "./FormActions";
 import { SectionHeader } from "./SectionHeader";
 
+/** The wiring Field hands a control so it announces its own label and help. */
+export interface ControlProps {
+  id: string;
+  "aria-describedby"?: string;
+  "aria-invalid"?: boolean;
+  "aria-labelledby"?: string;
+}
+
 /** Controls that render purely from a value prop, so they must be controlled. */
 export type ValueDrivenFieldType = "radio-cards" | "switch";
 
@@ -38,7 +46,15 @@ interface BaseFormField<T extends Record<string, any>> {
   placeholder?: string;
   isValid?: boolean | null;
   message?: React.ReactNode;
-  customComponent?: React.ReactNode; // Custom component for rendering
+  /**
+   * Renders a `custom` field. Prefer the FUNCTION form: it receives the same
+   * ids Field hands its render-prop children, and spreading them onto the real
+   * control is what associates the help text and errors with it. A plain
+   * ReactNode cannot receive them, so it gets wrapped in a group instead —
+   * workable, but weaker, since a description on a wrapper is not announced
+   * with the control inside it.
+   */
+  customComponent?: React.ReactNode | ((props: ControlProps) => React.ReactNode);
   options?: FormFieldOption[]; // Options for select and radio-cards fields
   /** Render the value in the code face — for IDs, emails and URLs. */
   mono?: boolean;
@@ -90,8 +106,6 @@ export interface FormFieldOption {
   /** Shown under the label. `radio-cards` only — a `select` has no room for it. */
   description?: React.ReactNode;
   disabled?: boolean;
-  /** Why the option can't be chosen. Rendered in place of the description. */
-  disabledReason?: React.ReactNode;
 }
 
 export interface FormState<T> {
@@ -280,22 +294,28 @@ export function DynamicForm<T extends Record<string, any>>({
     }
   }, [state.success, state.redirectTo, router]);
 
-  const renderControl = (
-    field: FormField<T>,
-    controlProps: {
-      id: string;
-      "aria-describedby"?: string;
-      "aria-invalid"?: boolean;
-    }
-  ) => {
+  const renderControl = (field: FormField<T>, controlProps: ControlProps) => {
     const name = String(field.name);
     const isDisabled = field.readOnly || disabled;
 
     if (field.type === "custom") {
-      // customComponent is a ReactNode, so it can never receive controlProps —
-      // which means a <label htmlFor> for it could never resolve. Wrap it so the
-      // label and description reach it as a named group instead.
-      return field.label ? (
+      // Given the function form, the caller spreads the ids onto the real
+      // control — the only way a description is genuinely announced with it,
+      // since aria-describedby on a wrapper does not reach the control inside.
+      if (typeof field.customComponent === "function") {
+        return field.customComponent(controlProps);
+      }
+
+      // A ReactNode cannot receive the ids, so wrap it. Wrapping whenever there
+      // is anything to convey — not only when a label exists — because an
+      // unlabelled-but-described field used to drop aria-describedby silently,
+      // which is the exact defect this component exists to prevent.
+      const hasWiring =
+        field.label ||
+        controlProps["aria-describedby"] ||
+        controlProps["aria-invalid"];
+
+      return hasWiring ? (
         <div role="group" {...controlProps}>
           {field.customComponent}
         </div>
@@ -369,18 +389,14 @@ export function DynamicForm<T extends Record<string, any>>({
                     <Text size="2" weight="medium">
                       {option.label}
                     </Text>
-                    {/* The description says what the option IS; the reason says
-                        why it can't be picked. Showing only the reason left a
-                        disabled option unexplained — you could no longer learn
-                        what "Unlisted" means from the card offering it. */}
+                    {/* A card says what the option is, and nothing more. The
+                        greyed-out treatment carries "unavailable" on its own,
+                        and the field's help text already names the dependency,
+                        so repeating a reason on every blocked card was noise —
+                        worse when the connection's name is long. */}
                     {option.description && (
                       <Text size="1" color="gray">
                         {option.description}
-                      </Text>
-                    )}
-                    {option.disabled && option.disabledReason && (
-                      <Text size="1" color="gray" weight="medium">
-                        {option.disabledReason}
                       </Text>
                     )}
                   </Flex>

--- a/src/components/core/DynamicForm.tsx
+++ b/src/components/core/DynamicForm.tsx
@@ -127,6 +127,61 @@ const monoStyle: React.CSSProperties = {
   fontFamily: "var(--code-font-family)",
 };
 
+/**
+ * The selection dot Radix's RadioCards leaves out.
+ *
+ * RadioCards conveys selection with the card border alone. That is a weak cue —
+ * it carries no shape, only weight, so it is easy to miss and it disappears in
+ * grayscale. This redraws the indicator from `<Radio variant="surface">` using
+ * Radix's own public tokens: same size (--space-4), same --accent-indicator fill
+ * with an --accent-contrast dot at 40%, same --gray-a3/--gray-a8 disabled
+ * treatment. Nothing here overrides a Radix class or reaches into its internals.
+ *
+ * It is decorative: RadioCards.Item is still the radio, so this is aria-hidden
+ * and never becomes a second control.
+ */
+function RadioDot({ checked, disabled }: { checked: boolean; disabled?: boolean }) {
+  return (
+    <span
+      aria-hidden
+      style={{
+        position: "relative",
+        display: "inline-block",
+        flexShrink: 0,
+        width: "var(--space-4)",
+        height: "var(--space-4)",
+        marginTop: "2px",
+        borderRadius: "100%",
+        backgroundColor: disabled
+          ? "var(--gray-a3)"
+          : checked
+            ? "var(--accent-indicator)"
+            : "var(--color-surface)",
+        boxShadow:
+          checked && !disabled
+            ? undefined
+            : `inset 0 0 0 1px var(--gray-a${disabled ? "6" : "7"})`,
+      }}
+    >
+      {checked && (
+        <span
+          style={{
+            position: "absolute",
+            inset: 0,
+            margin: "auto",
+            width: "40%",
+            height: "40%",
+            borderRadius: "100%",
+            backgroundColor: disabled
+              ? "var(--gray-a8)"
+              : "var(--accent-contrast)",
+          }}
+        />
+      )}
+    </span>
+  );
+}
+
 /** Runs of consecutive fields sharing a `section`, in declaration order. */
 function groupBySection<T extends Record<string, any>>(fields: FormField<T>[]) {
   const groups: Array<{ key: string; section?: string; fields: FormField<T>[] }> = [];
@@ -299,15 +354,30 @@ export function DynamicForm<T extends Record<string, any>>({
                 value={option.value}
                 disabled={option.disabled}
               >
-                <Flex direction="column" align="start" gap="1">
-                  <Text size="2" weight="medium">
-                    {option.label}
-                  </Text>
-                  {(option.disabled ? option.disabledReason : option.description) && (
-                    <Text size="1" color="gray">
-                      {option.disabled ? option.disabledReason : option.description}
+                <Flex align="start" gap="2">
+                  <RadioDot
+                    checked={value === option.value}
+                    disabled={option.disabled}
+                  />
+                  <Flex direction="column" align="start" gap="1">
+                    <Text size="2" weight="medium">
+                      {option.label}
                     </Text>
-                  )}
+                    {/* The description says what the option IS; the reason says
+                        why it can't be picked. Showing only the reason left a
+                        disabled option unexplained — you could no longer learn
+                        what "Unlisted" means from the card offering it. */}
+                    {option.description && (
+                      <Text size="1" color="gray">
+                        {option.description}
+                      </Text>
+                    )}
+                    {option.disabled && option.disabledReason && (
+                      <Text size="1" color="gray" weight="medium">
+                        {option.disabledReason}
+                      </Text>
+                    )}
+                  </Flex>
                 </Flex>
               </RadioCards.Item>
             ))}

--- a/src/components/core/DynamicForm.tsx
+++ b/src/components/core/DynamicForm.tsx
@@ -353,8 +353,14 @@ export function DynamicForm<T extends Record<string, any>>({
                 key={option.value}
                 value={option.value}
                 disabled={option.disabled}
+                // Radix centres item content on both axes. Options sit in a row
+                // and rarely have equal-length descriptions, so a short card
+                // floats mid-height and indents from the left while its
+                // neighbours start at the top. They have to share a baseline to
+                // read as one set.
+                style={{ alignItems: "flex-start", justifyContent: "flex-start" }}
               >
-                <Flex align="start" gap="2">
+                <Flex align="start" gap="2" width="100%">
                   <RadioDot
                     checked={value === option.value}
                     disabled={option.disabled}

--- a/src/components/core/DynamicForm.tsx
+++ b/src/components/core/DynamicForm.tsx
@@ -356,7 +356,9 @@ export function DynamicForm<T extends Record<string, any>>({
       // Radix RadioCards is not a form control, so the value rides a hidden
       // input. Radio cards are for a handful of options that each need a
       // sentence; anything longer stays a select.
-      const value = field.controlled ? field.value ?? "" : defaultValueFor(field);
+      // Narrowed to ValueDrivenFormField by the discriminant, so `value` is
+      // present and controlled — no uncontrolled fallback to reach.
+      const value = field.value;
       return (
         <>
           <input type="hidden" name={name} value={value} />
@@ -409,7 +411,7 @@ export function DynamicForm<T extends Record<string, any>>({
     }
 
     if (field.type === "switch") {
-      const raw = (field.controlled ? field.value : defaultValueFor(field)) === "true";
+      const raw = field.value === "true";
       const checked = field.invert ? !raw : raw;
       return (
         <>

--- a/src/components/core/Field.tsx
+++ b/src/components/core/Field.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useId } from "react";
+import { Flex, Text } from "@radix-ui/themes";
+
+export interface FieldProps {
+  /** Visible label. Omit only for a control that labels itself (a checkbox group uses `legend`). */
+  label?: React.ReactNode;
+  /**
+   * `id` of the control this labels. Defaults to a generated id, which `Field`
+   * passes to a single child element via `render`.
+   */
+  htmlFor?: string;
+  required?: boolean;
+  /** Guidance shown between the label and the control. */
+  help?: React.ReactNode;
+  /** Server-side validation errors for this field. */
+  errors?: string[];
+  /**
+   * Character count, for controls with a real enforced maximum. Caller-driven:
+   * Field wraps the control rather than owning it, so it cannot read the value
+   * itself and will render whatever number it is handed. `DynamicForm` computes
+   * this for any field declaring `maxLength`; drive it from state when using
+   * Field directly, or the count will not move as the user types.
+   */
+  counter?: { value: number; max: number };
+  /** Rendered on the label row, opposite the label (e.g. "Managed elsewhere"). */
+  aside?: React.ReactNode;
+  /**
+   * For a set of controls rather than one — a checkbox group, radio cards, or a
+   * read-only display. There is no single control to point a `<label>` at, so
+   * the label becomes the group's accessible name instead.
+   */
+  group?: boolean;
+  /**
+   * Renders the control. Prefer the FUNCTION form: it receives the ids to wire
+   * up, and spreading them onto the control is what associates the label, help
+   * text and errors with it. A plain element is only correct alongside `group`,
+   * or when you pass `htmlFor` and set that id on the control yourself.
+   */
+  children:
+    | React.ReactNode
+    | ((props: {
+        id: string;
+        "aria-describedby"?: string;
+        "aria-invalid"?: boolean;
+        /** Set only with `group`: the label is not a <label>, so name by id. */
+        "aria-labelledby"?: string;
+      }) => React.ReactNode);
+}
+
+/**
+ * The one field anatomy: label, help, control, error.
+ *
+ * Everything a field needs to be announced correctly — the generated id, the
+ * label association, `aria-describedby` covering both the help text and any
+ * errors, `aria-invalid` — is wired here so no caller has to remember it. The
+ * control is a child rather than a `type` union, which is what lets the same
+ * component wrap a text input, a select, a checkbox group or a dropzone.
+ */
+export function Field({
+  label,
+  htmlFor,
+  required,
+  help,
+  errors,
+  counter,
+  aside,
+  group,
+  children,
+}: FieldProps) {
+  const generatedId = useId();
+  const id = htmlFor ?? generatedId;
+  const labelId = `${id}-label`;
+  const helpId = help ? `${id}-help` : undefined;
+  const errorId = errors?.length ? `${id}-error` : undefined;
+  const describedBy = [helpId, errorId].filter(Boolean).join(" ") || undefined;
+
+  const labelContent = label && (
+    <>
+      {label}
+      {required && (
+        <>
+          {" "}
+          <Text color="red" aria-hidden="true">
+            *
+          </Text>
+          <span className="sr-only"> (required)</span>
+        </>
+      )}
+    </>
+  );
+
+  return (
+    <Flex direction="column" gap="1">
+      {(label || aside || counter) && (
+        <Flex align="baseline" justify="between" gap="3">
+          {label &&
+            (group ? (
+              // No single control owns this, so the label names the group via
+              // aria-labelledby rather than pointing htmlFor at nothing.
+              <Text as="div" id={labelId} size="2" weight="medium">
+                {labelContent}
+              </Text>
+            ) : (
+              <Text as="label" size="2" weight="medium" htmlFor={id}>
+                {labelContent}
+              </Text>
+            ))}
+          {counter && (
+            <Text
+              size="1"
+              color={counter.value > counter.max ? "red" : "gray"}
+              style={{ fontFamily: "var(--code-font-family)" }}
+            >
+              {counter.value} / {counter.max}
+            </Text>
+          )}
+          {aside}
+        </Flex>
+      )}
+
+      {help && (
+        <Text size="1" color="gray" id={helpId}>
+          {help}
+        </Text>
+      )}
+
+      {typeof children === "function" ? (
+        children({
+          id,
+          "aria-describedby": describedBy,
+          "aria-invalid": errors?.length ? true : undefined,
+          // With `group` the label is a <div>, not a <label>, so htmlFor buys
+          // nothing — the control has to name itself by pointing at it.
+          ...(group && label ? { "aria-labelledby": labelId } : {}),
+        })
+      ) : group ? (
+        <div
+          role="group"
+          aria-labelledby={label ? labelId : undefined}
+          aria-describedby={describedBy}
+        >
+          {children}
+        </div>
+      ) : (
+        children
+      )}
+
+      {/* One container carries the id, so aria-describedby covers every error.
+          Tagging only the first meant a screen reader announced one message and
+          silently dropped the rest — and zod's flatten() returns an array per
+          field precisely because several checks can fail at once. */}
+      {errors?.length ? (
+        <Flex direction="column" gap="1" id={errorId}>
+          {errors.map((error, index) => (
+            <Text size="1" color="red" key={`${id}-${index}`}>
+              {error}
+            </Text>
+          ))}
+        </Flex>
+      ) : null}
+    </Flex>
+  );
+}

--- a/src/components/core/FormActions.tsx
+++ b/src/components/core/FormActions.tsx
@@ -1,0 +1,43 @@
+import { Button, Flex, Text } from "@radix-ui/themes";
+
+interface FormActionsProps {
+  submitLabel: string;
+  pending?: boolean;
+  disabled?: boolean;
+  /**
+   * Secondary action rendered beside the submit button — a Cancel or a
+   * Dialog.Close. Passing it here rather than as a sibling of the form keeps a
+   * dialog to one action row instead of two stacked ones.
+   */
+  secondary?: React.ReactNode;
+  /** Status line for the last submission. */
+  message?: string;
+  /** Colours the message: green on success, red otherwise. */
+  success?: boolean;
+}
+
+/** The single action row a form ends with. */
+export function FormActions({
+  submitLabel,
+  pending,
+  disabled,
+  secondary,
+  message,
+  success,
+}: FormActionsProps) {
+  return (
+    <Flex mt="4" direction="column" gap="2" align="end">
+      <Flex align="center" gap="3">
+        {message && (
+          <Text size="1" color={success ? "green" : "red"}>
+            {message}
+          </Text>
+        )}
+        {secondary}
+        <Button size="3" type="submit" disabled={disabled || pending} loading={pending}>
+          {submitLabel}
+        </Button>
+      </Flex>
+    </Flex>
+  );
+}

--- a/src/components/core/SectionHeader.tsx
+++ b/src/components/core/SectionHeader.tsx
@@ -2,12 +2,15 @@ import { Text, Box, Separator, Flex } from "@radix-ui/themes";
 
 interface SectionHeaderProps {
   title: string;
+  /** One line on what the section is for, shown under the title. */
+  description?: React.ReactNode;
   children?: React.ReactNode;
   rightButton?: React.ReactNode;
 }
 
 export function SectionHeader({
   title,
+  description,
   children,
   rightButton,
 }: SectionHeaderProps) {
@@ -19,6 +22,11 @@ export function SectionHeader({
         </Text>
         {rightButton}
       </Flex>
+      {description && (
+        <Text as="p" size="1" color="gray" mt="1">
+          {description}
+        </Text>
+      )}
       <Box my="3">
         <Separator size="4" color="gray" />
       </Box>

--- a/src/components/core/__tests__/DynamicForm.test.tsx
+++ b/src/components/core/__tests__/DynamicForm.test.tsx
@@ -1,0 +1,181 @@
+// jest resolves react@18.3.1, which has no useActionState (it arrives in 19,
+// and the app only gets it through Next's bundled runtime). Without this shim
+// DynamicForm cannot be rendered here at all — which is how two label-wiring
+// bugs reached review: Field's own tests exercise Field, never the dispatch in
+// renderControl that decides which control each field type gets.
+// Add the one missing export to the real module rather than returning a copy:
+// babel's interop enumerates own keys, so neither a spread nor a Proxy survives
+// it — and a copy also loses `default`/`__esModule`.
+jest.mock("react", () => {
+  const actual = jest.requireActual("react");
+  actual.useActionState ??= (_action: unknown, initial: unknown) => [
+    initial,
+    () => {},
+    false,
+  ];
+  return actual;
+});
+
+import { render, screen } from "@testing-library/react";
+import { Theme } from "@radix-ui/themes";
+import { DynamicForm, type FormField, type FormState } from "../DynamicForm";
+
+// jsdom has no ResizeObserver; Radix's Select, Switch and RadioCards all use it.
+global.ResizeObserver ??= class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+} as unknown as typeof ResizeObserver;
+
+type Demo = Record<string, string>;
+
+const noop = (): FormState<Demo> => ({
+  fieldErrors: {},
+  data: new FormData(),
+  message: "",
+  success: false,
+});
+
+const renderForm = (fields: FormField<Demo>[]) =>
+  render(
+    <Theme>
+      <DynamicForm<Demo> fields={fields} action={noop} />
+    </Theme>
+  );
+
+describe("DynamicForm label wiring", () => {
+  it("labels a text field by pointing at its control", () => {
+    renderForm([{ label: "Name", name: "name", type: "text" }]);
+
+    expect(screen.getByLabelText("Name")).toBeInTheDocument();
+  });
+
+  it("labels a select by its trigger", () => {
+    renderForm([
+      {
+        label: "Role",
+        name: "role",
+        type: "select",
+        options: [{ value: "read", label: "Reader" }],
+      },
+    ]);
+
+    expect(screen.getByLabelText("Role")).toBeInTheDocument();
+  });
+
+  it("names a radio-cards group rather than pointing a label at a div", () => {
+    // RadioCards.Root renders div[role=radiogroup], which htmlFor cannot reach.
+    renderForm([
+      {
+        label: "Visibility",
+        name: "visibility",
+        type: "radio-cards",
+        controlled: true,
+        value: "public",
+        onValueChange: () => {},
+        options: [
+          { value: "public", label: "Public" },
+          { value: "unlisted", label: "Unlisted" },
+        ],
+      },
+    ]);
+
+    expect(screen.getByRole("radiogroup")).toHaveAccessibleName("Visibility");
+  });
+
+  it("names a custom field's group — customComponent never receives the id", () => {
+    renderForm([
+      {
+        label: "Websites",
+        name: "websites",
+        type: "custom",
+        customComponent: <input name="websites" aria-label="Website URL" />,
+      },
+    ]);
+
+    expect(screen.getByRole("group")).toHaveAccessibleName("Websites");
+  });
+
+  it("leaves an unlabelled custom field unwrapped", () => {
+    renderForm([
+      {
+        name: "flags",
+        type: "custom",
+        customComponent: <input name="flags" aria-label="Admin" />,
+      },
+    ]);
+
+    expect(screen.queryByRole("group")).toBeNull();
+  });
+
+  it("labels a switch by its button, which is labelable", () => {
+    renderForm([
+      {
+        label: "Status",
+        name: "disabled",
+        type: "switch",
+        controlled: true,
+        value: "false",
+        onValueChange: () => {},
+      },
+    ]);
+
+    expect(screen.getByLabelText("Status")).toBeInTheDocument();
+  });
+
+  it("leaves no label pointing at an id that does not exist", () => {
+    // The defect this whole refactor exists to prevent, asserted across every
+    // field type at once.
+    renderForm([
+      { label: "Name", name: "name", type: "text" },
+      { label: "Bio", name: "bio", type: "textarea" },
+      {
+        label: "Role",
+        name: "role",
+        type: "select",
+        options: [{ value: "read", label: "Reader" }],
+      },
+      {
+        label: "Visibility",
+        name: "visibility",
+        type: "radio-cards",
+        controlled: true,
+        value: "public",
+        onValueChange: () => {},
+        options: [{ value: "public", label: "Public" }],
+      },
+      {
+        label: "Status",
+        name: "st",
+        type: "switch",
+        controlled: true,
+        value: "false",
+        onValueChange: () => {},
+      },
+      {
+        label: "Websites",
+        name: "websites",
+        type: "custom",
+        customComponent: <input name="websites" aria-label="Website URL" />,
+      },
+    ]);
+
+    // htmlFor only associates with *labelable* elements. Pointing it at a div
+    // — RadioCards.Root is div[role=radiogroup] — resolves to a node but names
+    // nothing, so checking the id merely exists is not enough.
+    const LABELABLE = ["INPUT", "SELECT", "TEXTAREA", "BUTTON", "METER", "OUTPUT", "PROGRESS"];
+
+    const broken = Array.from(
+      document.querySelectorAll<HTMLLabelElement>("label[for]")
+    )
+      .map((label) => ({
+        text: label.textContent,
+        target: document.getElementById(label.htmlFor),
+      }))
+      .filter(({ target }) => !target || !LABELABLE.includes(target.tagName));
+
+    expect(
+      broken.map((b) => `${b.text} -> ${b.target?.tagName ?? "MISSING"}`)
+    ).toEqual([]);
+  });
+});

--- a/src/components/core/__tests__/DynamicForm.test.tsx
+++ b/src/components/core/__tests__/DynamicForm.test.tsx
@@ -96,6 +96,46 @@ describe("DynamicForm label wiring", () => {
     expect(screen.getByRole("group")).toHaveAccessibleName("Websites");
   });
 
+  it("hands a custom field's function form the ids to wire up itself", () => {
+    // The only way a description is genuinely announced with a custom control:
+    // aria-describedby on a wrapper does not reach the control inside it.
+    renderForm([
+      {
+        name: "flag",
+        type: "custom",
+        description: "Allows this account to create products.",
+        customComponent: (controlProps) => (
+          <label htmlFor="flag-box">
+            <input {...controlProps} id="flag-box" type="checkbox" name="flag" />
+            Create products
+          </label>
+        ),
+      },
+    ]);
+
+    const box = screen.getByLabelText("Create products");
+    const describedBy = box.getAttribute("aria-describedby") ?? "";
+    expect(describedBy).not.toEqual("");
+    expect(document.getElementById(describedBy.split(" ")[0])).toHaveTextContent(
+      "Allows this account to create products."
+    );
+  });
+
+  it("wraps an unlabelled custom field that still has a description", () => {
+    // Previously the wrapper was gated on `label`, so a described-but-unlabelled
+    // custom field dropped aria-describedby silently.
+    renderForm([
+      {
+        name: "flag",
+        type: "custom",
+        description: "Allows this account to create products.",
+        customComponent: <input name="flag" aria-label="Create products" />,
+      },
+    ]);
+
+    expect(screen.getByRole("group")).toHaveAttribute("aria-describedby");
+  });
+
   it("leaves an unlabelled custom field unwrapped", () => {
     renderForm([
       {

--- a/src/components/core/__tests__/Field.test.tsx
+++ b/src/components/core/__tests__/Field.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen } from "@testing-library/react";
+import { Theme } from "@radix-ui/themes";
+import { TextField } from "@radix-ui/themes";
+import { Field } from "../Field";
+
+// The point of Field is the wiring nobody remembers: label association and the
+// describedby/invalid attributes. If those break, everything downstream reads
+// as an unlabelled box to a screen reader, and nothing else would notice.
+const renderInTheme = (ui: React.ReactElement) =>
+  render(<Theme>{ui}</Theme>);
+
+describe("Field", () => {
+  it("associates the label with the control it wraps", () => {
+    renderInTheme(
+      <Field label="Bucket">
+        {(props) => <TextField.Root {...props} name="bucket" />}
+      </Field>
+    );
+
+    expect(screen.getByLabelText("Bucket")).toBeInTheDocument();
+  });
+
+  it("honours an explicit htmlFor", () => {
+    renderInTheme(
+      <Field label="Region" htmlFor="region-input">
+        <TextField.Root id="region-input" name="region" />
+      </Field>
+    );
+
+    expect(screen.getByLabelText("Region")).toHaveAttribute("id", "region-input");
+  });
+
+  it("describes the control with its help text", () => {
+    renderInTheme(
+      <Field label="Bucket" help="Name of the S3 bucket.">
+        {(props) => <TextField.Root {...props} name="bucket" />}
+      </Field>
+    );
+
+    const input = screen.getByLabelText("Bucket");
+    const describedBy = input.getAttribute("aria-describedby") ?? "";
+    expect(describedBy).not.toEqual("");
+    expect(document.getElementById(describedBy.split(" ")[0])).toHaveTextContent(
+      "Name of the S3 bucket."
+    );
+  });
+
+  it("marks the control invalid and points at the error", () => {
+    renderInTheme(
+      <Field label="Bucket" help="Name of the S3 bucket." errors={["Bucket is required"]}>
+        {(props) => <TextField.Root {...props} name="bucket" />}
+      </Field>
+    );
+
+    const input = screen.getByLabelText("Bucket");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+
+    const ids = (input.getAttribute("aria-describedby") ?? "").split(" ");
+    const described = ids.map((id) => document.getElementById(id)?.textContent).join(" ");
+    expect(described).toContain("Name of the S3 bucket.");
+    expect(described).toContain("Bucket is required");
+  });
+
+  it("describes the control with every error, not just the first", () => {
+    // zod's flatten() returns an array per field because several checks can
+    // fail at once; tagging only the first error dropped the rest silently.
+    renderInTheme(
+      <Field label="Bucket" errors={["Bucket is required", "Must be lowercase"]}>
+        {(props) => <TextField.Root {...props} name="bucket" />}
+      </Field>
+    );
+
+    const input = screen.getByLabelText("Bucket");
+    const described = (input.getAttribute("aria-describedby") ?? "")
+      .split(" ")
+      .map((id) => document.getElementById(id)?.textContent)
+      .join(" ");
+
+    expect(described).toContain("Bucket is required");
+    expect(described).toContain("Must be lowercase");
+  });
+
+  it("leaves the control valid when there are no errors", () => {
+    renderInTheme(
+      <Field label="Bucket">
+        {(props) => <TextField.Root {...props} name="bucket" />}
+      </Field>
+    );
+
+    expect(screen.getByLabelText("Bucket")).not.toHaveAttribute("aria-invalid");
+  });
+
+  it("names a group instead of pointing a label at nothing", () => {
+    // A set of controls has no single element to own the id. The plain-children
+    // path used to emit <label htmlFor> against an id that existed nowhere,
+    // which is how ~20 DataConnectionForm fields shipped unwired.
+    renderInTheme(
+      <Field label="Allowed visibilities" help="Which visibilities may be used." group>
+        <TextField.Root name="a" />
+      </Field>
+    );
+
+    const group = screen.getByRole("group");
+    expect(group).toHaveAccessibleName("Allowed visibilities");
+    expect(document.querySelector("label[for]")).toBeNull();
+  });
+
+  it("hands a group's render-prop child an aria-labelledby to name itself", () => {
+    // RadioCards.Root is a div[role=radiogroup] and a custom component never
+    // receives the id — neither can be named by htmlFor, so Field passes the
+    // label's id through for the control to point at.
+    renderInTheme(
+      <Field label="Visibility" group>
+        {(props) => (
+          <div role="radiogroup" {...props}>
+            <span>Public</span>
+          </div>
+        )}
+      </Field>
+    );
+
+    expect(screen.getByRole("radiogroup")).toHaveAccessibleName("Visibility");
+  });
+
+  it("omits aria-labelledby when the field is not a group", () => {
+    renderInTheme(
+      <Field label="Bucket">
+        {(props) => <TextField.Root {...props} name="bucket" />}
+      </Field>
+    );
+
+    expect(screen.getByLabelText("Bucket")).not.toHaveAttribute(
+      "aria-labelledby"
+    );
+  });
+
+  it("renders a counter against the enforced maximum", () => {
+    renderInTheme(
+      <Field label="Bio" counter={{ value: 74, max: 1024 }}>
+        {(props) => <TextField.Root {...props} name="bio" />}
+      </Field>
+    );
+
+    expect(screen.getByText("74 / 1024")).toBeInTheDocument();
+  });
+});

--- a/src/components/core/index.ts
+++ b/src/components/core/index.ts
@@ -1,5 +1,9 @@
 export { MonoText } from "./MonoText";
 export { SectionHeader } from "./SectionHeader";
+export { Field } from "./Field";
+export type { FieldProps } from "./Field";
+export { FormActions } from "./FormActions";
+export { DangerZone } from "./DangerZone";
 export { Skeleton } from "./Skeleton";
 export { FormSkeleton } from "./FormSkeleton";
 export { FormTitle } from "./FormTitle";

--- a/src/components/features/accounts/AccountFlagsForm.tsx
+++ b/src/components/features/accounts/AccountFlagsForm.tsx
@@ -90,10 +90,14 @@ export function AccountFlagsForm({ session, account }: AccountFlagsFormProps) {
         name,
         description,
         type: "custom" as const,
-        customComponent: (
+        // Function form: the checkbox itself takes aria-describedby, so each
+        // flag's explanation is announced with it. As a plain node the ids had
+        // nowhere to land and the description sat unassociated.
+        customComponent: (controlProps) => (
           <Label.Root htmlFor={name}>
             <Flex align="center" gap="2">
               <Checkbox
+                {...controlProps}
                 name={name}
                 id={name}
                 checked={flagValues[name]}

--- a/src/components/features/accounts/InviteMemberForm.tsx
+++ b/src/components/features/accounts/InviteMemberForm.tsx
@@ -68,6 +68,8 @@ export function InviteMemberForm({
           Invite a user to join {organization.name} as a member.
         </Dialog.Description>
 
+        {/* Cancel goes through the form's own action row — as a sibling of the
+            form it produced a second right-aligned row under the submit. */}
         <DynamicForm<InviteMemberFormData>
           fields={fields}
           action={inviteMember}
@@ -80,15 +82,14 @@ export function InviteMemberForm({
             product_id: product?.product_id,
           }}
           onSuccess={() => setOpen(false)}
+          secondaryAction={
+            <Dialog.Close>
+              <Button type="button" size="3" variant="soft" color="gray">
+                Cancel
+              </Button>
+            </Dialog.Close>
+          }
         />
-
-        <Flex gap="3" mt="4" justify="end">
-          <Dialog.Close>
-            <Button variant="soft" color="gray">
-              Cancel
-            </Button>
-          </Dialog.Close>
-        </Flex>
       </Dialog.Content>
     </Dialog.Root>
   );

--- a/src/components/features/data-connections/DataConnectionForm.tsx
+++ b/src/components/features/data-connections/DataConnectionForm.tsx
@@ -295,7 +295,7 @@ export function DataConnectionForm({
 
         <Field
           label="Allowed Visibilities"
-          help="Product visibilities permitted to use this connection. (Not currently enforced.)"
+          help="Which visibilities a product on this connection may use. Checked when a product is created and whenever its visibility changes."
           errors={state.fieldErrors?.allowed_visibilities}
           group
         >
@@ -321,7 +321,7 @@ export function DataConnectionForm({
         {!ownerAccountId && (
           <Field
             label="Required Flag"
-            help="Account flag a user must have for their products to use this connection. Choose None for no restriction. (Not currently enforced.)"
+            help="Account flag an owner must hold before this connection can back their products. Choose None for no restriction."
             errors={state.fieldErrors?.required_flag}
           >
             {(props) => (

--- a/src/components/features/data-connections/DataConnectionForm.tsx
+++ b/src/components/features/data-connections/DataConnectionForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useActionState, startTransition } from "react";
-import { Button, Text, Flex, Checkbox, Code } from "@radix-ui/themes";
+import { Text, Flex, Checkbox, Code, Select, TextField } from "@radix-ui/themes";
 import { CopyToClipboard } from "@/components/core/CopyToClipboard";
 import { useRouter } from "next/navigation";
 import {
@@ -12,7 +12,7 @@ import {
   ProductVisibility,
   AccountFlags,
 } from "@/types";
-import { formFieldStyle as fieldStyle } from "@/components/core/DynamicForm";
+import { Field, FormActions } from "@/components/core";
 import {
   createDataConnection,
   updateDataConnection,
@@ -81,51 +81,8 @@ const AUTH_TYPE_DESCRIPTIONS: Partial<
     "Keyless: the proxy federates into a GCP service account via Workload Identity.",
 };
 
-function FieldErrors({ errors, name }: { errors?: string[]; name: string }) {
-  if (!errors?.length) return null;
-  return (
-    <>
-      {errors.map((error, index) => (
-        <Text size="1" color="red" key={`${name}-${index}`}>
-          {error}
-        </Text>
-      ))}
-    </>
-  );
-}
-
-/**
- * Labelled field wrapper: renders the label, a gray description of what the
- * field does, the control, and any server-side validation errors.
- */
-function Field({
-  label,
-  name,
-  description,
-  errors,
-  children,
-}: {
-  label: string;
-  name: string;
-  description?: React.ReactNode;
-  errors?: string[];
-  children: React.ReactNode;
-}) {
-  return (
-    <Flex direction="column" gap="1">
-      <Text size="3" weight="medium">
-        {label}
-      </Text>
-      {description && (
-        <Text size="1" color="gray">
-          {description}
-        </Text>
-      )}
-      {children}
-      <FieldErrors name={name} errors={errors} />
-    </Flex>
-  );
-}
+// Radix Select has no empty-string item value; this stands in for "unset".
+const NONE = "__none__";
 
 export function DataConnectionForm({
   dataConnection,
@@ -157,6 +114,23 @@ export function DataConnectionForm({
 
   const [authType, setAuthType] = useState<string>(
     dataConnection?.authentication?.type || ""
+  );
+
+  // Controlled for the same reason as the checkboxes below: a Radix Select is
+  // not a native form control that re-seeds itself from `state.data` after a
+  // failed submit, so the user's choice lives in state.
+  const [requiredFlag, setRequiredFlag] = useState<string>(
+    dataConnection?.required_flag ?? ""
+  );
+  const [s3Region, setS3Region] = useState<string>(
+    dataConnection?.details.provider === DataProvider.S3
+      ? dataConnection.details.region
+      : ""
+  );
+  const [azureRegion, setAzureRegion] = useState<string>(
+    dataConnection?.details.provider === DataProvider.Azure
+      ? dataConnection.details.region
+      : ""
   );
 
   // Controlled so the user's selections survive a re-render after a failed
@@ -235,76 +209,77 @@ export function DataConnectionForm({
         )}
         <Field
           label="Connection ID"
-          name="data_connection_id"
-          description={
+          help={
             ownerAccountId && mode === "create"
               ? `Lowercase letters, numbers, and hyphens only. It will be stored as ${ownerAccountId}--<id>; cannot be changed after creation.`
               : "Unique identifier used in URLs and as the storage key. Lowercase letters, numbers, and hyphens only; cannot be changed after creation."
           }
           errors={state.fieldErrors?.data_connection_id}
         >
-          <input
-            type="text"
-            name="data_connection_id"
-            required
-            placeholder="my-data-connection"
-            readOnly={mode === "edit"}
-            defaultValue={
-              (state.data.get("data_connection_id") as string) ||
-              dataConnection?.data_connection_id ||
-              ""
-            }
-            style={{
-              ...fieldStyle,
-              ...(mode === "edit"
-                ? { backgroundColor: "var(--gray-3)", cursor: "not-allowed" }
-                : {}),
-            }}
-          />
+          {(props) => (
+            <TextField.Root
+              {...props}
+              type="text"
+              name="data_connection_id"
+              required
+              placeholder="my-data-connection"
+              readOnly={mode === "edit"}
+              defaultValue={
+                (state.data.get("data_connection_id") as string) ||
+                dataConnection?.data_connection_id ||
+                ""
+              }
+              variant={mode === "edit" ? "soft" : "surface"}
+            />
+          )}
         </Field>
 
         <Field
           label="Name"
-          name="name"
-          description="Human-readable label shown in admin lists and the product mirror picker."
+          help="Human-readable label shown in admin lists and the product mirror picker."
           errors={state.fieldErrors?.name}
         >
-          <input
-            type="text"
-            name="name"
-            required
-            defaultValue={
-              (state.data.get("name") as string) || dataConnection?.name || ""
-            }
-            style={fieldStyle}
-          />
+          {(props) => (
+            <TextField.Root
+              {...props}
+              type="text"
+              name="name"
+              required
+              defaultValue={
+                (state.data.get("name") as string) || dataConnection?.name || ""
+              }
+              size="3"
+            />
+          )}
         </Field>
 
         <Field
           label="Prefix Template"
-          name="prefix_template"
-          description="Template for the object-key prefix each product receives within the bucket/container. {{repository.account_id}} and {{repository.repository_id}} are substituted when a product attaches this connection. Example: {{repository.account_id}}/{{repository.repository_id}}/"
+          help="Template for the object-key prefix each product receives within the bucket/container. {{repository.account_id}} and {{repository.repository_id}} are substituted when a product attaches this connection. Example: {{repository.account_id}}/{{repository.repository_id}}/"
           errors={state.fieldErrors?.prefix_template}
         >
-          <input
-            type="text"
-            name="prefix_template"
-            defaultValue={
-              // has()-check, not ||: preserve a user-cleared value across a
-              // failed submit instead of reverting to the stored value.
-              state.data.has("prefix_template")
-                ? (state.data.get("prefix_template") as string)
-                : (dataConnection?.prefix_template ?? "")
-            }
-            style={fieldStyle}
-          />
+          {(props) => (
+            <TextField.Root
+              {...props}
+              type="text"
+              name="prefix_template"
+              defaultValue={
+                // has()-check, not ||: preserve a user-cleared value across a
+                // failed submit instead of reverting to the stored value.
+                state.data.has("prefix_template")
+                  ? (state.data.get("prefix_template") as string)
+                  : (dataConnection?.prefix_template ?? "")
+              }
+              size="3"
+            />
+          )}
         </Field>
 
         <Field
           label="Read Only"
-          name="read_only"
-          description="Prevents products from writing or modifying data through this connection — browse and download only. Required for unsigned (no-auth) connections."
+          help="Prevents products from writing or modifying data through this connection — browse and download only. Required for unsigned (no-auth) connections."
           errors={state.fieldErrors?.read_only}
+          group
         >
           <Flex align="center" gap="2" asChild>
             <label>
@@ -320,9 +295,9 @@ export function DataConnectionForm({
 
         <Field
           label="Allowed Visibilities"
-          name="allowed_visibilities"
-          description="Product visibilities permitted to use this connection. (Not currently enforced.)"
+          help="Product visibilities permitted to use this connection. (Not currently enforced.)"
           errors={state.fieldErrors?.allowed_visibilities}
+          group
         >
           <Flex direction="column" gap="2">
             {Object.values(ProductVisibility).map((visibility) => (
@@ -346,49 +321,64 @@ export function DataConnectionForm({
         {!ownerAccountId && (
           <Field
             label="Required Flag"
-            name="required_flag"
-            description="Account flag a user must have for their products to use this connection. Choose None for no restriction. (Not currently enforced.)"
+            help="Account flag a user must have for their products to use this connection. Choose None for no restriction. (Not currently enforced.)"
             errors={state.fieldErrors?.required_flag}
           >
-            <select
-              name="required_flag"
-              defaultValue={
-                // has()-check, not ||: a user-selected "None" ("") must survive a
-                // failed submit instead of reverting to the stored flag.
-                state.data.has("required_flag")
-                  ? (state.data.get("required_flag") as string)
-                  : (dataConnection?.required_flag ?? "")
-              }
-              style={fieldStyle}
-            >
-              <option value="">None</option>
-              {Object.values(AccountFlags).map((flag) => (
-                <option key={flag} value={flag}>
-                  {flag}
-                </option>
-              ))}
-            </select>
+            {(props) => (
+              <>
+                {/* The Select is UI only; the hidden input carries "" for None,
+                    which Radix cannot express as an item value. */}
+                <input type="hidden" name="required_flag" value={requiredFlag} />
+                <Select.Root
+                  size="3"
+                  value={requiredFlag || NONE}
+                  onValueChange={(value) =>
+                    setRequiredFlag(value === NONE ? "" : value)
+                  }
+                >
+                  <Select.Trigger
+                    {...props}
+                    style={{ width: "100%" }}
+                  />
+                  <Select.Content>
+                    <Select.Item value={NONE}>None</Select.Item>
+                    {Object.values(AccountFlags).map((flag) => (
+                      <Select.Item key={flag} value={flag}>
+                        {flag}
+                      </Select.Item>
+                    ))}
+                  </Select.Content>
+                </Select.Root>
+              </>
+            )}
           </Field>
         )}
 
         <Field
           label="Provider"
-          name="provider"
-          description="Storage backend type. Determines the connection and authentication fields shown below."
+          help="Storage backend type. Determines the connection and authentication fields shown below."
           errors={state.fieldErrors?.provider}
         >
-          <select
-            name="provider"
-            value={provider}
-            onChange={(e) => handleProviderChange(e.target.value)}
-            style={fieldStyle}
-          >
-            {providerOptions.map((p) => (
-              <option key={p.value} value={p.value}>
-                {p.label}
-              </option>
-            ))}
-          </select>
+          {(props) => (
+            <Select.Root
+              name="provider"
+              size="3"
+              value={provider}
+              onValueChange={handleProviderChange}
+            >
+              <Select.Trigger
+                {...props}
+                style={{ width: "100%" }}
+              />
+              <Select.Content>
+                {providerOptions.map((p) => (
+                  <Select.Item key={p.value} value={p.value}>
+                    {p.label}
+                  </Select.Item>
+                ))}
+              </Select.Content>
+            </Select.Root>
+          )}
         </Field>
 
         {/* Provider-specific fields */}
@@ -396,87 +386,94 @@ export function DataConnectionForm({
           <>
             <Field
               label="Bucket"
-              name="bucket"
-              description="Name of the S3 bucket that stores the data."
+              help="Name of the S3 bucket that stores the data."
               errors={state.fieldErrors?.bucket}
             >
-              <input
-                type="text"
-                name="bucket"
-                defaultValue={
-                  (state.data.get("bucket") as string) ||
-                  (dataConnection?.details.provider === DataProvider.S3
-                    ? dataConnection.details.bucket
-                    : "")
-                }
-                style={fieldStyle}
-              />
+              {(props) => (
+                <TextField.Root
+                  {...props}
+                  type="text"
+                  name="bucket"
+                  defaultValue={
+                    (state.data.get("bucket") as string) ||
+                    (dataConnection?.details.provider === DataProvider.S3
+                      ? dataConnection.details.bucket
+                      : "")
+                  }
+                  size="3"
+                />
+              )}
             </Field>
 
             <Field
               label="Base Prefix"
-              name="base_prefix"
-              description="Optional key prefix prepended to every object path in the bucket (a shared root folder). Leave blank for the bucket root."
+              help="Optional key prefix prepended to every object path in the bucket (a shared root folder). Leave blank for the bucket root."
               errors={state.fieldErrors?.base_prefix}
             >
-              <input
-                type="text"
-                name="base_prefix"
-                defaultValue={
-                  (state.data.get("base_prefix") as string) ||
-                  (dataConnection?.details.provider === DataProvider.S3
-                    ? dataConnection.details.base_prefix
-                    : "")
-                }
-                style={fieldStyle}
-              />
+              {(props) => (
+                <TextField.Root
+                  {...props}
+                  type="text"
+                  name="base_prefix"
+                  defaultValue={
+                    (state.data.get("base_prefix") as string) ||
+                    (dataConnection?.details.provider === DataProvider.S3
+                      ? dataConnection.details.base_prefix
+                      : "")
+                  }
+                  size="3"
+                />
+              )}
             </Field>
 
             <Field
               label="Region"
-              name="region"
-              description="AWS region the bucket is hosted in. Use “auto” for S3-compatible backends like Cloudflare R2."
+              help="AWS region the bucket is hosted in. Use “auto” for S3-compatible backends like Cloudflare R2."
               errors={state.fieldErrors?.region}
             >
-              <select
-                name="region"
-                defaultValue={
-                  (state.data.get("region") as string) ||
-                  (dataConnection?.details.provider === DataProvider.S3
-                    ? dataConnection.details.region
-                    : "")
-                }
-                style={fieldStyle}
-              >
-                <option value="" disabled>
-                  Select a region
-                </option>
-                {Object.values(S3Regions).map((region) => (
-                  <option key={region} value={region}>
-                    {region}
-                  </option>
-                ))}
-              </select>
+              {(props) => (
+                <Select.Root
+                  name="region"
+                  size="3"
+                  value={s3Region || undefined}
+                  onValueChange={setS3Region}
+                >
+                  <Select.Trigger
+                    {...props}
+                    placeholder="Select a region"
+                    style={{ width: "100%" }}
+                  />
+                  <Select.Content>
+                    {Object.values(S3Regions).map((region) => (
+                      <Select.Item key={region} value={region}>
+                        {region}
+                      </Select.Item>
+                    ))}
+                  </Select.Content>
+                </Select.Root>
+              )}
             </Field>
 
             <Field
               label="Endpoint"
-              name="endpoint"
-              description="Custom S3-compatible endpoint for non-AWS backends (Cloudflare R2, MinIO, Ceph). Leave blank for AWS S3."
+              help="Custom S3-compatible endpoint for non-AWS backends (Cloudflare R2, MinIO, Ceph). Leave blank for AWS S3."
               errors={state.fieldErrors?.endpoint}
             >
-              <input
-                type="text"
-                name="endpoint"
-                placeholder="https://<account>.r2.cloudflarestorage.com"
-                defaultValue={
-                  (state.data.get("endpoint") as string) ||
-                  (dataConnection?.details.provider === DataProvider.S3
-                    ? dataConnection.details.endpoint ?? ""
-                    : "")
-                }
-                style={fieldStyle}
-              />
+              {(props) => (
+                <TextField.Root
+                  {...props}
+                  type="text"
+                  name="endpoint"
+                  placeholder="https://<account>.r2.cloudflarestorage.com"
+                  defaultValue={
+                    (state.data.get("endpoint") as string) ||
+                    (dataConnection?.details.provider === DataProvider.S3
+                      ? dataConnection.details.endpoint ?? ""
+                      : "")
+                  }
+                  size="3"
+                />
+              )}
             </Field>
           </>
         )}
@@ -485,40 +482,44 @@ export function DataConnectionForm({
           <>
             <Field
               label="Bucket"
-              name="bucket"
-              description="Name of the Google Cloud Storage bucket."
+              help="Name of the Google Cloud Storage bucket."
               errors={state.fieldErrors?.bucket}
             >
-              <input
-                type="text"
-                name="bucket"
-                defaultValue={
-                  (state.data.get("bucket") as string) ||
-                  (dataConnection?.details.provider === DataProvider.GCS
-                    ? dataConnection.details.bucket
-                    : "")
-                }
-                style={fieldStyle}
-              />
+              {(props) => (
+                <TextField.Root
+                  {...props}
+                  type="text"
+                  name="bucket"
+                  defaultValue={
+                    (state.data.get("bucket") as string) ||
+                    (dataConnection?.details.provider === DataProvider.GCS
+                      ? dataConnection.details.bucket
+                      : "")
+                  }
+                  size="3"
+                />
+              )}
             </Field>
 
             <Field
               label="Base Prefix"
-              name="base_prefix"
-              description="Optional key prefix prepended to every object path in the bucket. Leave blank for the bucket root."
+              help="Optional key prefix prepended to every object path in the bucket. Leave blank for the bucket root."
               errors={state.fieldErrors?.base_prefix}
             >
-              <input
-                type="text"
-                name="base_prefix"
-                defaultValue={
-                  (state.data.get("base_prefix") as string) ||
-                  (dataConnection?.details.provider === DataProvider.GCS
-                    ? dataConnection.details.base_prefix
-                    : "")
-                }
-                style={fieldStyle}
-              />
+              {(props) => (
+                <TextField.Root
+                  {...props}
+                  type="text"
+                  name="base_prefix"
+                  defaultValue={
+                    (state.data.get("base_prefix") as string) ||
+                    (dataConnection?.details.provider === DataProvider.GCS
+                      ? dataConnection.details.base_prefix
+                      : "")
+                  }
+                  size="3"
+                />
+              )}
             </Field>
           </>
         )}
@@ -527,112 +528,128 @@ export function DataConnectionForm({
           <>
             <Field
               label="Account Name"
-              name="account_name"
-              description="Azure Storage account name."
+              help="Azure Storage account name."
               errors={state.fieldErrors?.account_name}
             >
-              <input
-                type="text"
-                name="account_name"
-                defaultValue={
-                  (state.data.get("account_name") as string) ||
-                  (dataConnection?.details.provider === DataProvider.Azure
-                    ? dataConnection.details.account_name
-                    : "")
-                }
-                style={fieldStyle}
-              />
+              {(props) => (
+                <TextField.Root
+                  {...props}
+                  type="text"
+                  name="account_name"
+                  defaultValue={
+                    (state.data.get("account_name") as string) ||
+                    (dataConnection?.details.provider === DataProvider.Azure
+                      ? dataConnection.details.account_name
+                      : "")
+                  }
+                  size="3"
+                />
+              )}
             </Field>
 
             <Field
               label="Container Name"
-              name="container_name"
-              description="Azure Blob Storage container name."
+              help="Azure Blob Storage container name."
               errors={state.fieldErrors?.container_name}
             >
-              <input
-                type="text"
-                name="container_name"
-                defaultValue={
-                  (state.data.get("container_name") as string) ||
-                  (dataConnection?.details.provider === DataProvider.Azure
-                    ? dataConnection.details.container_name
-                    : "")
-                }
-                style={fieldStyle}
-              />
+              {(props) => (
+                <TextField.Root
+                  {...props}
+                  type="text"
+                  name="container_name"
+                  defaultValue={
+                    (state.data.get("container_name") as string) ||
+                    (dataConnection?.details.provider === DataProvider.Azure
+                      ? dataConnection.details.container_name
+                      : "")
+                  }
+                  size="3"
+                />
+              )}
             </Field>
 
             <Field
               label="Base Prefix"
-              name="base_prefix"
-              description="Optional key prefix prepended to every object path in the container. Leave blank for the container root."
+              help="Optional key prefix prepended to every object path in the container. Leave blank for the container root."
               errors={state.fieldErrors?.base_prefix}
             >
-              <input
-                type="text"
-                name="base_prefix"
-                defaultValue={
-                  (state.data.get("base_prefix") as string) ||
-                  (dataConnection?.details.provider === DataProvider.Azure
-                    ? dataConnection.details.base_prefix
-                    : "")
-                }
-                style={fieldStyle}
-              />
+              {(props) => (
+                <TextField.Root
+                  {...props}
+                  type="text"
+                  name="base_prefix"
+                  defaultValue={
+                    (state.data.get("base_prefix") as string) ||
+                    (dataConnection?.details.provider === DataProvider.Azure
+                      ? dataConnection.details.base_prefix
+                      : "")
+                  }
+                  size="3"
+                />
+              )}
             </Field>
 
             <Field
               label="Region"
-              name="region"
-              description="Azure region the storage account is hosted in."
+              help="Azure region the storage account is hosted in."
               errors={state.fieldErrors?.region}
             >
-              <select
-                name="region"
-                defaultValue={
-                  (state.data.get("region") as string) ||
-                  (dataConnection?.details.provider === DataProvider.Azure
-                    ? dataConnection.details.region
-                    : "")
-                }
-                style={fieldStyle}
-              >
-                <option value="" disabled>
-                  Select a region
-                </option>
-                {Object.values(AzureRegions).map((region) => (
-                  <option key={region} value={region}>
-                    {region}
-                  </option>
-                ))}
-              </select>
+              {(props) => (
+                <Select.Root
+                  name="region"
+                  size="3"
+                  value={azureRegion || undefined}
+                  onValueChange={setAzureRegion}
+                >
+                  <Select.Trigger
+                    {...props}
+                    placeholder="Select a region"
+                    style={{ width: "100%" }}
+                  />
+                  <Select.Content>
+                    {Object.values(AzureRegions).map((region) => (
+                      <Select.Item key={region} value={region}>
+                        {region}
+                      </Select.Item>
+                    ))}
+                  </Select.Content>
+                </Select.Root>
+              )}
             </Field>
           </>
         )}
 
         <Field
           label="Authentication Type"
-          name="auth_type"
-          description={
+          help={
             (authType && AUTH_TYPE_DESCRIPTIONS[authType as DataConnectionAuthenticationType]) ||
             "How the data proxy authenticates to this backend when serving the product's data. Choose None for unsigned (public) access."
           }
           errors={state.fieldErrors?.auth_type}
         >
-          <select
-            name="auth_type"
-            value={authType}
-            onChange={(e) => setAuthType(e.target.value)}
-            style={fieldStyle}
-          >
-            <option value="">None (unsigned)</option>
-            {authOptions.map((type) => (
-              <option key={type} value={type}>
-                {AUTH_TYPE_LABELS[type]}
-              </option>
-            ))}
-          </select>
+          {(props) => (
+            <>
+              <input type="hidden" name="auth_type" value={authType} />
+              <Select.Root
+                size="3"
+                value={authType || NONE}
+                onValueChange={(value) => setAuthType(value === NONE ? "" : value)}
+              >
+                <Select.Trigger
+                  {...props}
+                  style={{ width: "100%" }}
+                />
+                <Select.Content>
+                  <Select.Item value={NONE}>None (unsigned)</Select.Item>
+                  {authOptions.map((type) => (
+                    <Select.Item key={type} value={type}>
+                      {AUTH_TYPE_LABELS[type]}
+                    </Select.Item>
+                  ))}
+                </Select.Content>
+              </Select.Root>
+            </>
+          )}
         </Field>
 
         {/* Auth-specific fields */}
@@ -640,40 +657,44 @@ export function DataConnectionForm({
           <>
             <Field
               label="Access Key ID"
-              name="access_key_id"
-              description={withSecretHint(
+              help={withSecretHint(
                 "AWS access key ID for static-credential access."
               )}
               errors={state.fieldErrors?.access_key_id}
             >
-              <input
-                type="text"
-                name="access_key_id"
-                autoComplete="off"
-                required={mode === "create"}
-                defaultValue={(state.data.get("access_key_id") as string) || ""}
-                style={fieldStyle}
-              />
+              {(props) => (
+                <TextField.Root
+                  {...props}
+                  type="text"
+                  name="access_key_id"
+                  autoComplete="off"
+                  required={mode === "create"}
+                  defaultValue={(state.data.get("access_key_id") as string) || ""}
+                  size="3"
+                />
+              )}
             </Field>
 
             <Field
               label="Secret Access Key"
-              name="secret_access_key"
-              description={withSecretHint(
+              help={withSecretHint(
                 "AWS secret access key paired with the access key ID. Never shown after saving."
               )}
               errors={state.fieldErrors?.secret_access_key}
             >
-              <input
-                type="password"
-                name="secret_access_key"
-                autoComplete="new-password"
-                required={mode === "create"}
-                defaultValue={
-                  (state.data.get("secret_access_key") as string) || ""
-                }
-                style={fieldStyle}
-              />
+              {(props) => (
+                <TextField.Root
+                  {...props}
+                  type="password"
+                  name="secret_access_key"
+                  autoComplete="new-password"
+                  required={mode === "create"}
+                  defaultValue={
+                    (state.data.get("secret_access_key") as string) || ""
+                  }
+                  size="3"
+                />
+              )}
             </Field>
           </>
         )}
@@ -681,20 +702,22 @@ export function DataConnectionForm({
         {authType === DataConnectionAuthenticationType.AzureSasToken && (
           <Field
             label="SAS Token"
-            name="sas_token"
-            description={withSecretHint(
+            help={withSecretHint(
               "Azure shared access signature granting access to the container. Never shown after saving."
             )}
             errors={state.fieldErrors?.sas_token}
           >
-            <input
-              type="password"
-              name="sas_token"
-              autoComplete="new-password"
-              required={mode === "create"}
-              defaultValue={(state.data.get("sas_token") as string) || ""}
-              style={fieldStyle}
-            />
+            {(props) => (
+              <TextField.Root
+                {...props}
+                type="password"
+                name="sas_token"
+                autoComplete="new-password"
+                required={mode === "create"}
+                defaultValue={(state.data.get("sas_token") as string) || ""}
+                size="3"
+              />
+            )}
           </Field>
         )}
 
@@ -702,27 +725,28 @@ export function DataConnectionForm({
           <>
             <Field
               label="Role ARN"
-              name="role_arn"
-              description="IAM role the proxy assumes via AssumeRoleWithWebIdentity (keyless federation). This is an ARN, not a secret."
+              help="IAM role the proxy assumes via AssumeRoleWithWebIdentity (keyless federation). This is an ARN, not a secret."
               errors={state.fieldErrors?.role_arn}
             >
-              <input
-                type="text"
-                name="role_arn"
-                required
-                placeholder="arn:aws:iam::123456789012:role/my-role"
-                defaultValue={
-                  (state.data.get("role_arn") as string) || initialRoleArn
-                }
-                style={fieldStyle}
-              />
+              {(props) => (
+                <TextField.Root
+                  {...props}
+                  type="text"
+                  name="role_arn"
+                  required
+                  placeholder="arn:aws:iam::123456789012:role/my-role"
+                  defaultValue={
+                    (state.data.get("role_arn") as string) || initialRoleArn
+                  }
+                  size="3"
+                />
+              )}
             </Field>
 
             {mode === "edit" && (
               <Field
                 label="Trust-policy subject"
-                name="sub_pattern"
-                description={
+                help={
                   <>
                     The proxy presents this OIDC subject when assuming the role.
                     In the role&apos;s trust policy, add a{" "}
@@ -735,6 +759,7 @@ export function DataConnectionForm({
                     .
                   </>
                 }
+                group
               >
                 <Flex align="center" gap="2">
                   <Code size="2" variant="soft">
@@ -751,38 +776,42 @@ export function DataConnectionForm({
           <>
             <Field
               label="Tenant ID"
-              name="tenant_id"
-              description="Azure AD tenant (directory) ID used for workload-identity federation."
+              help="Azure AD tenant (directory) ID used for workload-identity federation."
               errors={state.fieldErrors?.tenant_id}
             >
-              <input
-                type="text"
-                name="tenant_id"
-                required
-                placeholder="00000000-0000-0000-0000-000000000000"
-                defaultValue={
-                  (state.data.get("tenant_id") as string) || initialTenantId
-                }
-                style={fieldStyle}
-              />
+              {(props) => (
+                <TextField.Root
+                  {...props}
+                  type="text"
+                  name="tenant_id"
+                  required
+                  placeholder="00000000-0000-0000-0000-000000000000"
+                  defaultValue={
+                    (state.data.get("tenant_id") as string) || initialTenantId
+                  }
+                  size="3"
+                />
+              )}
             </Field>
 
             <Field
               label="Client ID"
-              name="client_id"
-              description="App registration (client) ID that holds the federated identity credential."
+              help="App registration (client) ID that holds the federated identity credential."
               errors={state.fieldErrors?.client_id}
             >
-              <input
-                type="text"
-                name="client_id"
-                required
-                placeholder="00000000-0000-0000-0000-000000000000"
-                defaultValue={
-                  (state.data.get("client_id") as string) || initialClientId
-                }
-                style={fieldStyle}
-              />
+              {(props) => (
+                <TextField.Root
+                  {...props}
+                  type="text"
+                  name="client_id"
+                  required
+                  placeholder="00000000-0000-0000-0000-000000000000"
+                  defaultValue={
+                    (state.data.get("client_id") as string) || initialClientId
+                  }
+                  size="3"
+                />
+              )}
             </Field>
           </>
         )}
@@ -792,57 +821,54 @@ export function DataConnectionForm({
           <>
             <Field
               label="Workload Identity Provider"
-              name="workload_identity_provider"
-              description="Full GCP Workload Identity provider resource. Not a secret."
+              help="Full GCP Workload Identity provider resource. Not a secret."
               errors={state.fieldErrors?.workload_identity_provider}
             >
-              <input
-                type="text"
-                name="workload_identity_provider"
-                required
-                placeholder="//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider"
-                defaultValue={
-                  (state.data.get("workload_identity_provider") as string) ||
-                  initialWorkloadIdentityProvider
-                }
-                style={fieldStyle}
-              />
+              {(props) => (
+                <TextField.Root
+                  {...props}
+                  type="text"
+                  name="workload_identity_provider"
+                  required
+                  placeholder="//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider"
+                  defaultValue={
+                    (state.data.get("workload_identity_provider") as string) ||
+                    initialWorkloadIdentityProvider
+                  }
+                  size="3"
+                />
+              )}
             </Field>
 
             <Field
               label="Service Account"
-              name="service_account"
-              description="Email of the GCP service account the proxy impersonates. Not a secret."
+              help="Email of the GCP service account the proxy impersonates. Not a secret."
               errors={state.fieldErrors?.service_account}
             >
-              <input
-                type="text"
-                name="service_account"
-                required
-                placeholder="sa@my-project.iam.gserviceaccount.com"
-                defaultValue={
-                  (state.data.get("service_account") as string) ||
-                  initialServiceAccount
-                }
-                style={fieldStyle}
-              />
+              {(props) => (
+                <TextField.Root
+                  {...props}
+                  type="text"
+                  name="service_account"
+                  required
+                  placeholder="sa@my-project.iam.gserviceaccount.com"
+                  defaultValue={
+                    (state.data.get("service_account") as string) ||
+                    initialServiceAccount
+                  }
+                  size="3"
+                />
+              )}
             </Field>
           </>
         )}
 
-        {/* Submit */}
-        <Flex mt="4" justify="end">
-          <Flex direction="column" gap="2" align="end">
-            <Button size="3" type="submit" disabled={pending} loading={pending}>
-              {mode === "create" ? "Create Connection" : "Update Connection"}
-            </Button>
-            {state?.message && (
-              <Text size="1" color={state.success ? "green" : "red"}>
-                {state.message}
-              </Text>
-            )}
-          </Flex>
-        </Flex>
+        <FormActions
+          submitLabel={mode === "create" ? "Create Connection" : "Update Connection"}
+          pending={pending}
+          message={state?.message}
+          success={state.success}
+        />
       </Flex>
     </form>
   );

--- a/src/components/features/data-connections/ProductMirrorsManager.tsx
+++ b/src/components/features/data-connections/ProductMirrorsManager.tsx
@@ -10,11 +10,12 @@ import {
   Heading,
   Code,
   Tooltip,
+  Select,
+  TextField,
 } from "@radix-ui/themes";
 import { Link1Icon, InfoCircledIcon } from "@radix-ui/react-icons";
 import Form from "next/form";
 import Link from "next/link";
-import { formFieldStyle } from "@/components/core/DynamicForm";
 import { Product } from "@/types";
 import {
   addProductMirror,
@@ -280,15 +281,14 @@ export function ProductMirrorsManager({
                       hint="You can edit this prefix because you manage both this product's account and its data connection."
                     >
                       <Flex gap="2" align="center">
-                        <input
+                        <TextField.Root
                           name="prefix"
+                          size="1"
                           defaultValue={mirror.prefix}
                           placeholder="(connection root)"
                           style={{
-                            ...formFieldStyle,
                             flex: 1,
                             fontFamily: "var(--code-font-family)",
-                            fontSize: "var(--font-size-1)",
                           }}
                         />
                         <Button
@@ -358,25 +358,23 @@ export function ProductMirrorsManager({
               value={product.product_id}
             />
             <Flex gap="2" align="end">
-              <select
-                name="connection_id"
-                required
-                defaultValue=""
-                style={{ ...formFieldStyle, flex: 1 }}
-              >
-                <option value="" disabled>
-                  Select a data connection...
-                </option>
-                {unusedConnections.map((conn) => (
-                  <option
-                    key={conn.data_connection_id}
-                    value={conn.data_connection_id}
-                  >
-                    {conn.name} ({conn.provider}
-                    {conn.region ? ` - ${conn.region}` : ""})
-                  </option>
-                ))}
-              </select>
+              <Select.Root name="connection_id" size="2" required>
+                <Select.Trigger
+                  placeholder="Select a data connection..."
+                  style={{ flex: 1 }}
+                />
+                <Select.Content>
+                  {unusedConnections.map((conn) => (
+                    <Select.Item
+                      key={conn.data_connection_id}
+                      value={conn.data_connection_id}
+                    >
+                      {conn.name} ({conn.provider}
+                      {conn.region ? ` - ${conn.region}` : ""})
+                    </Select.Item>
+                  ))}
+                </Select.Content>
+              </Select.Root>
               <Button
                 type="submit"
                 size="2"

--- a/src/components/features/products/ProductCreationForm.tsx
+++ b/src/components/features/products/ProductCreationForm.tsx
@@ -150,12 +150,6 @@ export function ProductCreationForm({
     isEditMode ? product.disabled : false
   );
 
-  // The currently selected visibility must always be selectable, even if it
-  // falls outside the connection's allowed set (e.g. legacy data drift).
-  const visibilityOptions = ALL_VISIBILITIES.includes(visibility)
-    ? ALL_VISIBILITIES
-    : [visibility, ...ALL_VISIBILITIES];
-
   // When the connection changes, drop a now-disallowed visibility back to a
   // permitted one so the form can't submit an invalid combination.
   const handleConnectionChange = (value: string) => {
@@ -301,15 +295,18 @@ export function ProductCreationForm({
       description: connectionMissing
         ? "This product's data connection could not be found, so its visibility can't be changed."
         : "Who can reach this product. The options depend on its data connection.",
-      options: visibilityOptions.map((value) => {
+      // Every visibility is listed; the connection decides which are selectable.
+      options: ALL_VISIBILITIES.map((value) => {
         const permitted = allowedVisibilities.includes(value);
         return {
           value,
           label: VISIBILITY_LABELS[value],
           description: VISIBILITY_DESCRIPTIONS[value],
+          // The current value stays selectable even when the connection no
+          // longer permits it (legacy drift), so an edit of some other field
+          // isn't blocked by a visibility the user didn't choose today.
           // The greyed-out card carries "unavailable" by itself, and the help
           // text above already says the options follow the data connection.
-          // Naming the connection on each blocked card only repeated it.
           disabled: !permitted && value !== visibility,
         };
       }),

--- a/src/components/features/products/ProductCreationForm.tsx
+++ b/src/components/features/products/ProductCreationForm.tsx
@@ -307,11 +307,10 @@ export function ProductCreationForm({
           value,
           label: VISIBILITY_LABELS[value],
           description: VISIBILITY_DESCRIPTIONS[value],
-          // A disabled <option> cannot explain itself; a card can.
+          // The greyed-out card carries "unavailable" by itself, and the help
+          // text above already says the options follow the data connection.
+          // Naming the connection on each blocked card only repeated it.
           disabled: !permitted && value !== visibility,
-          disabledReason: `Not offered by ${
-            selectedConnection?.name ?? "this data connection"
-          }.`,
         };
       }),
       readOnly: connectionMissing,

--- a/src/components/features/products/ProductCreationForm.tsx
+++ b/src/components/features/products/ProductCreationForm.tsx
@@ -33,9 +33,12 @@ const ALL_VISIBILITIES: ProductVisibility[] = [
 function allowedVisibilitiesFor(
   connection: DataConnection | undefined
 ): ProductVisibility[] {
-  return connection?.allowed_visibilities?.length
-    ? connection.allowed_visibilities
-    : ALL_VISIBILITIES;
+  // A connection that resolves but permits nothing is not the same as one that
+  // could not be resolved. The `?.length` check used to conflate them, so a
+  // connection with an empty allowed_visibilities offered all three options
+  // while createProduct/updateProduct rejected every one of them — the form
+  // promised a choice the server always refused.
+  return connection ? connection.allowed_visibilities : ALL_VISIBILITIES;
 }
 
 // Region is only present on S3/Azure connections, not GCP (keyless WIF).
@@ -99,10 +102,16 @@ export function ProductCreationForm({
   const validationState = useProductIdValidation(productId, accountId);
 
   // Connections available to the currently selected owner account: either
-  // unowned (Source-Coop-managed) or explicitly owned by that account.
+  // unowned (Source-Coop-managed) or explicitly owned by that account. A
+  // connection permitting no visibilities is excluded: createProduct rejects
+  // every visibility against it, so offering it would only produce a dead end.
+  // Edit mode is unaffected — the product's existing connection is passed in
+  // separately and stays resolvable whatever it permits.
   const connectionsForAccount = (forAccountId: string) =>
     dataConnections.filter(
-      (dc) => !dc.owner || dc.owner === forAccountId
+      (dc) =>
+        (!dc.owner || dc.owner === forAccountId) &&
+        dc.allowed_visibilities.length > 0
     );
 
   // Data connection selection. In edit mode the storage backend is fixed once

--- a/src/components/features/products/ProductCreationForm.tsx
+++ b/src/components/features/products/ProductCreationForm.tsx
@@ -14,6 +14,14 @@ const VISIBILITY_LABELS: Record<ProductVisibility, string> = {
   [ProductVisibility.Restricted]: "Restricted",
 };
 
+const VISIBILITY_DESCRIPTIONS: Record<ProductVisibility, string> = {
+  [ProductVisibility.Public]:
+    "Anyone can find and download it. Appears in search and the product feed.",
+  [ProductVisibility.Unlisted]:
+    "Anyone with the link can download it. Hidden from search and the feed.",
+  [ProductVisibility.Restricted]: "Members of this product only.",
+};
+
 // Fallback when no data connection is selected (e.g. legacy products in edit
 // mode whose connection can no longer be resolved).
 const ALL_VISIBILITIES: ProductVisibility[] = [
@@ -135,9 +143,9 @@ export function ProductCreationForm({
 
   // The currently selected visibility must always be selectable, even if it
   // falls outside the connection's allowed set (e.g. legacy data drift).
-  const visibilityOptions = allowedVisibilities.includes(visibility)
-    ? allowedVisibilities
-    : [visibility, ...allowedVisibilities];
+  const visibilityOptions = ALL_VISIBILITIES.includes(visibility)
+    ? ALL_VISIBILITIES
+    : [visibility, ...ALL_VISIBILITIES];
 
   // When the connection changes, drop a now-disallowed visibility back to a
   // permitted one so the form can't submit an invalid combination.
@@ -178,6 +186,7 @@ export function ProductCreationForm({
       name: "title",
       type: "text",
       required: true,
+      section: "Description",
       description: "The name of your product",
       placeholder: "Enter product name",
     },
@@ -190,6 +199,7 @@ export function ProductCreationForm({
             name: "account_id",
             type: "select",
             required: true,
+            section: "Description",
             description: "The account that owns the product",
             options: potentialOwnerAccounts.map((account) => ({
               value: account.account_id,
@@ -204,6 +214,8 @@ export function ProductCreationForm({
             name: "product_id",
             type: "text",
             required: true,
+            section: "Description",
+            mono: true,
             description: "The ID of your product",
             placeholder: "Enter product ID",
             controlled: true,
@@ -234,6 +246,7 @@ export function ProductCreationForm({
       name: "description",
       type: "textarea",
       required: false,
+      section: "Description",
       description: "A brief description of your product",
       placeholder: "Describe your product",
     },
@@ -247,6 +260,7 @@ export function ProductCreationForm({
             name: "data_connection_id" as keyof Product,
             type: "select",
             required: true,
+            section: "Storage",
             description:
               "Where this product's data is stored. Determines the available region and visibility options. If you're unsure, choose a us-west-2 connection.",
             options: [...availableConnections]
@@ -272,15 +286,25 @@ export function ProductCreationForm({
     {
       label: "Visibility",
       name: "visibility",
-      type: "select",
+      type: "radio-cards",
       required: true,
+      section: "Access",
       description: connectionMissing
         ? "This product's data connection could not be found, so its visibility can't be changed."
-        : "Your product's visibility. The available options depend on the product's primary data connection.",
-      options: visibilityOptions.map((value) => ({
-        value,
-        label: VISIBILITY_LABELS[value],
-      })),
+        : "Who can reach this product. The options depend on its data connection.",
+      options: visibilityOptions.map((value) => {
+        const permitted = allowedVisibilities.includes(value);
+        return {
+          value,
+          label: VISIBILITY_LABELS[value],
+          description: VISIBILITY_DESCRIPTIONS[value],
+          // A disabled <option> cannot explain itself; a card can.
+          disabled: !permitted && value !== visibility,
+          disabledReason: `Not offered by ${
+            selectedConnection?.name ?? "this data connection"
+          }.`,
+        };
+      }),
       readOnly: connectionMissing,
       controlled: true,
       value: visibility,
@@ -293,14 +317,12 @@ export function ProductCreationForm({
           {
             label: "Status",
             name: "disabled" as keyof Product,
-            type: "select",
-            required: true,
+            type: "switch",
+            section: "Status",
+            switchLabel: disabled ? "Deactivated" : "Active",
+            invert: true,
             description:
-              "A deactivated product is inaccessible via the data.source.coop API and hidden from the source.coop UI for everyone except administrators. This does not delete the product's data — it only makes it unavailable. Reactivating it afterwards requires a Source Cooperative administrator.",
-            options: [
-              { value: "false", label: "Active" },
-              { value: "true", label: "Deactivated" },
-            ],
+              "Deactivating hides the product from source.coop and blocks the data.source.coop API. The data is kept, but only a Source Cooperative administrator can reactivate it.",
             controlled: true,
             value: String(disabled),
             onValueChange: (value) => setDisabled(value === "true"),

--- a/src/components/features/profiles/EditProfileForm.tsx
+++ b/src/components/features/profiles/EditProfileForm.tsx
@@ -5,8 +5,8 @@ import { Account } from "@/types";
 import {
   Button,
   Flex,
-  Text,
   Box,
+  IconButton,
   TextField,
   Tooltip,
   Link,
@@ -15,6 +15,7 @@ import { TrashIcon } from "@radix-ui/react-icons";
 import { DynamicForm, FormField } from "@/components/core";
 import { updateAccountProfile } from "@/lib/actions/account";
 import { orySettingsUrl } from "@/lib/urls";
+import { BIO_MAX_LENGTH } from "@/types/account";
 
 interface Website {
   url: string;
@@ -44,6 +45,11 @@ export function EditProfileForm({
       ? accountWebsites.map((domain) => ({ url: domain.domain }))
       : [{ url: "" }]; // Start with one empty website field if no existing websites
   });
+
+  // Controlled so the character counter tracks what is actually in the field.
+  const [description, setDescription] = useState(
+    initialAccount.metadata_public?.bio || ""
+  );
 
   const handleWebsiteChange = (index: number, url: string) => {
     setWebsites((prev) =>
@@ -77,10 +83,11 @@ export function EditProfileForm({
 
   const fields: FormField<EditProfileFormData>[] = [
     {
-      label: "Name (Required)",
+      label: "Name",
       name: "name",
       type: "text",
       required: true,
+      section: "Identity",
       placeholder: "Your Name",
       description: "This is the name that will be displayed on your profile",
     },
@@ -89,6 +96,8 @@ export function EditProfileForm({
       name: "email",
       type: "email",
       readOnly: true,
+      section: "Identity",
+      mono: true,
       placeholder: "you@example.com",
       description:
         initialAccount.type === "individual" ? (
@@ -104,16 +113,22 @@ export function EditProfileForm({
       label: initialAccount.type === "individual" ? "Bio" : "Description",
       name: "description",
       type: "textarea",
+      section: "About",
+      // BIO_MAX_LENGTH comes from the schema that validates this, so the
+      // counter and the validator cannot drift apart the way the old
+      // "220 characters maximum" help text had.
+      maxLength: BIO_MAX_LENGTH,
+      controlled: true,
+      value: description,
+      onValueChange: setDescription,
       ...(initialAccount.type === "individual"
         ? {
             placeholder: "Tell us about yourself",
-            description:
-              "A brief description of yourself or your work (220 characters maximum)",
+            description: "A brief description of yourself or your work",
           }
         : {
             placeholder: "Tell us about your organization",
-            description:
-              "A brief description of your organization (220 characters maximum)",
+            description: "A brief description of your organization",
           }),
     },
     ...(initialAccount.type === "individual"
@@ -122,6 +137,8 @@ export function EditProfileForm({
             label: "ORCID ID",
             name: "orcid",
             type: "text" as const,
+            section: "Identifiers",
+            mono: true,
             placeholder: "0000-0002-1825-0097",
             description: "Your ORCID identifier (optional)",
           } as const,
@@ -133,6 +150,8 @@ export function EditProfileForm({
             label: "ROR ID",
             name: "ror_id",
             type: "text" as const,
+            section: "Identifiers",
+            mono: true,
             placeholder: "03yrm5c26",
             description: "Your Research Organization Registry identifier (optional)",
           } as const,
@@ -142,22 +161,19 @@ export function EditProfileForm({
       label: "Websites",
       name: "websites",
       type: "custom",
+      section: "Links",
       description: "Add websites associated with your profile",
       customComponent: (
         <Box>
           <Flex direction="column" gap="3">
             {websites.map((website, index) => (
-              <Box key={`website-${index}`}>
-                <WebsiteInputField
-                  value={website.url}
-                  onChange={(value) => handleWebsiteChange(index, value)}
-                  onRemove={() => removeWebsite(index)}
-                  showRemoveButton={websites.length > 1}
-                />
-                <Text size="1" color="gray" mt="1">
-                  Website URL
-                </Text>
-              </Box>
+              <WebsiteInputField
+                key={`website-${index}`}
+                value={website.url}
+                onChange={(value) => handleWebsiteChange(index, value)}
+                onRemove={() => removeWebsite(index)}
+                showRemoveButton={websites.length > 1}
+              />
             ))}
           </Flex>
           <Box mt="3">
@@ -200,8 +216,6 @@ function WebsiteInputField({
   onRemove?: () => void;
   showRemoveButton: boolean;
 }) {
-  const [isHovering, setIsHovering] = useState(false);
-
   return (
     <Flex align="center" gap="2">
       <Box style={{ flexGrow: 1 }}>
@@ -211,28 +225,24 @@ function WebsiteInputField({
           onChange={(e) => onChange(e.target.value)}
           size="3"
           variant="surface"
-          style={{ width: "100%" }}
+          style={{
+            width: "100%",
+            fontFamily: "var(--code-font-family)",
+          }}
         />
       </Box>
       {showRemoveButton && onRemove && (
         <Tooltip content="Remove website">
-          <Box
-            style={{
-              cursor: "pointer",
-              display: "flex",
-              alignItems: "center",
-              padding: "6px",
-            }}
+          <IconButton
+            type="button"
+            size="3"
+            variant="ghost"
+            color="gray"
+            aria-label="Remove website"
             onClick={onRemove}
-            onMouseEnter={() => setIsHovering(true)}
-            onMouseLeave={() => setIsHovering(false)}
           >
-            <TrashIcon
-              color={isHovering ? "tomato" : "gray"}
-              width="18"
-              height="18"
-            />
-          </Box>
+            <TrashIcon width="18" height="18" />
+          </IconButton>
         </Tooltip>
       )}
     </Flex>

--- a/src/components/features/uploader/Dropzone.tsx
+++ b/src/components/features/uploader/Dropzone.tsx
@@ -66,6 +66,10 @@ export function Dropzone({
           : {}),
       }}
     >
+      {/* eslint-disable-next-line no-restricted-syntax --
+          react-dropzone supplies type="file" through the spread, so the
+          exemption can't be seen statically. It is a visually hidden file
+          picker, not a themed control. */}
       <input {...getInputProps()} />
       <style>{`
         @keyframes fadeIn {

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -60,12 +60,20 @@ export const AccountDomainSchema = z.object({
 // Export the type for use in other files
 export type AccountDomain = z.infer<typeof AccountDomainSchema>;
 
+// Exported so the edit form's character counter reads the same number the
+// validator enforces, rather than a second one written into help text.
+export const BIO_MAX_LENGTH = 1024;
+
 const BaseAccountProfileSchema = z.object({
   bio: z
     .preprocess((bio) => {
       if (!bio || typeof bio !== "string") return undefined;
       return bio === "" ? undefined : bio;
-    }, z.optional(z.string().max(1024, "Bio must not exceed 1024 characters")))
+    }, z.optional(
+      z
+        .string()
+        .max(BIO_MAX_LENGTH, `Bio must not exceed ${BIO_MAX_LENGTH} characters`)
+    ))
     .openapi({ example: "Software Engineer @radiantearth" }),
   location: z
     .preprocess((location) => {


### PR DESCRIPTION
Performs the refactor from the [design canvas](https://claude.ai/code/artifact/66c8a032-8f0d-474f-86d6-09a5a9af24f6).

**Storybook has been split out into #498, stacked on this branch.** This PR is now forms only. (The branch was rewritten to drop the Storybook commits, so the two earlier review threads no longer anchor to lines — both findings were addressed, and the responses are in the comments below.)

## Why

The field anatomy — label, help, control, error — had already been written twice: inlined across three branches of `DynamicForm`, and again as a local `Field` in `DataConnectionForm`, which imported `formFieldStyle` across a module boundary to keep the two looking alike. So this is mostly deletion.

`formFieldStyle` hand-rolled what the Radix theme already provides. Removing it is the whole of "use the existing Radix theme": focus rings, disabled states, dark mode and the configured `radius: none` / gray accent / 110% scaling now apply because nothing overrides them.

## What changed

**`<Field>`** (`src/components/core/Field.tsx`) owns the wiring nobody remembers: generated id, label association, `aria-describedby` covering help *and* errors, `aria-invalid`. The control is a **child**, not a `type` union — which is what lets one wrapper serve a text input, a select, radio cards, a switch or a dropzone.

Where there is no single labelable control, the field is marked `group` and the label names a `role="group"` via `aria-labelledby`. This matters more than it sounds: `htmlFor` only associates with input, select, textarea, button, meter, output and progress. Pointing it at `RadioCards.Root` (a `div[role=radiogroup]`) resolves to a node that names nothing, and a `customComponent` can never receive the id at all.

**`<FormActions>`** gives a form one action row. `InviteMemberForm` rendered Cancel as a sibling of the form, so the dialog had two right-aligned rows with Cancel stranded under the primary button.

**`DynamicForm`** keeps its public API — the seven forms using it needed no changes — but renders Radix controls through `Field` and groups fields by `section`. Two type-level guards were added: `radio-cards` and `switch` render entirely from their value prop, so the field type now requires `controlled`/`value`/`onValueChange` rather than letting someone ship a control that never moves when clicked. The character counter tracks live input inside `DynamicForm` instead of reading the seeded value, so it doesn't silently depend on the caller also wiring the field as controlled.

**Per-form**, from the canvas: product visibility is radio cards (a disabled `<option>` can't say *why* it's unavailable; a card can), status is a Switch instead of a two-value select, and delete moves into a labelled `DangerZone`.

## One bug fixed on the way

The bio help text promised "220 characters maximum". `AccountProfileSchema` enforces 1024. Nobody wrote a bug — two sources of truth drifted and nothing could catch it. `BIO_MAX_LENGTH` is now exported from the schema and drives the counter, so they can't drift again.

## Guardrail

An eslint `no-restricted-syntax` rule keeps raw `input`/`select`/`textarea` out of `src/components`, exempting `type="hidden"` and `type="file"`. One inline disable, in `Dropzone`, where `react-dropzone` supplies the type through a spread.

## Tests

`Field` in isolation, plus `DynamicForm`'s field-type dispatch — including a general check that no `label[for]` in a rendered form points at a non-labelable element, which encodes the rule rather than the instance.

Worth knowing why that dispatch was untested before: `DynamicForm` could not be rendered under jest at all. It calls `useActionState`, which doesn't exist in the `react@18.3.1` jest resolves — the app only gets that hook through Next's bundled runtime. That gap is why two rounds of label-wiring bugs reached review. A shim in the test file adds the missing export to the real module (neither a spread nor a Proxy survives babel's interop, which enumerates own keys).

## Verification

`tsc --noEmit` clean · jest 59 suites / 505 tests · `next lint` 0 errors.

`next build` compiles and lints clean but can't finish locally: prerendering the marketing homepage calls DynamoDB and there are no AWS credentials in this environment. That path is not in this diff.

## Follow-up, not here

The primary button fails WCAG AA contrast — white on `--accent-9` (`#8d8d8d`, 3.31:1 against a required 4.5:1) because the theme sets `accentColor="gray"`. That's every primary button in the app, not something this PR introduced, and it wants its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mnsg8m1dXZ5z5ig5xMtkE
