### PR TITLE
feat(products): show a deactivated product's switch in red

### DIFF
--- a/src/components/core/DynamicForm.tsx
+++ b/src/components/core/DynamicForm.tsx
@@ -68,6 +68,12 @@ interface BaseFormField<T extends Record<string, any>> {
   /** Label beside the control, for `switch`. */
   switchLabel?: string;
   /**
+   * `switch` only: draw the off state in red. For a switch whose off state
+   * takes something away rather than merely being the other setting, so the
+   * control reads as a warning without having to read the label.
+   */
+  dangerWhenOff?: boolean;
+  /**
    * `switch` only: the switch reads on when the value is "false". For flags
    * stored as the negative of what the user is being asked (`disabled`), so the
    * affirmative reading stays on the left.
@@ -413,6 +419,7 @@ export function DynamicForm<T extends Record<string, any>>({
     if (field.type === "switch") {
       const raw = field.value === "true";
       const checked = field.invert ? !raw : raw;
+      const danger = !!field.dangerWhenOff && !checked;
       return (
         <>
           <input type="hidden" name={name} value={String(raw)} />
@@ -420,13 +427,18 @@ export function DynamicForm<T extends Record<string, any>>({
             <Switch
               {...controlProps}
               size="2"
+              className={danger ? "switch-danger" : undefined}
               checked={checked}
               disabled={isDisabled}
               onCheckedChange={(next: boolean) =>
                 handleControlledChange(name, String(field.invert ? !next : next))
               }
             />
-            {field.switchLabel && <Text size="2">{field.switchLabel}</Text>}
+            {field.switchLabel && (
+              <Text size="2" color={danger ? "red" : undefined}>
+                {field.switchLabel}
+              </Text>
+            )}
           </Flex>
         </>
       );

--- a/src/components/core/__tests__/DynamicForm.test.tsx
+++ b/src/components/core/__tests__/DynamicForm.test.tsx
@@ -163,6 +163,28 @@ describe("DynamicForm label wiring", () => {
     expect(screen.getByLabelText("Status")).toBeInTheDocument();
   });
 
+  it("marks a dangerWhenOff switch red only while it is off", () => {
+    const danger = {
+      type: "switch" as const,
+      invert: true,
+      dangerWhenOff: true,
+      controlled: true as const,
+      onValueChange: () => {},
+    };
+
+    renderForm([
+      { ...danger, label: "Deactivated product", name: "off", value: "true" },
+      { ...danger, label: "Active product", name: "on", value: "false" },
+    ]);
+
+    expect(screen.getByLabelText("Deactivated product")).toHaveClass(
+      "switch-danger"
+    );
+    expect(screen.getByLabelText("Active product")).not.toHaveClass(
+      "switch-danger"
+    );
+  });
+
   it("leaves no label pointing at an id that does not exist", () => {
     // The defect this whole refactor exists to prevent, asserted across every
     // field type at once.

--- a/src/components/features/products/ProductCreationForm.tsx
+++ b/src/components/features/products/ProductCreationForm.tsx
@@ -326,6 +326,7 @@ export function ProductCreationForm({
             section: "Status",
             switchLabel: disabled ? "Deactivated" : "Active",
             invert: true,
+            dangerWhenOff: true,
             description:
               "Deactivating hides the product from source.coop and blocks the data.source.coop API. The data is kept, but only a Source Cooperative administrator can reactivate it.",
             controlled: true,

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -142,3 +142,11 @@ a.rt-BaseMenuItem,
 .animate-spin {
   animation: spin 1s linear infinite;
 }
+
+/* A switch whose off state takes something away reads red, not merely grey.
+   Radix paints the track on ::before; the [data-state] selector outspecifies
+   its :where()-wrapped variant rule. */
+.switch-danger[data-state="unchecked"]::before {
+  background-color: var(--red-a5);
+  box-shadow: inset 0 0 0 1px var(--red-a7);
+}


### PR DESCRIPTION
The Status switch looked the same whether a product was active or deactivated — just off. Deactivating is the state that hides the product from source.coop, blocks the data.source.coop API, and needs a Source Cooperative administrator to undo, so it should not read as an ordinary off position.

Deactivated now paints the switch track red and the adjacent "Deactivated" label red.

## How

Radix Themes paints the switch track on `::before` and its `color` prop only tints the *checked* state, so the off state needs a rule of its own. `.switch-danger[data-state="unchecked"]::before` overrides the track colour; Radix wraps its own variant selectors in `:where()`, so the plain attribute selector outspecifies them without `!important`.

`DynamicForm` gains an opt-in `dangerWhenOff` on switch fields — the product Status switch is the only field that sets it. Switches where off is merely the other setting stay grey.

## Testing

- New `DynamicForm` test asserts the class is applied only while the switch is off (10/10 in that suite pass).
- Product component suites pass (8/8).
- `tsc` clean for the touched files.
- Not verified in a browser — the exact red shade is unconfirmed visually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
