### PR TITLE
feat(accounts): type-ahead user search in invite and admin lookup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@radix-ui/react-form": "^0.1.3-rc.7",
         "@radix-ui/react-icons": "^1.3.2",
         "@radix-ui/react-label": "^2.1.2",
+        "@radix-ui/react-popover": "^1.1.6",
         "@radix-ui/react-select": "^2.1.6",
         "@radix-ui/themes": "^3.2.1",
         "@tanstack/react-virtual": "^3.13.4",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@radix-ui/react-form": "^0.1.3-rc.7",
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/react-label": "^2.1.2",
+    "@radix-ui/react-popover": "^1.1.6",
     "@radix-ui/react-select": "^2.1.6",
     "@radix-ui/themes": "^3.2.1",
     "@tanstack/react-virtual": "^3.13.4",

--- a/src/app/(app)/admin/user-lookup/page.tsx
+++ b/src/app/(app)/admin/user-lookup/page.tsx
@@ -13,7 +13,7 @@ export default function AdminUserLookupPage() {
     <Box>
       <FormTitle
         title="User lookup"
-        description="Find a user by email and open their profile."
+        description="Find a user by username, name, or email and open their profile."
       />
       <AdminUserLookupForm />
     </Box>

--- a/src/components/core/AccountIdentity.tsx
+++ b/src/components/core/AccountIdentity.tsx
@@ -1,0 +1,54 @@
+import { Text, Flex } from "@radix-ui/themes";
+import { MonoText } from "./MonoText";
+
+/**
+ * The surface an account card sits on. Shared so the picker's suggestion list
+ * and the profile hover card are visibly the same object.
+ */
+export const accountCardSurface: React.CSSProperties = {
+  backgroundColor: "var(--gray-2)",
+  border: "1px solid var(--gray-6)",
+  borderRadius: "8px",
+  boxShadow: "0 4px 12px rgba(0, 0, 0, 0.1)",
+};
+
+interface AccountIdentityProps {
+  name: string;
+  accountId: string;
+  /**
+   * Passed in rather than derived, because callers have different amounts to
+   * work with: a profile page holds a whole Account and can render
+   * <ProfileAvatar> with its Gravatar fallback, while a search result holds
+   * only public identity fields and falls back to an initial.
+   */
+  avatar: React.ReactNode;
+  /** Display-name size. The handle stays small so the name leads. */
+  size?: "2" | "3";
+}
+
+/**
+ * Avatar, display name, handle — the way an account is introduced everywhere it
+ * appears out of context: the profile hover card, and the account picker's
+ * suggestions. Shared so a person looks the same in the list they are picked
+ * from as in the card that confirms who they are.
+ */
+export function AccountIdentity({
+  name,
+  accountId,
+  avatar,
+  size = "3",
+}: AccountIdentityProps) {
+  return (
+    <Flex align="center" gap="3">
+      {avatar}
+      <Flex direction="column" gap="1" minWidth="0">
+        <Text size={size} weight="bold">
+          {name}
+        </Text>
+        <MonoText size="1" color="gray">
+          @{accountId}
+        </MonoText>
+      </Flex>
+    </Flex>
+  );
+}

--- a/src/components/core/AccountInfoHoverCard.tsx
+++ b/src/components/core/AccountInfoHoverCard.tsx
@@ -1,6 +1,6 @@
 import { Text, Flex, HoverCard } from "@radix-ui/themes";
-import { MonoText } from "./MonoText";
 import { Account } from "@/types";
+import { AccountIdentity, accountCardSurface } from "./AccountIdentity";
 import { ProfileAvatar } from "../features/profiles";
 
 interface AccountInfoHoverCardProps {
@@ -28,26 +28,17 @@ export function AccountInfoHoverCard({
       <HoverCard.Content
         sideOffset={5}
         style={{
+          ...accountCardSurface,
           maxWidth: "300px",
           padding: "16px",
-          backgroundColor: "var(--gray-2)",
-          border: "1px solid var(--gray-6)",
-          borderRadius: "8px",
-          boxShadow: "0 4px 12px rgba(0, 0, 0, 0.1)",
         }}
       >
         <Flex direction="column" gap="3">
-          <Flex align="center" gap="3">
-            <ProfileAvatar account={account} size="2" />
-            <Flex direction="column" gap="1">
-              <Text size="3" weight="bold">
-                {account.name}
-              </Text>
-              <MonoText size="1" color="gray">
-                @{account.account_id}
-              </MonoText>
-            </Flex>
-          </Flex>
+          <AccountIdentity
+            name={account.name}
+            accountId={account.account_id}
+            avatar={<ProfileAvatar account={account} size="2" />}
+          />
 
           {account.metadata_public?.bio && (
             <Text size="2" color="gray">

--- a/src/components/core/AccountSearchInput.test.tsx
+++ b/src/components/core/AccountSearchInput.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { Theme } from "@radix-ui/themes";
+import { Dialog, Theme } from "@radix-ui/themes";
 import { AccountSearchInput } from "./AccountSearchInput";
 import { searchAccounts } from "@/lib/actions/account";
 
@@ -85,6 +85,33 @@ describe("AccountSearchInput", () => {
     });
     // "jane" only. Writing the handle into the input must not read as typing.
     expect(mockSearchAccounts).not.toHaveBeenCalledWith("jane-doe");
+  });
+
+  it("escapes the dialog it sits in rather than being clipped by it", async () => {
+    // The invite form is a Dialog, whose content is its own scroll box: a list
+    // positioned inside the field was cut off at the dialog's edge. It has to
+    // portal out -- and still be reachable, since a modal marks everything
+    // outside it aria-hidden.
+    const user = userEvent.setup();
+    render(
+      <Theme>
+        <Dialog.Root defaultOpen>
+          <Dialog.Content>
+            <Dialog.Title>Invite New Member</Dialog.Title>
+            <AccountSearchInput name="account_id" />
+          </Dialog.Content>
+        </Dialog.Root>
+      </Theme>
+    );
+
+    const input = screen.getByRole("combobox");
+    await user.type(input, "jane");
+
+    const options = await screen.findAllByRole("option");
+    expect(options[0].closest('[role="dialog"]')).toBeNull();
+
+    await user.click(screen.getByText("Janet Reyes"));
+    expect(input).toHaveValue("janet-r");
   });
 
   it("reports busy while the lookup is outstanding, and stops when it lands", async () => {

--- a/src/components/core/AccountSearchInput.test.tsx
+++ b/src/components/core/AccountSearchInput.test.tsx
@@ -12,21 +12,25 @@ const mockSearchAccounts = searchAccounts as jest.MockedFunction<
   typeof searchAccounts
 >;
 
+const renderInput = () =>
+  render(
+    <Theme>
+      <AccountSearchInput name="account_id" />
+    </Theme>
+  );
+
 describe("AccountSearchInput", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockSearchAccounts.mockResolvedValue([
       { account_id: "jane-doe", name: "Jane Doe" },
+      { account_id: "janet-r", name: "Janet Reyes" },
     ]);
   });
 
-  it("offers matching accounts as datalist options, keyed by handle", async () => {
+  it("shows each match as an account card, name and handle", async () => {
     const user = userEvent.setup();
-    render(
-      <Theme>
-        <AccountSearchInput name="account_id" />
-      </Theme>
-    );
+    renderInput();
 
     await user.type(screen.getByRole("combobox"), "jane");
 
@@ -34,11 +38,88 @@ describe("AccountSearchInput", () => {
       expect(mockSearchAccounts).toHaveBeenCalledWith("jane");
     });
 
-    const option = await screen.findByText("Jane Doe");
-    expect(option).toHaveValue("jane-doe");
-    // The <datalist> is what makes the browser render the suggestions.
-    expect(option.closest("datalist")?.id).toBe(
-      screen.getByRole("combobox").getAttribute("list")
+    const options = await screen.findAllByRole("option");
+    expect(options).toHaveLength(2);
+    expect(options[0]).toHaveTextContent("Jane Doe");
+    // The handle is what identifies the account, so it is on the card too --
+    // two people can share a display name.
+    expect(options[0]).toHaveTextContent("@jane-doe");
+  });
+
+  it("submits the handle, not the display name, when a match is clicked", async () => {
+    const user = userEvent.setup();
+    renderInput();
+
+    const input = screen.getByRole("combobox");
+    await user.type(input, "jane");
+
+    const option = await screen.findByText("Janet Reyes");
+    await user.click(option);
+
+    expect(input).toHaveValue("janet-r");
+  });
+
+  it("chooses with the keyboard without focus leaving the input", async () => {
+    const user = userEvent.setup();
+    renderInput();
+
+    const input = screen.getByRole("combobox");
+    await user.type(input, "jane");
+    await screen.findAllByRole("option");
+
+    await user.keyboard("{ArrowDown}{ArrowDown}{Enter}");
+
+    expect(input).toHaveValue("janet-r");
+    expect(input).toHaveFocus();
+  });
+
+  it("does not search again for the account just chosen", async () => {
+    const user = userEvent.setup();
+    renderInput();
+
+    await user.type(screen.getByRole("combobox"), "jane");
+    await user.click(await screen.findByText("Jane Doe"));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    });
+    // "jane" only. Writing the handle into the input must not read as typing.
+    expect(mockSearchAccounts).not.toHaveBeenCalledWith("jane-doe");
+  });
+
+  it("reports busy while the lookup is outstanding, and stops when it lands", async () => {
+    const user = userEvent.setup();
+    let resolve: (value: Awaited<ReturnType<typeof searchAccounts>>) => void =
+      () => {};
+    mockSearchAccounts.mockReturnValue(
+      new Promise((r) => {
+        resolve = r;
+      })
     );
+
+    renderInput();
+    const input = screen.getByRole("combobox");
+    await user.type(input, "jane");
+
+    // aria-busy rather than the spinner element: the spinner is decorative, and
+    // its markup is Radix's to change.
+    await waitFor(() => expect(input).toHaveAttribute("aria-busy", "true"));
+
+    resolve([{ account_id: "jane-doe", name: "Jane Doe" }]);
+
+    await waitFor(() => expect(input).toHaveAttribute("aria-busy", "false"));
+  });
+
+  it("stays quiet until there is enough to match on", async () => {
+    const user = userEvent.setup();
+    renderInput();
+
+    await user.type(screen.getByRole("combobox"), "j");
+    // Past the debounce, so this fails if a one-character query is merely slow
+    // rather than actually suppressed.
+    await new Promise((resolve) => setTimeout(resolve, 400));
+
+    // A single character matches most of the table; the round trip is waste.
+    expect(mockSearchAccounts).not.toHaveBeenCalled();
   });
 });

--- a/src/components/core/AccountSearchInput.test.tsx
+++ b/src/components/core/AccountSearchInput.test.tsx
@@ -87,6 +87,24 @@ describe("AccountSearchInput", () => {
     expect(mockSearchAccounts).not.toHaveBeenCalledWith("jane-doe");
   });
 
+  it("keeps searching after choosing the handle that was typed in full", async () => {
+    // Typing a handle out and then confirming it from the list writes back the
+    // value already in the input. Suppressing "the search for what was just
+    // chosen" must not outlive that non-event and swallow the next real edit.
+    const user = userEvent.setup();
+    renderInput();
+
+    const input = screen.getByRole("combobox");
+    await user.type(input, "jane-doe");
+    await user.click(await screen.findByText("Jane Doe"));
+
+    await user.type(input, "x");
+
+    await waitFor(() => {
+      expect(mockSearchAccounts).toHaveBeenCalledWith("jane-doex");
+    });
+  });
+
   it("escapes the dialog it sits in rather than being clipped by it", async () => {
     // The invite form is a Dialog, whose content is its own scroll box: a list
     // positioned inside the field was cut off at the dialog's edge. It has to

--- a/src/components/core/AccountSearchInput.test.tsx
+++ b/src/components/core/AccountSearchInput.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Theme } from "@radix-ui/themes";
+import { AccountSearchInput } from "./AccountSearchInput";
+import { searchAccounts } from "@/lib/actions/account";
+
+jest.mock("@/lib/actions/account", () => ({
+  searchAccounts: jest.fn(),
+}));
+
+const mockSearchAccounts = searchAccounts as jest.MockedFunction<
+  typeof searchAccounts
+>;
+
+describe("AccountSearchInput", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSearchAccounts.mockResolvedValue([
+      { account_id: "jane-doe", name: "Jane Doe" },
+    ]);
+  });
+
+  it("offers matching accounts as datalist options, keyed by handle", async () => {
+    const user = userEvent.setup();
+    render(
+      <Theme>
+        <AccountSearchInput name="account_id" />
+      </Theme>
+    );
+
+    await user.type(screen.getByRole("combobox"), "jane");
+
+    await waitFor(() => {
+      expect(mockSearchAccounts).toHaveBeenCalledWith("jane");
+    });
+
+    const option = await screen.findByText("Jane Doe");
+    expect(option).toHaveValue("jane-doe");
+    // The <datalist> is what makes the browser render the suggestions.
+    expect(option.closest("datalist")?.id).toBe(
+      screen.getByRole("combobox").getAttribute("list")
+    );
+  });
+});

--- a/src/components/core/AccountSearchInput.tsx
+++ b/src/components/core/AccountSearchInput.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useEffect, useId, useState } from "react";
+import { TextField } from "@radix-ui/themes";
+import { searchAccounts } from "@/lib/actions/account";
+import type { ControlProps } from "./DynamicForm";
+
+interface AccountSearchInputProps extends Partial<ControlProps> {
+  name: string;
+  required?: boolean;
+  placeholder?: string;
+  defaultValue?: string;
+}
+
+/**
+ * Text input backed by a native `<datalist>`: the browser draws the suggestion
+ * list and handles its keyboard navigation and accessibility, so we only fetch
+ * the options. Suggestions are individual accounts whose handle or display name
+ * matches what has been typed, and the submitted value is always the handle.
+ *
+ * ponytail: no combobox library, no custom popover. Where `<datalist>` is
+ * unsupported this degrades to the plain text input it replaced.
+ */
+export function AccountSearchInput({
+  name,
+  required,
+  placeholder,
+  defaultValue = "",
+  ...controlProps
+}: AccountSearchInputProps) {
+  const listId = useId();
+  const [query, setQuery] = useState(defaultValue);
+  const [matches, setMatches] = useState<
+    Array<{ account_id: string; name: string }>
+  >([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const timer = setTimeout(() => {
+      searchAccounts(query)
+        .then((results) => {
+          if (!cancelled) setMatches(results);
+        })
+        .catch(() => {
+          if (!cancelled) setMatches([]);
+        });
+    }, 250);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [query]);
+
+  return (
+    <>
+      <TextField.Root
+        {...controlProps}
+        type="text"
+        name={name}
+        size="3"
+        list={listId}
+        required={required}
+        placeholder={placeholder}
+        value={query}
+        onChange={(event) => setQuery(event.target.value)}
+        autoComplete="off"
+      />
+      <datalist id={listId}>
+        {matches.map((match) => (
+          <option key={match.account_id} value={match.account_id}>
+            {match.name}
+          </option>
+        ))}
+      </datalist>
+    </>
+  );
+}

--- a/src/components/core/AccountSearchInput.tsx
+++ b/src/components/core/AccountSearchInput.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { useEffect, useId, useRef, useState } from "react";
-import { Avatar, Box, Spinner, TextField } from "@radix-ui/themes";
+import { Avatar, Box, Spinner, TextField, Theme } from "@radix-ui/themes";
+// The primitive rather than `Popover` from @radix-ui/themes: that wrapper's
+// Anchor destructures `children` away and never renders them, so the field
+// inside it disappears. Same package Themes builds its own Popover on, and the
+// repo already depends on four other @radix-ui/react-* primitives directly.
+import * as PopoverPrimitive from "@radix-ui/react-popover";
 import { searchAccounts } from "@/lib/actions/account";
 import type { AccountSuggestion } from "@/lib/clients/database/accounts";
 import { AccountIdentity, accountCardSurface } from "./AccountIdentity";
@@ -119,91 +124,105 @@ export function AccountSearchInput({
   }
 
   return (
-    <Box position="relative">
-      <TextField.Root
-        {...controlProps}
-        type="text"
-        name={name}
-        size="3"
-        required={required}
-        placeholder={placeholder}
-        value={query}
-        onChange={(event) => setQuery(event.target.value)}
-        onKeyDown={onKeyDown}
-        onBlur={() => setOpen(false)}
-        autoComplete="off"
-        role="combobox"
-        aria-autocomplete="list"
-        // The spinner is decorative; this is what tells a screen reader the
-        // suggestions are still being fetched.
-        aria-busy={loading}
-        aria-expanded={open}
-        aria-controls={listId}
-        aria-activedescendant={
-          open && activeIndex >= 0 ? optionId(activeIndex) : undefined
-        }
-      >
-        {/* Always mounted so the text does not shift when the spinner appears. */}
-        <TextField.Slot side="right">
-          <Spinner loading={loading} />
-        </TextField.Slot>
-      </TextField.Root>
-
-      {open && (
-        <Box
-          id={listId}
-          role="listbox"
-          aria-label="Matching accounts"
-          position="absolute"
-          left="0"
-          right="0"
-          mt="1"
-          py="1"
-          style={{
-            ...accountCardSurface,
-            zIndex: 10,
-            maxHeight: "18rem",
-            overflowY: "auto",
-          }}
+    <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
+      <PopoverPrimitive.Anchor>
+        <TextField.Root
+          {...controlProps}
+          type="text"
+          name={name}
+          size="3"
+          required={required}
+          placeholder={placeholder}
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          onKeyDown={onKeyDown}
+          onBlur={() => setOpen(false)}
+          autoComplete="off"
+          role="combobox"
+          aria-autocomplete="list"
+          // The spinner is decorative; this is what tells a screen reader the
+          // suggestions are still being fetched.
+          aria-busy={loading}
+          aria-expanded={open}
+          aria-controls={listId}
+          aria-activedescendant={
+            open && activeIndex >= 0 ? optionId(activeIndex) : undefined
+          }
         >
-          {matches.map((match, index) => (
-            <Box
-              key={match.account_id}
-              id={optionId(index)}
-              role="option"
-              aria-selected={index === activeIndex}
-              px="3"
-              py="2"
-              // Pointer, not click: click lands after blur has already closed
-              // the list, so the selection would never register.
-              onMouseDown={(event) => {
-                event.preventDefault();
-                select(match);
-              }}
-              onMouseEnter={() => setActiveIndex(index)}
-              style={{
-                cursor: "pointer",
-                backgroundColor:
-                  index === activeIndex ? "var(--gray-4)" : undefined,
-              }}
-            >
-              <AccountIdentity
-                name={match.name}
-                accountId={match.account_id}
-                size="2"
-                avatar={
-                  <Avatar
-                    size="2"
-                    radius="full"
-                    src={match.profile_image}
-                    fallback={(match.name || match.account_id)[0].toUpperCase()}
-                  />
-                }
-              />
-            </Box>
-          ))}
-        </Box>
-      )}
-    </Box>
+          {/* Always mounted so the text does not shift when the spinner
+              appears. */}
+          <TextField.Slot side="right">
+            <Spinner loading={loading} />
+          </TextField.Slot>
+        </TextField.Root>
+      </PopoverPrimitive.Anchor>
+
+      {/* Portalled, which is the whole reason for the Popover: positioned
+          absolutely inside the field, the list was clipped by the scroll box of
+          any dialog the form sat in -- and the invite form is a dialog.
+          <Theme asChild> because a portal renders outside the theme's element,
+          so without it none of the CSS variables below resolve. */}
+      <PopoverPrimitive.Portal>
+        <Theme asChild>
+          <PopoverPrimitive.Content
+            id={listId}
+            role="listbox"
+            aria-label="Matching accounts"
+            side="bottom"
+            align="start"
+            sideOffset={4}
+            // Focus has to stay on the input: it is the combobox, and it is
+            // what carries aria-activedescendant. Radix would otherwise move
+            // focus here on open and back to the anchor on close.
+            onOpenAutoFocus={(event) => event.preventDefault()}
+            onCloseAutoFocus={(event) => event.preventDefault()}
+            style={{
+              ...accountCardSurface,
+              width: "var(--radix-popover-trigger-width)",
+              maxHeight: "18rem",
+              overflowY: "auto",
+              padding: "var(--space-1)",
+            }}
+          >
+        {matches.map((match, index) => (
+          <Box
+            key={match.account_id}
+            id={optionId(index)}
+            role="option"
+            aria-selected={index === activeIndex}
+            px="3"
+            py="2"
+            // Pointer, not click: click lands after blur has already closed
+            // the list, so the selection would never register.
+            onMouseDown={(event) => {
+              event.preventDefault();
+              select(match);
+            }}
+            onMouseEnter={() => setActiveIndex(index)}
+            style={{
+              cursor: "pointer",
+              backgroundColor:
+                index === activeIndex ? "var(--gray-4)" : undefined,
+            }}
+          >
+            <AccountIdentity
+              name={match.name}
+              accountId={match.account_id}
+              size="2"
+              avatar={
+                <Avatar
+                  size="2"
+                  radius="full"
+                  src={match.profile_image}
+                  fallback={(match.name || match.account_id)[0].toUpperCase()}
+                />
+              }
+            />
+          </Box>
+        ))}
+          </PopoverPrimitive.Content>
+        </Theme>
+      </PopoverPrimitive.Portal>
+    </PopoverPrimitive.Root>
   );
 }

--- a/src/components/core/AccountSearchInput.tsx
+++ b/src/components/core/AccountSearchInput.tsx
@@ -51,11 +51,16 @@ export function AccountSearchInput({
 
   // Choosing a suggestion writes the handle into the input, which would
   // otherwise read as typing and fire a fresh search for the thing just picked.
-  const skipNextSearch = useRef(false);
+  // It holds the chosen handle rather than a bare "skip the next one" flag:
+  // choosing a handle that was already typed out in full leaves the query
+  // untouched, so the effect never runs to clear a flag — which would then
+  // swallow the next genuine edit instead.
+  const justSelected = useRef<string | null>(null);
 
   useEffect(() => {
-    if (skipNextSearch.current) {
-      skipNextSearch.current = false;
+    const selected = justSelected.current;
+    justSelected.current = null;
+    if (selected === query) {
       setLoading(false);
       return;
     }
@@ -95,7 +100,7 @@ export function AccountSearchInput({
   }, [query]);
 
   function select(match: AccountSuggestion) {
-    skipNextSearch.current = true;
+    justSelected.current = match.account_id;
     setQuery(match.account_id);
     setOpen(false);
     setActiveIndex(-1);

--- a/src/components/core/AccountSearchInput.tsx
+++ b/src/components/core/AccountSearchInput.tsx
@@ -1,9 +1,15 @@
 "use client";
 
-import { useEffect, useId, useState } from "react";
-import { TextField } from "@radix-ui/themes";
+import { useEffect, useId, useRef, useState } from "react";
+import { Avatar, Box, Spinner, TextField } from "@radix-ui/themes";
 import { searchAccounts } from "@/lib/actions/account";
+import type { AccountSuggestion } from "@/lib/clients/database/accounts";
+import { AccountIdentity, accountCardSurface } from "./AccountIdentity";
 import type { ControlProps } from "./DynamicForm";
+
+/** Below this, a search matches most of the table and tells you nothing. */
+const MIN_QUERY = 2;
+const DEBOUNCE_MS = 250;
 
 interface AccountSearchInputProps extends Partial<ControlProps> {
   name: string;
@@ -13,13 +19,14 @@ interface AccountSearchInputProps extends Partial<ControlProps> {
 }
 
 /**
- * Text input backed by a native `<datalist>`: the browser draws the suggestion
- * list and handles its keyboard navigation and accessibility, so we only fetch
- * the options. Suggestions are individual accounts whose handle or display name
- * matches what has been typed, and the submitted value is always the handle.
+ * Account picker: type part of a handle or display name, choose from the
+ * matches, and the handle is what gets submitted.
  *
- * ponytail: no combobox library, no custom popover. Where `<datalist>` is
- * unsupported this degrades to the plain text input it replaced.
+ * Each suggestion is the same identity block the profile hover card shows, so
+ * the person you pick from the list looks like the person you land on. That
+ * rules out `<datalist>`, which can only render flat strings — hence the
+ * listbox below, kept to the ARIA combobox pattern: the input owns
+ * `aria-activedescendant` and focus never leaves it.
  */
 export function AccountSearchInput({
   name,
@@ -29,22 +36,52 @@ export function AccountSearchInput({
   ...controlProps
 }: AccountSearchInputProps) {
   const listId = useId();
+  const optionId = (index: number) => `${listId}-option-${index}`;
+
   const [query, setQuery] = useState(defaultValue);
-  const [matches, setMatches] = useState<
-    Array<{ account_id: string; name: string }>
-  >([]);
+  const [matches, setMatches] = useState<AccountSuggestion[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+
+  // Choosing a suggestion writes the handle into the input, which would
+  // otherwise read as typing and fire a fresh search for the thing just picked.
+  const skipNextSearch = useRef(false);
 
   useEffect(() => {
+    if (skipNextSearch.current) {
+      skipNextSearch.current = false;
+      setLoading(false);
+      return;
+    }
+
+    if (query.trim().length < MIN_QUERY) {
+      setMatches([]);
+      setOpen(false);
+      setLoading(false);
+      return;
+    }
+
+    // Set before the debounce rather than around the request alone: the wait is
+    // part of what the reader is waiting through.
+    setLoading(true);
+
     let cancelled = false;
     const timer = setTimeout(() => {
       searchAccounts(query)
         .then((results) => {
-          if (!cancelled) setMatches(results);
+          if (cancelled) return;
+          setMatches(results);
+          setActiveIndex(-1);
+          setOpen(results.length > 0);
         })
         .catch(() => {
           if (!cancelled) setMatches([]);
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false);
         });
-    }, 250);
+    }, DEBOUNCE_MS);
 
     return () => {
       cancelled = true;
@@ -52,27 +89,121 @@ export function AccountSearchInput({
     };
   }, [query]);
 
+  function select(match: AccountSuggestion) {
+    skipNextSearch.current = true;
+    setQuery(match.account_id);
+    setOpen(false);
+    setActiveIndex(-1);
+  }
+
+  function onKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      if (!open && matches.length > 0) {
+        setOpen(true);
+        setActiveIndex(0);
+        return;
+      }
+      setActiveIndex((index) => Math.min(index + 1, matches.length - 1));
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActiveIndex((index) => Math.max(index - 1, 0));
+    } else if (event.key === "Enter" && open && activeIndex >= 0) {
+      // Only swallow Enter when it is being used to choose; otherwise it must
+      // still submit the form.
+      event.preventDefault();
+      select(matches[activeIndex]);
+    } else if (event.key === "Escape") {
+      setOpen(false);
+    }
+  }
+
   return (
-    <>
+    <Box position="relative">
       <TextField.Root
         {...controlProps}
         type="text"
         name={name}
         size="3"
-        list={listId}
         required={required}
         placeholder={placeholder}
         value={query}
         onChange={(event) => setQuery(event.target.value)}
+        onKeyDown={onKeyDown}
+        onBlur={() => setOpen(false)}
         autoComplete="off"
-      />
-      <datalist id={listId}>
-        {matches.map((match) => (
-          <option key={match.account_id} value={match.account_id}>
-            {match.name}
-          </option>
-        ))}
-      </datalist>
-    </>
+        role="combobox"
+        aria-autocomplete="list"
+        // The spinner is decorative; this is what tells a screen reader the
+        // suggestions are still being fetched.
+        aria-busy={loading}
+        aria-expanded={open}
+        aria-controls={listId}
+        aria-activedescendant={
+          open && activeIndex >= 0 ? optionId(activeIndex) : undefined
+        }
+      >
+        {/* Always mounted so the text does not shift when the spinner appears. */}
+        <TextField.Slot side="right">
+          <Spinner loading={loading} />
+        </TextField.Slot>
+      </TextField.Root>
+
+      {open && (
+        <Box
+          id={listId}
+          role="listbox"
+          aria-label="Matching accounts"
+          position="absolute"
+          left="0"
+          right="0"
+          mt="1"
+          py="1"
+          style={{
+            ...accountCardSurface,
+            zIndex: 10,
+            maxHeight: "18rem",
+            overflowY: "auto",
+          }}
+        >
+          {matches.map((match, index) => (
+            <Box
+              key={match.account_id}
+              id={optionId(index)}
+              role="option"
+              aria-selected={index === activeIndex}
+              px="3"
+              py="2"
+              // Pointer, not click: click lands after blur has already closed
+              // the list, so the selection would never register.
+              onMouseDown={(event) => {
+                event.preventDefault();
+                select(match);
+              }}
+              onMouseEnter={() => setActiveIndex(index)}
+              style={{
+                cursor: "pointer",
+                backgroundColor:
+                  index === activeIndex ? "var(--gray-4)" : undefined,
+              }}
+            >
+              <AccountIdentity
+                name={match.name}
+                accountId={match.account_id}
+                size="2"
+                avatar={
+                  <Avatar
+                    size="2"
+                    radius="full"
+                    src={match.profile_image}
+                    fallback={(match.name || match.account_id)[0].toUpperCase()}
+                  />
+                }
+              />
+            </Box>
+          ))}
+        </Box>
+      )}
+    </Box>
   );
 }

--- a/src/components/core/index.ts
+++ b/src/components/core/index.ts
@@ -7,6 +7,7 @@ export { DangerZone } from "./DangerZone";
 export { Skeleton } from "./Skeleton";
 export { FormSkeleton } from "./FormSkeleton";
 export { FormTitle } from "./FormTitle";
+export { AccountSearchInput } from "./AccountSearchInput";
 export { DynamicForm } from "./DynamicForm";
 export type { FormField } from "./DynamicForm";
 export { SmallColumnContainer } from "./SmallColumnContainer";

--- a/src/components/features/accounts/InviteMemberForm.tsx
+++ b/src/components/features/accounts/InviteMemberForm.tsx
@@ -3,7 +3,11 @@
 import { useState } from "react";
 import { Account, MembershipRole, Product } from "@/types";
 import { Flex, Button, Dialog } from "@radix-ui/themes";
-import { DynamicForm, FormField } from "@/components/core";
+import {
+  AccountSearchInput,
+  DynamicForm,
+  FormField,
+} from "@/components/core";
 import { inviteMember } from "@/lib/actions/memberships";
 import { PlusIcon } from "@radix-ui/react-icons";
 
@@ -26,12 +30,19 @@ export function InviteMemberForm({
 
   const fields: FormField<InviteMemberFormData>[] = [
     {
-      label: "Account ID",
+      label: "User",
       name: "account_id",
-      type: "text",
+      type: "custom",
       required: true,
-      placeholder: "user-account-id",
-      description: "The account ID of the user to invite",
+      description: "Search by username or name, or type an account ID",
+      customComponent: (controlProps) => (
+        <AccountSearchInput
+          {...controlProps}
+          name="account_id"
+          required
+          placeholder="username or name"
+        />
+      ),
     },
     {
       label: "Role",

--- a/src/components/features/admin/AdminUserLookupForm.tsx
+++ b/src/components/features/admin/AdminUserLookupForm.tsx
@@ -1,21 +1,28 @@
 "use client";
 
-import { DynamicForm, FormField } from "@/components/core";
-import { lookupUserByEmail } from "@/lib/actions/admin";
+import { AccountSearchInput, DynamicForm, FormField } from "@/components/core";
+import { lookupUser } from "@/lib/actions/admin";
 
 type LookupFormData = {
-  email: string;
+  query: string;
 };
 
 const fields: FormField<LookupFormData>[] = [
   {
-    label: "Email",
-    name: "email",
-    type: "email",
+    label: "User",
+    name: "query",
+    type: "custom",
     required: true,
-    placeholder: "user@example.com",
     description:
-      "Looks up the email in Ory and, if found, opens that user's profile.",
+      "Search by username or name, or enter an email address to look it up in Ory. Opens that user's profile.",
+    customComponent: (controlProps) => (
+      <AccountSearchInput
+        {...controlProps}
+        name="query"
+        required
+        placeholder="username, name, or user@example.com"
+      />
+    ),
   },
 ];
 
@@ -23,7 +30,7 @@ export function AdminUserLookupForm() {
   return (
     <DynamicForm<LookupFormData>
       fields={fields}
-      action={lookupUserByEmail}
+      action={lookupUser}
       submitButtonText="Look up user"
     />
   );

--- a/src/components/features/admin/tools.ts
+++ b/src/components/features/admin/tools.ts
@@ -33,7 +33,7 @@ export const ADMIN_TOOLS: AdminTool[] = [
   },
   {
     name: "User Lookup",
-    description: "Find a user by email and open their profile.",
+    description: "Find a user by username, name, or email and open their profile.",
     href: adminUserLookupUrl(),
     Icon: MagnifyingGlassIcon,
   },

--- a/src/lib/actions/account.ts
+++ b/src/lib/actions/account.ts
@@ -21,6 +21,7 @@ import {
 import { isAuthorized } from "../api/authz";
 import { getPageSession } from "../api/utils";
 import { accountsTable, membershipsTable } from "../clients";
+import type { AccountSuggestion } from "../clients/database/accounts";
 import { FormState } from "@/components/core/DynamicForm";
 import { revalidatePath } from "next/cache";
 import {
@@ -411,7 +412,7 @@ export async function updateAccountFlags(
  */
 export async function searchAccounts(
   query: string
-): Promise<Array<{ account_id: string; name: string }>> {
+): Promise<AccountSuggestion[]> {
   const session = await getPageSession();
   if (!session?.identity_id) return [];
   if (query.trim().length < 2) return [];

--- a/src/lib/actions/account.ts
+++ b/src/lib/actions/account.ts
@@ -402,3 +402,19 @@ export async function updateAccountFlags(
     };
   }
 }
+
+/**
+ * Type-ahead search over individual accounts, matching either the handle
+ * (`account_id`) or the display name. Returns only the public identity fields
+ * already shown on every profile page. Requires a session so it isn't an open
+ * directory-scraping endpoint.
+ */
+export async function searchAccounts(
+  query: string
+): Promise<Array<{ account_id: string; name: string }>> {
+  const session = await getPageSession();
+  if (!session?.identity_id) return [];
+  if (query.trim().length < 2) return [];
+
+  return accountsTable.searchIndividuals(query);
+}

--- a/src/lib/actions/admin.test.ts
+++ b/src/lib/actions/admin.test.ts
@@ -1,4 +1,4 @@
-import { lookupUserByEmail } from "./admin";
+import { lookupUser } from "./admin";
 import { accountsTable } from "../clients";
 import { getPageSession, getOryIdentityIdByEmail } from "../api/utils";
 import { isAdmin } from "../api/authz";
@@ -6,6 +6,7 @@ import { isAdmin } from "../api/authz";
 jest.mock("../clients", () => ({
   accountsTable: {
     fetchByOryId: jest.fn(),
+    fetchById: jest.fn(),
   },
 }));
 
@@ -28,15 +29,15 @@ const mockGetOryIdentityIdByEmail =
   >;
 const mockIsAdmin = isAdmin as jest.MockedFunction<typeof isAdmin>;
 
-function formDataFor(email?: string): FormData {
+function formDataFor(query?: string): FormData {
   const fd = new FormData();
-  if (email !== undefined) {
-    fd.set("email", email);
+  if (query !== undefined) {
+    fd.set("query", query);
   }
   return fd;
 }
 
-describe("lookupUserByEmail", () => {
+describe("lookupUser", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetPageSession.mockResolvedValue(null);
@@ -46,25 +47,25 @@ describe("lookupUserByEmail", () => {
   test("rejects non-admins", async () => {
     mockIsAdmin.mockReturnValue(false);
 
-    const result = await lookupUserByEmail({}, formDataFor("user@example.com"));
+    const result = await lookupUser({}, formDataFor("user@example.com"));
 
     expect(result.success).toBe(false);
     expect(result.message).toBe("Unauthorized");
     expect(mockGetOryIdentityIdByEmail).not.toHaveBeenCalled();
   });
 
-  test("reports field error for an invalid email", async () => {
-    const result = await lookupUserByEmail({}, formDataFor("not-an-email"));
+  test("reports a field error for an empty query", async () => {
+    const result = await lookupUser({}, formDataFor("   "));
 
     expect(result.success).toBe(false);
-    expect(result.fieldErrors.email).toBeDefined();
+    expect(result.fieldErrors.query).toBeDefined();
     expect(mockGetOryIdentityIdByEmail).not.toHaveBeenCalled();
   });
 
   test("reports when the email is not found in Ory", async () => {
     mockGetOryIdentityIdByEmail.mockResolvedValue(null);
 
-    const result = await lookupUserByEmail({}, formDataFor("missing@example.com"));
+    const result = await lookupUser({}, formDataFor("missing@example.com"));
 
     expect(result.success).toBe(false);
     expect(result.message).toContain("No user found in Ory");
@@ -75,19 +76,19 @@ describe("lookupUserByEmail", () => {
     mockGetOryIdentityIdByEmail.mockResolvedValue("ory-id-1");
     mockAccountsTable.fetchByOryId.mockResolvedValue(null);
 
-    const result = await lookupUserByEmail({}, formDataFor("user@example.com"));
+    const result = await lookupUser({}, formDataFor("user@example.com"));
 
     expect(result.success).toBe(false);
     expect(result.message).toContain("no source.coop profile");
   });
 
-  test("redirects to the profile when a match is found", async () => {
+  test("redirects to the profile when an email matches", async () => {
     mockGetOryIdentityIdByEmail.mockResolvedValue("ory-id-1");
     mockAccountsTable.fetchByOryId.mockResolvedValue({
       account_id: "jane",
     } as Awaited<ReturnType<typeof accountsTable.fetchByOryId>>);
 
-    const result = await lookupUserByEmail({}, formDataFor("jane@example.com"));
+    const result = await lookupUser({}, formDataFor("jane@example.com"));
 
     expect(result.success).toBe(true);
     expect(result.redirectTo).toBe("/jane");
@@ -97,10 +98,32 @@ describe("lookupUserByEmail", () => {
   test("trims whitespace around the submitted email", async () => {
     mockGetOryIdentityIdByEmail.mockResolvedValue(null);
 
-    await lookupUserByEmail({}, formDataFor("  spaced@example.com  "));
+    await lookupUser({}, formDataFor("  spaced@example.com  "));
 
     expect(mockGetOryIdentityIdByEmail).toHaveBeenCalledWith(
       "spaced@example.com"
     );
+  });
+
+  test("resolves a non-email query as an account handle", async () => {
+    mockAccountsTable.fetchById.mockResolvedValue({
+      account_id: "jane",
+    } as Awaited<ReturnType<typeof accountsTable.fetchById>>);
+
+    const result = await lookupUser({}, formDataFor("Jane"));
+
+    expect(result.success).toBe(true);
+    expect(result.redirectTo).toBe("/jane");
+    expect(mockAccountsTable.fetchById).toHaveBeenCalledWith("jane");
+    expect(mockGetOryIdentityIdByEmail).not.toHaveBeenCalled();
+  });
+
+  test("reports when no account matches the handle", async () => {
+    mockAccountsTable.fetchById.mockResolvedValue(null);
+
+    const result = await lookupUser({}, formDataFor("nobody"));
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("No account found");
   });
 });

--- a/src/lib/actions/admin.ts
+++ b/src/lib/actions/admin.ts
@@ -7,37 +7,32 @@ import { getOryIdentityIdByEmail, getPageSession } from "../api/utils";
 import { accountsTable } from "../clients";
 import { FormState } from "@/components/core/DynamicForm";
 import { accountUrl } from "@/lib/urls";
+import type { Account } from "@/types";
 
 const LookupSchema = z.object({
-  email: z.string().trim().email("Enter a valid email address"),
+  query: z.string().trim().min(1, "Enter an email address or username"),
 });
 
 /**
- * Admin-only action: looks up an email in Ory and, when a matching user with a
- * source.coop profile exists, returns a `redirectTo` pointing at that user's
- * profile page. Otherwise reports that the email was not found.
+ * Admin-only action: resolves a user to their profile page. An email is looked
+ * up in Ory; anything else is treated as an account handle — which is what the
+ * field's type-ahead fills in. Returns a `redirectTo` pointing at the profile,
+ * or reports that nothing matched.
  *
  * @param initialState - The initial form state.
- * @param formData - The submitted form data containing the `email` field.
+ * @param formData - The submitted form data containing the `query` field.
  */
-export async function lookupUserByEmail(
+export async function lookupUser(
   initialState: any,
   formData: FormData
 ): Promise<FormState<any>> {
   const session = await getPageSession();
 
   if (!isAdmin(session)) {
-    return {
-      fieldErrors: {},
-      data: formData,
-      message: "Unauthorized",
-      success: false,
-    };
+    return failure(formData, "Unauthorized");
   }
 
-  const parsed = LookupSchema.safeParse({
-    email: formData.get("email"),
-  });
+  const parsed = LookupSchema.safeParse({ query: formData.get("query") });
   if (!parsed.success) {
     return {
       fieldErrors: parsed.error.flatten().fieldErrors,
@@ -47,33 +42,37 @@ export async function lookupUserByEmail(
     };
   }
 
-  const { email } = parsed.data;
+  const { query } = parsed.data;
+  let account: Account | null;
 
-  const identityId = await getOryIdentityIdByEmail(email);
-  if (!identityId) {
-    return {
-      fieldErrors: {},
-      data: formData,
-      message: `No user found in Ory for ${email}`,
-      success: false,
-    };
+  if (query.includes("@")) {
+    const identityId = await getOryIdentityIdByEmail(query);
+    if (!identityId) {
+      return failure(formData, `No user found in Ory for ${query}`);
+    }
+
+    account = await accountsTable.fetchByOryId(identityId);
+    if (!account) {
+      // The identity exists in Ory but has no corresponding source.coop profile.
+      return failure(
+        formData,
+        `${query} exists in Ory but has no source.coop profile`
+      );
+    }
+  } else {
+    account = await accountsTable.fetchById(query.toLowerCase());
+    if (!account) {
+      return failure(formData, `No account found for ${query}`);
+    }
   }
 
-  const account = await accountsTable.fetchByOryId(identityId);
-  if (!account) {
-    // The identity exists in Ory but has no corresponding source.coop profile.
-    return {
-      fieldErrors: {},
-      data: formData,
-      message: `${email} exists in Ory but has no source.coop profile`,
-      success: false,
-    };
-  }
-
-  LOGGER.info("Admin resolved email to profile", {
-    operation: "lookupUserByEmail",
+  LOGGER.info("Admin resolved a user to their profile", {
+    operation: "lookupUser",
     context: "admin",
-    metadata: { account_id: account.account_id, looked_up_by: session?.account?.account_id },
+    metadata: {
+      account_id: account.account_id,
+      looked_up_by: session?.account?.account_id,
+    },
   });
 
   // Navigate on the client (see FormState.redirectTo) rather than redirect()
@@ -85,4 +84,8 @@ export async function lookupUserByEmail(
     success: true,
     redirectTo: accountUrl(account.account_id),
   };
+}
+
+function failure(data: FormData, message: string): FormState<any> {
+  return { fieldErrors: {}, data, message, success: false };
 }

--- a/src/lib/clients/database/accounts.search.test.ts
+++ b/src/lib/clients/database/accounts.search.test.ts
@@ -1,0 +1,74 @@
+import { type DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { AccountsTable } from "./accounts";
+import { createMemoizedRead } from "./request-cache";
+import { fakeReactCache } from "./__test-helpers__/fake-react-cache";
+import { AccountType, type Account } from "@/types";
+
+jest.mock("@/lib/config", () => ({
+  CONFIG: { environment: { stage: "test" }, database: {} },
+}));
+jest.mock("@/lib/logging", () => ({
+  LOGGER: { error: jest.fn(), debug: jest.fn(), info: jest.fn() },
+}));
+
+const account = (fields: Partial<Account>): Account =>
+  ({
+    type: AccountType.INDIVIDUAL,
+    disabled: false,
+    ...fields,
+  }) as Account;
+
+const ITEMS = [
+  account({ account_id: "jane-doe", name: "Jane Doe" }),
+  account({ account_id: "jsmith", name: "John Smith" }),
+  account({ account_id: "acme", name: "Jane's Lab", type: AccountType.ORGANIZATION }),
+  account({ account_id: "janitor", name: "Jan Retired", disabled: true }),
+];
+
+function tableFor(items: Account[], extra: Record<string, any> = {}) {
+  const send = jest.fn().mockResolvedValue({ Items: items, ...extra });
+  const table = new AccountsTable({
+    client: { send } as unknown as DynamoDBDocumentClient,
+    memoizedRead: createMemoizedRead(fakeReactCache),
+  });
+  return { table, send };
+}
+
+describe("AccountsTable.searchIndividuals", () => {
+  it("matches the handle or the display name, case-insensitively", async () => {
+    const { table } = tableFor(ITEMS);
+
+    expect(await table.searchIndividuals("JANE")).toEqual([
+      { account_id: "jane-doe", name: "Jane Doe" },
+    ]);
+    expect(await table.searchIndividuals("smith")).toEqual([
+      { account_id: "jsmith", name: "John Smith" },
+    ]);
+  });
+
+  it("skips organizations and disabled accounts", async () => {
+    const { table } = tableFor(ITEMS);
+
+    // "jan" is a substring of the org's name and the disabled account's handle.
+    expect(await table.searchIndividuals("jan")).toEqual([
+      { account_id: "jane-doe", name: "Jane Doe" },
+    ]);
+  });
+
+  it("returns nothing for an empty query without hitting DynamoDB", async () => {
+    const { table, send } = tableFor(ITEMS);
+
+    expect(await table.searchIndividuals("  ")).toEqual([]);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("stops scanning once the limit is reached", async () => {
+    // LastEvaluatedKey would otherwise drive a second page.
+    const { table, send } = tableFor(ITEMS, { LastEvaluatedKey: { account_id: "x" } });
+
+    expect(await table.searchIndividuals("j", 1)).toEqual([
+      { account_id: "jane-doe", name: "Jane Doe" },
+    ]);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/clients/database/accounts.search.test.ts
+++ b/src/lib/clients/database/accounts.search.test.ts
@@ -46,6 +46,32 @@ describe("AccountsTable.searchIndividuals", () => {
     ]);
   });
 
+  it("carries the public profile image, and never an email", async () => {
+    // The picker draws the same account card the profile hover card does, which
+    // needs the avatar. Emails must not ride along: the Gravatar fallback used
+    // elsewhere would expose an address hash for every account a search matches.
+    const { table, send } = tableFor([
+      account({
+        account_id: "jane-doe",
+        name: "Jane Doe",
+        metadata_public: { profile_image: "https://example.test/jane.png" },
+        emails: [{ address: "jane@example.test", is_primary: true }],
+      } as Partial<Account>),
+    ]);
+
+    expect(await table.searchIndividuals("jane")).toEqual([
+      {
+        account_id: "jane-doe",
+        name: "Jane Doe",
+        profile_image: "https://example.test/jane.png",
+      },
+    ]);
+
+    const projection = send.mock.calls[0][0].input.ProjectionExpression;
+    expect(projection).toContain("metadata_public.profile_image");
+    expect(projection).not.toContain("emails");
+  });
+
   it("skips organizations and disabled accounts", async () => {
     const { table } = tableFor(ITEMS);
 

--- a/src/lib/clients/database/accounts.ts
+++ b/src/lib/clients/database/accounts.ts
@@ -1,5 +1,7 @@
 import {
   QueryCommand,
+  ScanCommand,
+  type ScanCommandOutput,
   UpdateCommand,
   DeleteCommand,
   PutCommand,
@@ -143,6 +145,54 @@ export class AccountsTable extends BaseTable {
    * accept a user-supplied id should catch it and report the collision rather
    * than surfacing a server error.
    */
+  /**
+   * Substring match over individual accounts' handles and display names, for
+   * type-ahead pickers. Returns only publicly visible identity fields.
+   *
+   * ponytail: full table scan filtered app-side. DynamoDB has no
+   * case-insensitive `contains()` and this table has no search index, so
+   * matching on `name` any other way means denormalizing a lowercased
+   * `search_text` field (as `products` does) and backfilling it. Fine at the
+   * current account count; do that — or move to a search service — if the
+   * scans start to hurt.
+   */
+  async searchIndividuals(
+    query: string,
+    limit = 10
+  ): Promise<Array<{ account_id: string; name: string }>> {
+    const q = query.trim().toLowerCase();
+    if (!q) return [];
+
+    const matches: Array<{ account_id: string; name: string }> = [];
+    let lastEvaluatedKey: Record<string, any> | undefined = undefined;
+
+    do {
+      // Annotated because the paging assignment below otherwise makes the
+      // inferred type of `result` depend on itself.
+      const result: ScanCommandOutput = await this.cachedSend(
+        new ScanCommand({
+          TableName: this.table,
+          ProjectionExpression: "account_id, #name, #type, disabled",
+          ExpressionAttributeNames: { "#name": "name", "#type": "type" },
+          ExclusiveStartKey: lastEvaluatedKey,
+        })
+      );
+
+      for (const item of (result.Items ?? []) as Account[]) {
+        if (item.type !== AccountType.INDIVIDUAL || item.disabled) continue;
+        const name = item.name ?? "";
+        if (!item.account_id.includes(q) && !name.toLowerCase().includes(q))
+          continue;
+        matches.push({ account_id: item.account_id, name });
+        if (matches.length >= limit) return matches;
+      }
+
+      lastEvaluatedKey = result.LastEvaluatedKey;
+    } while (lastEvaluatedKey);
+
+    return matches;
+  }
+
   async create(account: Account): Promise<Account> {
     try {
       await this.client.send(

--- a/src/lib/clients/database/accounts.ts
+++ b/src/lib/clients/database/accounts.ts
@@ -18,6 +18,16 @@ import {
 import { BaseTable } from "./base";
 import { LOGGER } from "@/lib/logging";
 
+/**
+ * What a type-ahead picker needs to introduce an account: enough to render the
+ * same identity block the profile hover card shows. Public fields only.
+ */
+export interface AccountSuggestion {
+  account_id: string;
+  name: string;
+  profile_image?: string;
+}
+
 export class AccountsTable extends BaseTable {
   model = "accounts";
 
@@ -147,7 +157,10 @@ export class AccountsTable extends BaseTable {
    */
   /**
    * Substring match over individual accounts' handles and display names, for
-   * type-ahead pickers. Returns only publicly visible identity fields.
+   * type-ahead pickers. Returns only publicly visible identity fields --
+   * `profile_image` comes from `metadata_public` and is what profile pages
+   * already render. Deliberately no email: the Gravatar fallback used elsewhere
+   * would leak an address hash for every account a search happens to match.
    *
    * ponytail: full table scan filtered app-side. DynamoDB has no
    * case-insensitive `contains()` and this table has no search index, so
@@ -159,11 +172,11 @@ export class AccountsTable extends BaseTable {
   async searchIndividuals(
     query: string,
     limit = 10
-  ): Promise<Array<{ account_id: string; name: string }>> {
+  ): Promise<AccountSuggestion[]> {
     const q = query.trim().toLowerCase();
     if (!q) return [];
 
-    const matches: Array<{ account_id: string; name: string }> = [];
+    const matches: AccountSuggestion[] = [];
     let lastEvaluatedKey: Record<string, any> | undefined = undefined;
 
     do {
@@ -172,7 +185,8 @@ export class AccountsTable extends BaseTable {
       const result: ScanCommandOutput = await this.cachedSend(
         new ScanCommand({
           TableName: this.table,
-          ProjectionExpression: "account_id, #name, #type, disabled",
+          ProjectionExpression:
+            "account_id, #name, #type, disabled, metadata_public.profile_image",
           ExpressionAttributeNames: { "#name": "name", "#type": "type" },
           ExclusiveStartKey: lastEvaluatedKey,
         })
@@ -183,7 +197,11 @@ export class AccountsTable extends BaseTable {
         const name = item.name ?? "";
         if (!item.account_id.includes(q) && !name.toLowerCase().includes(q))
           continue;
-        matches.push({ account_id: item.account_id, name });
+        matches.push({
+          account_id: item.account_id,
+          name,
+          profile_image: item.metadata_public?.profile_image,
+        });
         if (matches.length >= limit) return matches;
       }
 


### PR DESCRIPTION
## What

The Invite Member dialog and the admin User Lookup both asked for an exact identifier typed from memory — an account ID in one, an email in the other. Both now suggest matching users as you type, matching either the account handle or the display name.

Only public identity fields are involved: the search returns `{account_id, name, profile_image}` for non-disabled individual accounts, all of which every profile page already shows. Organizations are excluded because `inviteMember` rejects them anyway.

## The suggestions are the account card

Everywhere else in the app, an account shown out of context is introduced the same way — avatar, display name, `@handle` — by the profile hover card. The picker now uses that card for each suggestion, so the person you choose from a list looks like the person you land on.

That body is one component, `AccountIdentity`, rendered by both the hover card and the suggestion rows on a shared surface, so the two can't drift into looking like different objects.

## Why not `<datalist>`, after all

The first revision of this PR used a native `<datalist>` and argued for it at some length: the browser draws the list, owns its keyboard handling and accessibility, and there is no popover code to get wrong. That reasoning still holds, and it is the right default whenever the rows are plain strings.

These rows are not plain strings. `<datalist>` renders an option's `value` and label text and nothing else — an avatar inside one is not possible — so showing the account card meant giving it up.

What replaces it is a listbox held to the ARIA combobox pattern, which is the part worth reviewing:

- focus never leaves the input, which carries `role="combobox"`, `aria-autocomplete="list"`, `aria-expanded`, `aria-controls` and `aria-activedescendant`;
- ArrowDown/ArrowUp move the active option, Enter chooses it, Escape closes;
- **Enter still submits the form** when nothing is highlighted, so the field doesn't swallow the key it would normally pass on;
- selection binds to `mousedown`, not `click` — `click` lands after blur has already closed the list, so a mouse pick would otherwise never register.

**This is hand-rolled combobox behaviour, which is exactly what the earlier revision avoided.** If reviewer attention goes anywhere in this diff, it should go here.

### The list has to portal

Positioned inside the field, the list was clipped at the edge of the invite form's Dialog, which is its own scroll box — three suggestions visible and the fourth sliced in half. It now renders through a **Radix Popover portal** anchored to the input, which escapes the dialog and brings collision handling with it.

That needed `@radix-ui/react-popover` declared explicitly, alongside the four other `@radix-ui/react-*` primitives this repo already depends on directly. **`Popover` from `@radix-ui/themes` cannot be used here:** its `Anchor` destructures `children` off and never renders them, so the field inside it disappears entirely. The portalled content is wrapped in `<Theme asChild>` for the same reason Themes does it — outside the theme element, none of the CSS variables resolve.

Portalling out of a modal has a second failure mode worth naming: a Radix Dialog marks everything outside itself `aria-hidden`, which would leave the suggestions unreachable rather than merely clipped. The dialog test asserts both — that an option is not a descendant of the dialog, and that it is still selectable.

## Loading state

While a lookup is outstanding the field shows a Radix `<Spinner>` in a right-hand `TextField.Slot`. The slot is always mounted so the text doesn't shift when the spinner appears, and `aria-busy` on the input carries the same fact to a screen reader, since the spinner itself is decorative.

It starts before the 250ms debounce rather than around the request alone — the wait is part of what you're waiting through either way. Queries under two characters now short-circuit on the client and never round-trip at all; that minimum was previously enforced only server-side.

## Avatars, and what stays out of them

Suggestions carry `metadata_public.profile_image` so their avatars match the card rather than always falling back to an initial.

**Emails deliberately stay out of the projection.** `ProfileAvatar` falls back to Gravatar, which means MD5-ing the primary email — fine on a profile page you already have access to, not fine for every account a substring search happens to match. A search result gets the public image or a letter, and there is a test asserting the projection contains `metadata_public.profile_image` and not `emails`.

## Admin lookup now takes a handle too

Since the type-ahead fills the field with an account handle, the admin lookup had to accept one, so `lookupUserByEmail` became `lookupUser`: an input containing `@` still resolves through Ory as before, anything else resolves as an account handle via `fetchById`.

## Known ceiling

`searchIndividuals` is a full table scan filtered app-side. DynamoDB has no case-insensitive `contains()` and the accounts table has no search index, so matching on `name` any other way means denormalizing a lowercased `search_text` field (as `products` does) and backfilling it. That's fine at the current account count and is marked in the code with the upgrade path; revisit if the scans start to hurt. Adding `profile_image` doesn't change this — it rides along in the same projection.

## Testing

- `accounts.search.test.ts` — handle/name matching, case-insensitivity, skipping organizations and disabled accounts, empty query short-circuit, limit stops paging, and the profile-image/no-email projection.
- `AccountSearchInput.test.tsx` — the card contents of a suggestion, mouse select, keyboard select with focus retained, no re-search for the account just chosen, the busy state, the two-character floor, and the dialog case above. The floor was checked by removing the guard and confirming it fails.
- `admin.test.ts` — updated for `lookupUser`, plus handle-resolution and not-found branches.

`tsc` clean · jest 61 suites / 530 tests · `next lint` 0 errors.

Not exercised against a live browser — no AWS credentials in this environment. Given the combobox is hand-rolled, a keyboard pass on the preview is worth more here than the green check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mnsg8m1dXZ5z5ig5xMtkE
