### PR TITLE
fix(ci): repair the Storybook deploy and unmask the Vercel ids

### DIFF
--- a/.github/workflows/prod-deploy.yaml
+++ b/.github/workflows/prod-deploy.yaml
@@ -50,6 +50,6 @@ jobs:
       - name: Deploy to Vercel
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
         run: vercel deploy --prod --token="$VERCEL_TOKEN"

--- a/.github/workflows/staging-deploy.yaml
+++ b/.github/workflows/staging-deploy.yaml
@@ -51,6 +51,6 @@ jobs:
       - name: Deploy to Vercel
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
         run: vercel deploy --target=staging --token="$VERCEL_TOKEN"

--- a/.github/workflows/ui-deploy.yaml
+++ b/.github/workflows/ui-deploy.yaml
@@ -45,11 +45,13 @@ jobs:
       - name: Deploy Storybook to Vercel
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          # The same three repository secrets the app's deploys use. This job
-          # runs in the `UI` environment, which carries its own
-          # VERCEL_PROJECT_ID holding Storybook's project -- an environment
-          # secret wins over a repository secret of the same name, so only the
-          # project changes here.
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          # The same credentials the app's deploys use. This job runs in the
+          # `UI` environment, which carries its own VERCEL_PROJECT_ID holding
+          # Storybook's project -- an environment variable wins over a
+          # repository one of the same name, so only the project changes here.
+          # The ids are variables, not secrets: they are identifiers, not
+          # credentials, and masking them turns a log into `***` exactly when
+          # you need to read it.
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
         run: vercel deploy --prod --yes --token="$VERCEL_TOKEN"

--- a/.github/workflows/ui-deploy.yaml
+++ b/.github/workflows/ui-deploy.yaml
@@ -46,6 +46,10 @@ jobs:
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          # The app's project id is VERCEL_PROJECT_ID; this is Storybook's.
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_UI }}
+          # The same three repository secrets the app's deploys use. This job
+          # runs in the `UI` environment, which carries its own
+          # VERCEL_PROJECT_ID holding Storybook's project -- an environment
+          # secret wins over a repository secret of the same name, so only the
+          # project changes here.
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
         run: vercel deploy --prod --yes --token="$VERCEL_TOKEN"


### PR DESCRIPTION
The Storybook deploy has never succeeded. [Its only run](https://github.com/source-cooperative/source.coop/actions/runs/32877590495) died with:

```
VERCEL_TOKEN: ***
VERCEL_ORG_ID: ***
VERCEL_PROJECT_ID:            ← empty
Error: You specified `VERCEL_ORG_ID` but you forgot to specify `VERCEL_PROJECT_ID`.
```

Two problems, one commit each.

## 1. The project id resolved to nothing

The job read `secrets.VERCEL_PROJECT_ID_UI`, but that was never a secret — the `UI` environment carried it as a **variable**. `secrets.*` and `vars.*` are separate namespaces, so the expression quietly became an empty string.

## 2. The ids were masked, which is why that was hard to read

Neither the org id nor the project id is a credential. Vercel writes both to `.vercel/project.json` in plaintext on every machine that runs `vercel link`, and neither authenticates anything on its own — `VERCEL_TOKEN` does. Marking them secret bought nothing and cost real debugging time: two thirds of the evidence above is `***`, and the empty one had to be inferred from the CLI error rather than read off the log.

Both move to configuration variables. `VERCEL_TOKEN` stays a secret.

## Result

All three deploy workflows now read identically, and only the target differs:

```yaml
VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
```

Configuration variables have the [same precedence as secrets](https://docs.github.com/en/actions/reference/workflows-and-actions/variables) — environment beats repository — so `VERCEL_PROJECT_ID` means the app project everywhere except this job, where the `UI` environment points it at Storybook. No `_UI` suffix.

## Config already applied

- `UI` environment variable `VERCEL_PROJECT_ID` = `prj_oGppKbpyyHaqufdjB4jrDTN9ZVX3`
- **deleted** `UI` environment variable `VERCEL_ORG_ID`, which held the team *slug* `radiantearth` rather than the `team_…` id. Nothing read it while the workflows used `secrets.*`, but under `vars.*` it would have shadowed the repository value and broken this deploy. Read by no workflow, so deleting it changed no behavior.

The repository already had correct `VERCEL_ORG_ID` and `VERCEL_PROJECT_ID` variables — set 5 months ago, then never used because the workflows reached for secrets instead.

## Safe to merge as-is

Nothing is deleted that main depends on. After this is green, these are dead and can go:

- repository **secrets** `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`
- `UI` environment **secret** `VERCEL_PROJECT_ID`
- `UI` environment **variable** `VERCEL_PROJECT_ID_UI`

## One assumption the first green run settles

Vercel tokens can be scoped to an **account, a team, or a single project** ([docs](https://vercel.com/docs/accounts/access-tokens)). Sharing one across both projects works for the first two, not the third. `VERCEL_TOKEN` predates the Storybook project by months, so if it were project-scoped it would be scoped to the app and this job fails with an authorization error. The fix then is a team-scoped token, not a second secret.

Evidence it's otherwise sound: the push at `17:23:23Z` fired staging and Storybook together. Staging went green with these same credentials; only the empty project id differed.

## Interaction with #507

#507 deletes `ui-deploy.yaml` and drops staging's Vercel job. These are alternatives — merging both conflicts. Merge this for a working deploy with no dashboard changes; merge #507 to delete the workflow, the token usage, and the pinned `vercel@59`, after three Vercel dashboard changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
