### PR TITLE
feat(data-connections): rework the cards, the list, and where delete lives

### DIFF
--- a/src/app/(app)/admin/data-connections/[data_connection_id]/page.tsx
+++ b/src/app/(app)/admin/data-connections/[data_connection_id]/page.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/features/data-connections";
 import { ConnectionUsage } from "@/components/features/data-connections/ConnectionUsage";
 import { toEditableDataConnection } from "@/components/features/data-connections/redact";
+import { DangerZone } from "@/components/core";
 
 export const metadata: Metadata = {
   title: "Admin — Edit data connection",
@@ -32,12 +33,7 @@ export default async function EditDataConnectionPage({
 
   return (
     <Flex direction="column" gap="4">
-      <Flex justify="between" align="center">
-        <Heading size="4">Edit Data Connection</Heading>
-        <DeleteConnectionControl
-          connectionId={dataConnection.data_connection_id}
-        />
-      </Flex>
+      <Heading size="4">Edit Data Connection</Heading>
       <DataConnectionForm
         mode="edit"
         dataConnection={toEditableDataConnection(dataConnection)}
@@ -52,6 +48,17 @@ export default async function EditDataConnectionPage({
       >
         <ConnectionUsage connectionId={dataConnection.data_connection_id} />
       </Suspense>
+
+      {/* Below the usage list, which is what answers "can I delete this?" */}
+      <DangerZone
+        title="Delete this connection"
+        description="Removes the connection record and its stored credentials. The bucket and its objects are not touched."
+        action={
+          <DeleteConnectionControl
+            connectionId={dataConnection.data_connection_id}
+          />
+        }
+      />
     </Flex>
   );
 }

--- a/src/app/(app)/edit/account/[account_id]/data-connections/[data_connection_id]/page.tsx
+++ b/src/app/(app)/edit/account/[account_id]/data-connections/[data_connection_id]/page.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/components/features/data-connections";
 import { ConnectionUsage } from "@/components/features/data-connections/ConnectionUsage";
 import { toEditableDataConnection } from "@/components/features/data-connections/redact";
-import { FormTitle } from "@/components/core/FormTitle";
+import { FormTitle, DangerZone } from "@/components/core";
 
 export const metadata: Metadata = {
   title: "Edit data connection",
@@ -41,17 +41,10 @@ export default async function AccountEditDataConnectionPage({
 
   return (
     <Box>
-      <Flex justify="between" align="center" mb="6">
-        <Box>
-          <FormTitle
-            title="Edit Data Connection"
-            description="Update this connection's settings and credentials."
-          />
-        </Box>
-        <DeleteConnectionControl
-          connectionId={dataConnection.data_connection_id}
-        />
-      </Flex>
+      <FormTitle
+        title="Edit Data Connection"
+        description="Update this connection's settings and credentials."
+      />
       <DataConnectionForm
         mode="edit"
         ownerAccountId={account_id}
@@ -69,6 +62,17 @@ export default async function AccountEditDataConnectionPage({
           <ConnectionUsage connectionId={dataConnection.data_connection_id} />
         </Suspense>
       </Box>
+
+      {/* Below the usage list, which is what answers "can I delete this?" */}
+      <DangerZone
+        title="Delete this connection"
+        description="Removes the connection record and its stored credentials. The bucket and its objects are not touched."
+        action={
+          <DeleteConnectionControl
+            connectionId={dataConnection.data_connection_id}
+          />
+        }
+      />
     </Box>
   );
 }

--- a/src/components/features/data-connections/DataConnectionsTable.test.tsx
+++ b/src/components/features/data-connections/DataConnectionsTable.test.tsx
@@ -70,3 +70,60 @@ describe("DataConnectionsTable owner column", () => {
     expect(screen.getByText("ghost")).toBeInTheDocument();
   });
 });
+
+describe("DataConnectionsTable read-only and storage", () => {
+  it("marks a read-only connection on its row", () => {
+    renderWithTheme(
+      <DataConnectionsTable
+        connections={[conn({ read_only: true })]}
+        editHref={(id) => `/edit/${id}`}
+      />
+    );
+
+    expect(screen.getByText("Read only")).toBeInTheDocument();
+  });
+
+  it("says nothing at all about a writable connection", () => {
+    // Read-only is a deliberate configuration, not a fault. It used to render
+    // as a red "Yes", and every writable row carried a green "No" announcing
+    // that nothing had happened.
+    renderWithTheme(
+      <DataConnectionsTable
+        connections={[conn({ read_only: false })]}
+        editHref={(id) => `/edit/${id}`}
+      />
+    );
+
+    expect(screen.queryByText("Read only")).not.toBeInTheDocument();
+    expect(screen.queryByText("No")).not.toBeInTheDocument();
+    expect(screen.queryByText("Yes")).not.toBeInTheDocument();
+  });
+
+  it("folds provider and region into one storage cell", () => {
+    renderWithTheme(
+      <DataConnectionsTable
+        connections={[conn({})]}
+        editHref={(id) => `/edit/${id}`}
+      />
+    );
+
+    expect(screen.getByText("s3 · us-east-1")).toBeInTheDocument();
+  });
+
+  it("omits the region for a keyless provider that has none", () => {
+    renderWithTheme(
+      <DataConnectionsTable
+        connections={[
+          conn({
+            details: {
+              provider: DataProvider.GCS,
+            } as DataConnection["details"],
+          }),
+        ]}
+        editHref={(id) => `/edit/${id}`}
+      />
+    );
+
+    expect(screen.getByText("gcs")).toBeInTheDocument();
+  });
+});

--- a/src/components/features/data-connections/DataConnectionsTable.tsx
+++ b/src/components/features/data-connections/DataConnectionsTable.tsx
@@ -6,14 +6,19 @@ import { AccountInfoHoverCard } from "@/components/core/AccountInfoHoverCard";
 import { MonoText } from "@/components/core/MonoText";
 import { accountUrl } from "@/lib/urls";
 
-const PROVIDER_BADGE: Record<
-  DataProvider,
-  { label: string; color: "orange" | "blue" | "green" }
-> = {
-  [DataProvider.S3]: { label: "S3", color: "orange" },
-  [DataProvider.Azure]: { label: "Azure", color: "blue" },
-  [DataProvider.GCS]: { label: "GCS", color: "green" },
+const PROVIDER_LABEL: Record<DataProvider, string> = {
+  [DataProvider.S3]: "s3",
+  [DataProvider.Azure]: "azure",
+  [DataProvider.GCS]: "gcs",
 };
+
+/** GCS federates without a key, so it has no region to show. */
+function storageSummary(connection: DataConnection): string {
+  const provider = PROVIDER_LABEL[connection.details.provider];
+  const region =
+    "region" in connection.details ? connection.details.region : undefined;
+  return region ? `${provider} · ${region}` : provider;
+}
 
 interface DataConnectionsTableProps {
   connections: DataConnection[];
@@ -96,10 +101,8 @@ export function DataConnectionsTable({
           {ownerAccounts && (
             <Table.ColumnHeaderCell>Owner</Table.ColumnHeaderCell>
           )}
-          <Table.ColumnHeaderCell>Provider</Table.ColumnHeaderCell>
-          <Table.ColumnHeaderCell>Region</Table.ColumnHeaderCell>
-          <Table.ColumnHeaderCell>Read Only</Table.ColumnHeaderCell>
-          <Table.ColumnHeaderCell>Visibilities</Table.ColumnHeaderCell>
+          <Table.ColumnHeaderCell>Storage</Table.ColumnHeaderCell>
+          <Table.ColumnHeaderCell>Allows</Table.ColumnHeaderCell>
         </Table.Row>
       </Table.Header>
       <Table.Body>
@@ -107,12 +110,27 @@ export function DataConnectionsTable({
           <Table.Row key={conn.data_connection_id}>
             <Table.Cell>
               <Flex direction="column">
-                <Link
-                  href={editHref(conn.data_connection_id)}
-                  style={{ color: "var(--accent-11)" }}
-                >
-                  {conn.name}
-                </Link>
+                <Flex align="center" gap="2">
+                  <Link
+                    href={editHref(conn.data_connection_id)}
+                    style={{ color: "var(--accent-11)" }}
+                  >
+                    {conn.name}
+                  </Link>
+                  {conn.read_only && (
+                    <Text
+                      size="1"
+                      color="gray"
+                      style={{
+                        border: "1px solid var(--gray-7)",
+                        padding: "0 6px",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      Read only
+                    </Text>
+                  )}
+                </Flex>
                 <Text
                   size="1"
                   color="gray"
@@ -128,19 +146,9 @@ export function DataConnectionsTable({
               </Table.Cell>
             )}
             <Table.Cell>
-              <Badge color={PROVIDER_BADGE[conn.details.provider].color}>
-                {PROVIDER_BADGE[conn.details.provider].label}
-              </Badge>
-            </Table.Cell>
-            <Table.Cell>
-              <Text size="2">
-                {"region" in conn.details ? conn.details.region : "—"}
-              </Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Badge color={conn.read_only ? "red" : "green"}>
-                {conn.read_only ? "Yes" : "No"}
-              </Badge>
+              <MonoText size="1" color="gray">
+                {storageSummary(conn)}
+              </MonoText>
             </Table.Cell>
             <Table.Cell>
               <Flex gap="1" wrap="wrap">

--- a/src/components/features/data-connections/DeleteConnectionControl.tsx
+++ b/src/components/features/data-connections/DeleteConnectionControl.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from "react";
-import { Button } from "@radix-ui/themes";
+import { Button, Flex, Text } from "@radix-ui/themes";
 import { productsTable } from "@/lib/clients";
 import { DeleteDataConnectionButton } from "./DeleteDataConnectionButton";
 
@@ -18,7 +18,7 @@ export function DeleteConnectionControl({
     <Suspense
       fallback={
         <Button size="2" color="red" variant="soft" disabled>
-          Delete
+          Delete connection
         </Button>
       }
     >
@@ -29,10 +29,22 @@ export function DeleteConnectionControl({
 
 async function DeleteControlInner({ connectionId }: { connectionId: string }) {
   const products = await productsTable.listProductsByConnectionId(connectionId);
+
   return (
-    <DeleteDataConnectionButton
-      dataConnectionId={connectionId}
-      productsInUse={products.length}
-    />
+    <Flex direction="column" align="end" gap="2">
+      <DeleteDataConnectionButton
+        dataConnectionId={connectionId}
+        productsInUse={products.length}
+      />
+      {/* The count is resolved here, so the blocker is stated on the disabled
+          control rather than waiting to surprise someone inside the dialog. */}
+      {products.length > 0 && (
+        <Text size="1" color="red" align="right">
+          {products.length === 1
+            ? "1 product still uses it"
+            : `${products.length} products still use it`}
+        </Text>
+      )}
+    </Flex>
   );
 }

--- a/src/components/features/data-connections/DeleteDataConnectionButton.tsx
+++ b/src/components/features/data-connections/DeleteDataConnectionButton.tsx
@@ -39,22 +39,16 @@ export function DeleteDataConnectionButton({
   return (
     <AlertDialog.Root>
       <AlertDialog.Trigger>
-        <Button size="2" color="red" variant="soft">
-          Delete
+        <Button size="2" color="red" variant="soft" disabled={inUse}>
+          Delete connection
         </Button>
       </AlertDialog.Trigger>
       <AlertDialog.Content maxWidth="450px">
-        <AlertDialog.Title>Delete Data Connection</AlertDialog.Title>
-        <AlertDialog.Description>
-          Are you sure you want to delete this data connection? This action
-          cannot be undone.
+        <AlertDialog.Title>Delete this connection?</AlertDialog.Title>
+        <AlertDialog.Description size="2">
+          This removes the connection record and its stored credentials. The
+          bucket and its objects are not touched. It cannot be undone.
         </AlertDialog.Description>
-        {inUse && (
-          <Text as="p" size="1" color="red" mt="2">
-            You cannot delete a connection while products are using it — remove
-            it from all products first.
-          </Text>
-        )}
         <Flex gap="3" mt="4" justify="end">
           <AlertDialog.Cancel>
             <Button variant="soft" color="gray">

--- a/src/components/features/data-connections/ProductMirrorsManager.test.ts
+++ b/src/components/features/data-connections/ProductMirrorsManager.test.ts
@@ -1,0 +1,56 @@
+import { resultForRow } from "./ProductMirrorsManager";
+
+const ok = (message: string) => ({ message, success: true });
+const none = { message: "", success: false };
+
+describe("resultForRow", () => {
+  it("shows nothing on a row that was not acted on", () => {
+    expect(
+      resultForRow({ key: "a", action: "remove" }, "b", {
+        remove: ok("Removed X"),
+        primary: none,
+        prefix: none,
+      })
+    ).toBeNull();
+  });
+
+  it("shows the result of the action that ran on this row", () => {
+    expect(
+      resultForRow({ key: "a", action: "primary" }, "a", {
+        remove: none,
+        primary: ok("Primary mirror updated"),
+        prefix: none,
+      })
+    ).toEqual(ok("Primary mirror updated"));
+  });
+
+  it("is not fooled by a stale message from an earlier, different action", () => {
+    // Each action owns a useActionState, and those never reset — a state keeps
+    // its last message until that same action runs again. Remove a mirror, then
+    // save a prefix on another row: picking "whichever state still has a
+    // message" would surface the remove result on the row that saved a prefix.
+    expect(
+      resultForRow({ key: "b", action: "prefix" }, "b", {
+        remove: ok("Removed X"),
+        primary: none,
+        prefix: ok("Prefix updated"),
+      })
+    ).toEqual(ok("Prefix updated"));
+  });
+
+  it("stays silent when the acted-on action has produced nothing yet", () => {
+    expect(
+      resultForRow({ key: "b", action: "prefix" }, "b", {
+        remove: ok("Removed X"),
+        primary: none,
+        prefix: none,
+      })
+    ).toBeNull();
+  });
+
+  it("shows nothing before anything has been acted on", () => {
+    expect(
+      resultForRow(null, "a", { remove: none, primary: none, prefix: none })
+    ).toBeNull();
+  });
+});

--- a/src/components/features/data-connections/ProductMirrorsManager.tsx
+++ b/src/components/features/data-connections/ProductMirrorsManager.tsx
@@ -1,22 +1,28 @@
 "use client";
 
-import { useActionState } from "react";
+import { useActionState, useState, startTransition } from "react";
 import {
   Text,
-  Card,
   Flex,
-  Badge,
+  Box,
   Button,
-  Heading,
+  IconButton,
   Code,
-  Tooltip,
+  Callout,
   Select,
   TextField,
+  DropdownMenu,
+  AlertDialog,
 } from "@radix-ui/themes";
-import { Link1Icon, InfoCircledIcon } from "@radix-ui/react-icons";
+import {
+  Link1Icon,
+  InfoCircledIcon,
+  DotsHorizontalIcon,
+} from "@radix-ui/react-icons";
 import Form from "next/form";
 import Link from "next/link";
 import { Product } from "@/types";
+import { Field, FormTitle, SectionHeader } from "@/components/core";
 import {
   addProductMirror,
   removeProductMirror,
@@ -49,33 +55,6 @@ interface ProductMirrorsManagerProps {
   // Connection ids whose mirror prefix this user may edit (needs both account
   // and connection management). Others render the prefix read-only.
   editablePrefixConnectionIds: string[];
-}
-
-/** A labeled value on a mirror card, with an optional info tooltip. */
-function Field({
-  label,
-  hint,
-  children,
-}: {
-  label: string;
-  hint?: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <Flex direction="column" gap="1">
-      <Flex align="center" gap="1">
-        <Text size="1" color="gray">
-          {label}
-        </Text>
-        {hint && (
-          <Tooltip content={hint}>
-            <InfoCircledIcon color="var(--gray-8)" />
-          </Tooltip>
-        )}
-      </Flex>
-      {children}
-    </Flex>
-  );
 }
 
 const emptyFormState = {
@@ -113,6 +92,27 @@ export function ProductMirrorsManager({
     emptyFormState
   );
 
+  // Which mirror the last action targeted, so its result renders on that row
+  // instead of joining a pile of messages at the foot of the page.
+  const [actedOn, setActedOn] = useState<string | null>(null);
+  // The mirror queued for removal, i.e. the open confirmation.
+  const [pendingRemoval, setPendingRemoval] = useState<string | null>(null);
+
+  // Dispatching directly rather than through a <Form> per action: all three
+  // carry the same three values, so as markup they were nine hidden inputs per
+  // card, and a menu item cannot submit a form it does not contain.
+  const dispatchForMirror = (
+    action: (formData: FormData) => void,
+    mirrorKey: string
+  ) => {
+    const formData = new FormData();
+    formData.set("account_id", product.account_id);
+    formData.set("product_id", product.product_id);
+    formData.set("mirror_key", mirrorKey);
+    setActedOn(mirrorKey);
+    startTransition(() => action(formData));
+  };
+
   // Primary mirror first, then stable by key.
   const mirrors = Object.entries(product.metadata.mirrors).sort(
     ([keyA, a], [keyB, b]) =>
@@ -126,15 +126,58 @@ export function ProductMirrorsManager({
     (conn) => !usedConnectionIds.has(conn.data_connection_id)
   );
 
+  const removalTarget = pendingRemoval
+    ? product.metadata.mirrors[pendingRemoval]
+    : undefined;
+  const removalName = removalTarget
+    ? (connectionInfo[removalTarget.connection_id]?.name ??
+      removalTarget.connection_id)
+    : "";
+
+  /** The result of the last action, shown against the row that caused it. */
+  const rowMessage = (key: string) => {
+    if (actedOn !== key) return null;
+    const state = [removeState, primaryState, prefixState].find(
+      (candidate) => candidate.message
+    );
+    if (!state) return null;
+    return (
+      <Text size="1" color={state.success ? "green" : "red"}>
+        {state.message}
+      </Text>
+    );
+  };
+
   return (
-    <Flex direction="column" gap="4">
-      <Heading size="4">Data Connections</Heading>
+    <Box>
+      <FormTitle
+        title="Data Connections"
+        description="Where this product's objects live. The primary connection is the one visitors download from."
+      />
 
       {!canManageMirrors && (
-        <Text size="2" color="gray">
-          Only owners and maintainers of <Code>{product.account_id}</Code> can
-          change this product&apos;s data connections.
-        </Text>
+        <Callout.Root size="1" color="gray" mb="4">
+          <Callout.Icon>
+            <InfoCircledIcon />
+          </Callout.Icon>
+          <Callout.Text>
+            Only owners and maintainers of <Code>{product.account_id}</Code> can
+            change this product&apos;s data connections.
+          </Callout.Text>
+        </Callout.Root>
+      )}
+
+      {/* Standing, not fired after a save: it is worth knowing before acting. */}
+      {canManageMirrors && mirrors.length > 0 && (
+        <Callout.Root size="1" color="gray" mb="4">
+          <Callout.Icon>
+            <InfoCircledIcon />
+          </Callout.Icon>
+          <Callout.Text>
+            The data proxy caches these settings. Changes here can take up to
+            five minutes to take effect.
+          </Callout.Text>
+        </Callout.Root>
       )}
 
       {mirrors.length === 0 ? (
@@ -157,241 +200,293 @@ export function ProductMirrorsManager({
         </Flex>
       ) : (
         <Flex direction="column" gap="3">
-          {mirrors.map(([key, mirror]) => (
-            <Card key={key}>
-              <Flex direction="column" gap="3">
-                <Flex justify="between" align="start" gap="3" wrap="wrap">
-                  <Flex align="center" gap="2">
-                    <Text size="2" weight="medium">
-                      {/* Fall back to the id when the connection no longer
-                          loads (e.g. deleted). */}
-                      {connectionInfo[mirror.connection_id]?.name ??
-                        mirror.connection_id}
-                    </Text>
-                    {mirror.is_primary && <Badge color="green">Primary</Badge>}
-                  </Flex>
-                  <Flex align="center" gap="2">
-                    {(isAdmin ||
-                      ownedConnections.has(mirror.connection_id)) && (
-                      <Button asChild size="1" variant="soft">
-                        <Link
-                          // Owned connections are managed under the owner
-                          // account's settings (reachable by its owners and
-                          // maintainers); only unowned (system) connections
-                          // live in the admin view, which non-admins can't
-                          // open.
-                          href={
-                            ownedConnections.has(mirror.connection_id)
-                              ? accountDataConnectionEditUrl(
-                                  product.account_id,
-                                  mirror.connection_id
-                                )
-                              : adminDataConnectionEditUrl(
-                                  mirror.connection_id
-                                )
-                          }
+          {mirrors.map(([key, mirror]) => {
+            const info = connectionInfo[mirror.connection_id];
+            const canEditPrefix = editablePrefixConnections.has(
+              mirror.connection_id
+            );
+            const canOpenConnection =
+              isAdmin || ownedConnections.has(mirror.connection_id);
+
+            return (
+              <Box
+                key={key}
+                style={{
+                  border: "1px solid var(--gray-6)",
+                  backgroundColor: "var(--color-panel-solid)",
+                }}
+              >
+                <Flex justify="between" align="start" gap="3" p="4">
+                  <Box minWidth="0">
+                    <Flex align="center" gap="2">
+                      <Text size="2" weight="medium">
+                        {/* Fall back to the id when the connection no longer
+                            loads (e.g. deleted). */}
+                        {info?.name ?? mirror.connection_id}
+                      </Text>
+                      {mirror.is_primary && (
+                        <Text
+                          size="1"
+                          color="gray"
+                          style={{
+                            border: "1px solid var(--gray-7)",
+                            padding: "0 6px",
+                            textTransform: "uppercase",
+                            letterSpacing: "0.04em",
+                          }}
                         >
-                          Edit
-                        </Link>
-                      </Button>
+                          Primary
+                        </Text>
+                      )}
+                    </Flex>
+                    {info && (
+                      <Text
+                        size="1"
+                        color="gray"
+                        mt="1"
+                        style={{
+                          fontFamily: "var(--code-font-family)",
+                          display: "block",
+                        }}
+                      >
+                        {info.provider} · {info.bucket}
+                      </Text>
                     )}
-                    {canManageMirrors && !mirror.is_primary && (
-                      <Form action={primaryAction} style={{ display: "inline" }}>
-                        <input
-                          type="hidden"
-                          name="account_id"
-                          value={product.account_id}
-                        />
-                        <input
-                          type="hidden"
-                          name="product_id"
-                          value={product.product_id}
-                        />
-                        <input type="hidden" name="mirror_key" value={key} />
-                        <Button
-                          type="submit"
+                  </Box>
+
+                  {/* One affordance rather than three same-weight buttons, so
+                      the destructive one stops competing with the routine ones. */}
+                  {(canManageMirrors || canOpenConnection) && (
+                    <DropdownMenu.Root>
+                      <DropdownMenu.Trigger>
+                        <IconButton
                           size="1"
                           variant="soft"
-                          disabled={primaryPending}
-                          loading={primaryPending}
+                          color="gray"
+                          aria-label={`Actions for ${info?.name ?? mirror.connection_id}`}
+                          disabled={removePending || primaryPending}
                         >
-                          Set Primary
-                        </Button>
-                      </Form>
-                    )}
-                    {canManageMirrors && (
-                      <Form action={removeAction} style={{ display: "inline" }}>
-                        <input
-                          type="hidden"
-                          name="account_id"
-                          value={product.account_id}
-                        />
-                        <input
-                          type="hidden"
-                          name="product_id"
-                          value={product.product_id}
-                        />
-                        <input type="hidden" name="mirror_key" value={key} />
-                        <Button
-                          type="submit"
-                          size="1"
-                          variant="soft"
-                          color="red"
-                          disabled={removePending}
-                          loading={removePending}
-                        >
-                          Remove
-                        </Button>
-                      </Form>
-                    )}
-                  </Flex>
-                </Flex>
-                <Flex gap="5" wrap="wrap">
-                  <Field label="Type">
-                    <Text size="2">
-                      {connectionInfo[mirror.connection_id]?.provider}
-                    </Text>
-                  </Field>
-                  {connectionInfo[mirror.connection_id] && (
-                    <Field label="Bucket">
-                      <Code size="2" variant="ghost" color="gray">
-                        {connectionInfo[mirror.connection_id].bucket}
-                      </Code>
-                    </Field>
+                          <DotsHorizontalIcon />
+                        </IconButton>
+                      </DropdownMenu.Trigger>
+                      <DropdownMenu.Content>
+                        {canManageMirrors && !mirror.is_primary && (
+                          <DropdownMenu.Item
+                            onSelect={() =>
+                              dispatchForMirror(primaryAction, key)
+                            }
+                          >
+                            Make primary
+                          </DropdownMenu.Item>
+                        )}
+                        {canOpenConnection && (
+                          <DropdownMenu.Item asChild>
+                            <Link
+                              // Owned connections are managed under the owner
+                              // account's settings (reachable by its owners and
+                              // maintainers); only unowned (system) connections
+                              // live in the admin view, which non-admins can't
+                              // open.
+                              href={
+                                ownedConnections.has(mirror.connection_id)
+                                  ? accountDataConnectionEditUrl(
+                                      product.account_id,
+                                      mirror.connection_id
+                                    )
+                                  : adminDataConnectionEditUrl(
+                                      mirror.connection_id
+                                    )
+                              }
+                            >
+                              Edit connection
+                            </Link>
+                          </DropdownMenu.Item>
+                        )}
+                        {canManageMirrors && (
+                          <>
+                            <DropdownMenu.Separator />
+                            <DropdownMenu.Item
+                              color="red"
+                              onSelect={() => setPendingRemoval(key)}
+                            >
+                              Remove from product…
+                            </DropdownMenu.Item>
+                          </>
+                        )}
+                      </DropdownMenu.Content>
+                    </DropdownMenu.Root>
                   )}
                 </Flex>
+
                 {/* Prefix is editable only for users who can manage both the
                     owning account and this connection; the server action
                     re-checks. Others see it read-only. */}
-                {editablePrefixConnections.has(mirror.connection_id) ? (
-                  <Form action={prefixAction}>
-                    <input
-                      type="hidden"
-                      name="account_id"
-                      value={product.account_id}
-                    />
-                    <input
-                      type="hidden"
-                      name="product_id"
-                      value={product.product_id}
-                    />
-                    <input type="hidden" name="mirror_key" value={key} />
-                    <Field
-                      label="Prefix"
-                      hint="You can edit this prefix because you manage both this product's account and its data connection."
-                    >
-                      <Flex gap="2" align="center">
-                        <TextField.Root
-                          name="prefix"
-                          size="1"
-                          defaultValue={mirror.prefix}
-                          placeholder="(connection root)"
-                          style={{
-                            flex: 1,
-                            fontFamily: "var(--code-font-family)",
-                          }}
-                        />
-                        <Button
-                          type="submit"
-                          size="1"
-                          variant="soft"
-                          disabled={prefixPending}
-                          loading={prefixPending}
-                        >
-                          Save
-                        </Button>
-                      </Flex>
+                <Box
+                  p="4"
+                  style={{
+                    borderTop: "1px solid var(--gray-5)",
+                    backgroundColor: "var(--gray-2)",
+                  }}
+                >
+                  {canEditPrefix ? (
+                    <Form action={prefixAction}>
+                      <input
+                        type="hidden"
+                        name="account_id"
+                        value={product.account_id}
+                      />
+                      <input
+                        type="hidden"
+                        name="product_id"
+                        value={product.product_id}
+                      />
+                      <input type="hidden" name="mirror_key" value={key} />
+                      <Field
+                        label="Prefix"
+                        help="Where this product's objects sit inside the connection. You can change it because you manage both this product's account and its connection."
+                      >
+                        {(controlProps) => (
+                          <Flex gap="2" align="center">
+                            <TextField.Root
+                              {...controlProps}
+                              name="prefix"
+                              size="1"
+                              defaultValue={mirror.prefix}
+                              placeholder="(connection root)"
+                              style={{
+                                flex: 1,
+                                fontFamily: "var(--code-font-family)",
+                              }}
+                            />
+                            <Button
+                              type="submit"
+                              size="1"
+                              variant="soft"
+                              onClick={() => setActedOn(key)}
+                              disabled={prefixPending}
+                              loading={prefixPending}
+                            >
+                              Save
+                            </Button>
+                          </Flex>
+                        )}
+                      </Field>
+                    </Form>
+                  ) : (
+                    <Field label="Prefix" group>
+                      <Code size="2" variant="ghost" color="gray">
+                        {mirror.prefix || "(connection root)"}
+                      </Code>
                     </Field>
-                  </Form>
-                ) : (
-                  <Field label="Prefix">
-                    <Code size="2" variant="ghost" color="gray">
-                      {mirror.prefix}
-                    </Code>
-                  </Field>
-                )}
-              </Flex>
-            </Card>
-          ))}
+                  )}
+
+                  {rowMessage(key) && <Box mt="2">{rowMessage(key)}</Box>}
+                </Box>
+              </Box>
+            );
+          })}
         </Flex>
       )}
 
-      {removeState.message && (
-        <Text size="2" color={removeState.success ? "green" : "red"}>
-          {removeState.message}
-        </Text>
-      )}
-      {primaryState.message && (
-        <Text size="2" color={primaryState.success ? "green" : "red"}>
-          {primaryState.message}
-        </Text>
-      )}
-      {prefixState.message && (
-        <Text size="2" color={prefixState.success ? "green" : "red"}>
-          {prefixState.message}
-        </Text>
-      )}
-      {(addState.success ||
-        removeState.success ||
-        primaryState.success ||
-        prefixState.success) && (
-        <Text size="2" color="amber">
-          Data connections are cached on the data proxy; changes may take up to
-          5 minutes to take effect.
-        </Text>
-      )}
-
-      {canManageMirrors && unusedConnections.length > 0 && (
-        <Flex direction="column" gap="2">
-          <Text size="3" weight="medium">
-            Add Data Connection
-          </Text>
-          <Form action={addAction}>
-            <input
-              type="hidden"
-              name="account_id"
-              value={product.account_id}
-            />
-            <input
-              type="hidden"
-              name="product_id"
-              value={product.product_id}
-            />
-            <Flex gap="2" align="end">
-              <Select.Root name="connection_id" size="2" required>
-                <Select.Trigger
-                  placeholder="Select a data connection..."
-                  style={{ flex: 1 }}
+      {canManageMirrors && (
+        <Box mt="6">
+          <SectionHeader title="Add a connection">
+            {unusedConnections.length === 0 ? (
+              <Text size="2" color="gray">
+                {availableConnections.length === 0
+                  ? "No other connections are available to this account."
+                  : "Every connection available to this account is already attached."}
+              </Text>
+            ) : (
+              <Form action={addAction}>
+                <input
+                  type="hidden"
+                  name="account_id"
+                  value={product.account_id}
                 />
-                <Select.Content>
-                  {unusedConnections.map((conn) => (
-                    <Select.Item
-                      key={conn.data_connection_id}
-                      value={conn.data_connection_id}
-                    >
-                      {conn.name} ({conn.provider}
-                      {conn.region ? ` - ${conn.region}` : ""})
-                    </Select.Item>
-                  ))}
-                </Select.Content>
-              </Select.Root>
-              <Button
-                type="submit"
+                <input
+                  type="hidden"
+                  name="product_id"
+                  value={product.product_id}
+                />
+                <Flex gap="2" align="center">
+                  <Select.Root name="connection_id" size="2" required>
+                    <Select.Trigger
+                      placeholder="Choose a connection…"
+                      style={{ flex: 1 }}
+                    />
+                    <Select.Content>
+                      {unusedConnections.map((conn) => (
+                        <Select.Item
+                          key={conn.data_connection_id}
+                          value={conn.data_connection_id}
+                        >
+                          {conn.name} ({conn.provider}
+                          {conn.region ? ` - ${conn.region}` : ""})
+                        </Select.Item>
+                      ))}
+                    </Select.Content>
+                  </Select.Root>
+                  <Button
+                    type="submit"
+                    size="2"
+                    disabled={addPending}
+                    loading={addPending}
+                  >
+                    Add
+                  </Button>
+                </Flex>
+              </Form>
+            )}
+            {addState.message && (
+              <Text
+                as="p"
                 size="2"
-                disabled={addPending}
-                loading={addPending}
+                mt="2"
+                color={addState.success ? "green" : "red"}
               >
-                Add
-              </Button>
-            </Flex>
-          </Form>
-          {addState.message && (
-            <Text size="2" color={addState.success ? "green" : "red"}>
-              {addState.message}
-            </Text>
-          )}
-        </Flex>
+                {addState.message}
+              </Text>
+            )}
+          </SectionHeader>
+        </Box>
       )}
-    </Flex>
+
+      {/* Removing a mirror re-points where this product is served from, so it
+          asks first — as deleting a connection already does. */}
+      <AlertDialog.Root
+        open={pendingRemoval !== null}
+        onOpenChange={(open) => !open && setPendingRemoval(null)}
+      >
+        <AlertDialog.Content maxWidth="450px">
+          <AlertDialog.Title>Remove {removalName}?</AlertDialog.Title>
+          <AlertDialog.Description size="2">
+            This product will no longer be served from that storage. The objects
+            themselves are not deleted, and you can attach the connection again
+            later.
+          </AlertDialog.Description>
+          <Flex gap="3" mt="4" justify="end">
+            <AlertDialog.Cancel>
+              <Button variant="soft" color="gray">
+                Cancel
+              </Button>
+            </AlertDialog.Cancel>
+            <Button
+              color="red"
+              disabled={removePending}
+              loading={removePending}
+              onClick={() => {
+                if (pendingRemoval) {
+                  dispatchForMirror(removeAction, pendingRemoval);
+                }
+                setPendingRemoval(null);
+              }}
+            >
+              Remove
+            </Button>
+          </Flex>
+        </AlertDialog.Content>
+      </AlertDialog.Root>
+    </Box>
   );
 }

--- a/src/components/features/data-connections/ProductMirrorsManager.tsx
+++ b/src/components/features/data-connections/ProductMirrorsManager.tsx
@@ -64,6 +64,33 @@ const emptyFormState = {
   success: false,
 };
 
+/** Which per-mirror action a result came from. */
+export type MirrorAction = "remove" | "primary" | "prefix";
+
+interface ActionResult {
+  message: string;
+  success: boolean;
+}
+
+/**
+ * The result belonging to one row, or null.
+ *
+ * Each action has its own useActionState, and those never reset — a state keeps
+ * its last message until that same action runs again. So "whichever state still
+ * has a message" is not the same question as "what just happened here": remove a
+ * mirror, then save a prefix on another row, and the stale remove message would
+ * win on the row that saved. Both the row and the action have to match.
+ */
+export function resultForRow(
+  acted: { key: string; action: MirrorAction } | null,
+  key: string,
+  states: Record<MirrorAction, ActionResult>
+): ActionResult | null {
+  if (acted?.key !== key) return null;
+  const state = states[acted.action];
+  return state.message ? state : null;
+}
+
 export function ProductMirrorsManager({
   product,
   availableConnections,
@@ -92,9 +119,13 @@ export function ProductMirrorsManager({
     emptyFormState
   );
 
-  // Which mirror the last action targeted, so its result renders on that row
-  // instead of joining a pile of messages at the foot of the page.
-  const [actedOn, setActedOn] = useState<string | null>(null);
+  // Which mirror the last action targeted and which action it was, so its result
+  // renders on that row instead of joining a pile of messages at the foot of the
+  // page. The action matters as much as the row — see resultForRow.
+  const [actedOn, setActedOn] = useState<{
+    key: string;
+    action: MirrorAction;
+  } | null>(null);
   // The mirror queued for removal, i.e. the open confirmation.
   const [pendingRemoval, setPendingRemoval] = useState<string | null>(null);
 
@@ -103,13 +134,14 @@ export function ProductMirrorsManager({
   // card, and a menu item cannot submit a form it does not contain.
   const dispatchForMirror = (
     action: (formData: FormData) => void,
-    mirrorKey: string
+    mirrorKey: string,
+    kind: MirrorAction
   ) => {
     const formData = new FormData();
     formData.set("account_id", product.account_id);
     formData.set("product_id", product.product_id);
     formData.set("mirror_key", mirrorKey);
-    setActedOn(mirrorKey);
+    setActedOn({ key: mirrorKey, action: kind });
     startTransition(() => action(formData));
   };
 
@@ -136,10 +168,11 @@ export function ProductMirrorsManager({
 
   /** The result of the last action, shown against the row that caused it. */
   const rowMessage = (key: string) => {
-    if (actedOn !== key) return null;
-    const state = [removeState, primaryState, prefixState].find(
-      (candidate) => candidate.message
-    );
+    const state = resultForRow(actedOn, key, {
+      remove: removeState,
+      primary: primaryState,
+      prefix: prefixState,
+    });
     if (!state) return null;
     return (
       <Text size="1" color={state.success ? "green" : "red"}>
@@ -273,7 +306,7 @@ export function ProductMirrorsManager({
                         {canManageMirrors && !mirror.is_primary && (
                           <DropdownMenu.Item
                             onSelect={() =>
-                              dispatchForMirror(primaryAction, key)
+                              dispatchForMirror(primaryAction, key, "primary")
                             }
                           >
                             Make primary
@@ -362,7 +395,7 @@ export function ProductMirrorsManager({
                               type="submit"
                               size="1"
                               variant="soft"
-                              onClick={() => setActedOn(key)}
+                              onClick={() => setActedOn({ key, action: "prefix" })}
                               disabled={prefixPending}
                               loading={prefixPending}
                             >
@@ -477,7 +510,7 @@ export function ProductMirrorsManager({
               loading={removePending}
               onClick={() => {
                 if (pendingRemoval) {
-                  dispatchForMirror(removeAction, pendingRemoval);
+                  dispatchForMirror(removeAction, pendingRemoval, "remove");
                 }
                 setPendingRemoval(null);
               }}


### PR DESCRIPTION
Implements the **Data connections** page of the [design canvas](https://claude.ai/code/artifact/66c8a032-8f0d-474f-86d6-09a5a9af24f6). Three surfaces; the safety items first.

## Product mirror cards

**Removing a connection was one click, no confirmation** — a `size="1"` soft button between "Edit" and "Set Primary". Removing a mirror re-points where a product's bytes are served from. Meanwhile `DeleteDataConnectionButton` already guards *deleting* a connection behind an AlertDialog, and `DeleteProductModal` makes you type the full `account/product`. Three standards for comparable risk in one app. It now asks first, naming the connection, and says what *doesn't* happen — the objects aren't deleted — which is the sentence that settles the hesitation.

**Three same-weight buttons become one overflow menu.** Only hue separated the destructive one; now it's red inside a menu, where red means something.

**Results render on the row that caused them.** Four message slots stacked at the foot of the page, so acting on the third card reported below the fifth — and never named which connection.

**The proxy-cache caveat is a standing callout** above the list, rather than amber text that appeared *after* a save. It's worth knowing before you act.

**The add picker no longer vanishes** when every available connection is attached — it says which of the two reasons applies.

Mechanically: the three actions now dispatch directly rather than each living in its own `<Form>`. They carried identical values, so as markup that was nine hidden inputs per card, and a menu item can't submit a form it doesn't contain. This also retires this file's local `Field` — the third copy of the anatomy — for the shared one.

## Connections list

**Read-only rendered as a red "Yes".** Red reads as fault, but read-only is deliberate — it's how AWS Open Data works — so the most trustworthy row was painted like an error, while every writable row carried a green "No" announcing that nothing had happened. Now a marker, shown only when true.

**Provider colours were decorative.** Orange/blue/green per provider encoded nothing actionable, and in a gray-accent theme they were the only colour on the page. Provider and region fold into one mono `Storage` cell, which also absorbs the unexplained em-dash for regionless GCS.

Four new tests cover exactly this: the marker appears when true, *nothing* is said when false, and the storage cell folds correctly with and without a region.

## Connection edit

**Delete moves out of the page header** — the most prominent slot, above the form — into a `DangerZone` below the usage list, which is what answers "can I delete this?". Applied to both the account-scoped and admin pages.

**The blocker is stated on the disabled control.** `DeleteConnectionControl` already resolves the dependent-product count before rendering, yet the button looked live and the reason only appeared once you'd opened the dialog.

## Not in this PR

The connection **form** itself — sections, provider as radio cards, conditional-group rules, the prefix-template preview, and the Stored / Not set state on secrets. That last one is the sharpest remaining item: in edit mode a secret field renders empty whether or not a credential exists, so you can't tell an authenticated connection from a broken one. It's a larger change and wants its own review.

## Verification

`tsc` clean · jest 59 suites / 520 tests · `next lint` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mnsg8m1dXZ5z5ig5xMtkE
