### PR TITLE
refactor(products): move Status into the Access section

### DIFF
--- a/src/components/features/products/ProductCreationForm.tsx
+++ b/src/components/features/products/ProductCreationForm.tsx
@@ -323,9 +323,6 @@ export function ProductCreationForm({
             label: "Status",
             name: "disabled" as keyof Product,
             type: "switch",
-            // Belongs with Visibility: both answer "who can reach this", and a
-            // section holding one field repeated its own name as that field's
-            // label.
             section: "Access",
             switchLabel: disabled ? "Deactivated" : "Active",
             invert: true,

--- a/src/components/features/products/ProductCreationForm.tsx
+++ b/src/components/features/products/ProductCreationForm.tsx
@@ -323,7 +323,10 @@ export function ProductCreationForm({
             label: "Status",
             name: "disabled" as keyof Product,
             type: "switch",
-            section: "Status",
+            // Belongs with Visibility: both answer "who can reach this", and a
+            // section holding one field repeated its own name as that field's
+            // label.
+            section: "Access",
             switchLabel: disabled ? "Deactivated" : "Active",
             invert: true,
             description:


### PR DESCRIPTION
One line, off main, independent of #498 and #499.

Status had a section to itself holding exactly one field, so the heading and the field label both read **"Status"** — the same word twice, one line apart, for a single switch.

It belongs with Visibility anyway: both answer *who can reach this product*. Visibility decides which audience; Status decides whether anyone can at all. Reading them together is how the question actually gets asked — "is it live, and to whom".

Before / after:

```
Access                      Access
  Visibility  [cards]         Visibility  [cards]
Status                        Status      [switch]
  Status      [switch]
```

`section` grouping is `DynamicForm`'s, so this is a one-word change to the field definition — no layout code involved.

## Verification

`tsc` clean · jest 59 suites / 516 tests · `next lint` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mnsg8m1dXZ5z5ig5xMtkE
