### PR TITLE
docs(storybook): story the feature components worth reviewing in isolation

### DIFF
--- a/src/components/core/AccountIdentity.stories.tsx
+++ b/src/components/core/AccountIdentity.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Avatar, Box } from "@radix-ui/themes";
+import { AccountIdentity, accountCardSurface } from "./AccountIdentity";
+
+/**
+ * How an account is introduced anywhere it appears out of context: avatar,
+ * display name, handle.
+ *
+ * Shared by the profile hover card and the account picker's suggestions, so a
+ * person looks the same in the list they are picked from as in the card that
+ * confirms who they are. The avatar is a slot rather than derived, because
+ * callers hold different amounts: a profile page has a whole Account and can
+ * fall back to Gravatar, a search result has only public fields.
+ */
+const meta = {
+  title: "Accounts/AccountIdentity",
+  component: AccountIdentity,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof AccountIdentity>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const initial = (name: string) => (
+  <Avatar size="2" radius="full" fallback={name[0].toUpperCase()} />
+);
+
+export const Default: Story = {
+  args: {
+    name: "Qiusheng Wu",
+    accountId: "giswqs",
+    avatar: initial("Qiusheng Wu"),
+  },
+};
+
+/** Size 2 is what the picker's suggestion rows use, so the list stays dense. */
+export const InAList: Story = {
+  args: { ...Default.args, size: "2" },
+};
+
+/** On the shared card surface, which is how both callers present it. */
+export const OnCardSurface: Story = {
+  args: Default.args,
+  render: (args) => (
+    <Box p="4" style={{ ...accountCardSurface, maxWidth: 300 }}>
+      <AccountIdentity {...args} />
+    </Box>
+  ),
+};
+
+/** A long display name must not push the handle out of the row. */
+export const LongName: Story = {
+  args: {
+    name: "The Cascadia Marine Acoustics Research Collective",
+    accountId: "cascadia-research",
+    avatar: initial("The Cascadia"),
+  },
+};

--- a/src/components/core/AccountIdentity.stories.tsx
+++ b/src/components/core/AccountIdentity.stories.tsx
@@ -27,9 +27,9 @@ const initial = (name: string) => (
 
 export const Default: Story = {
   args: {
-    name: "Qiusheng Wu",
-    accountId: "giswqs",
-    avatar: initial("Qiusheng Wu"),
+    name: "Chris Holmes",
+    accountId: "cholmes",
+    avatar: initial("Chris Holmes"),
   },
 };
 

--- a/src/components/core/AccountInfoHoverCard.stories.tsx
+++ b/src/components/core/AccountInfoHoverCard.stories.tsx
@@ -24,18 +24,18 @@ type Story = StoryObj<typeof meta>;
 // ProfileAvatar falls back to an initial instead of fetching Gravatar — which
 // also keeps the story offline.
 const account = {
-  account_id: "giswqs",
-  name: "Qiusheng Wu",
+  account_id: "cholmes",
+  name: "Chris Holmes",
   type: "individual",
   metadata_public: {
-    bio: "Associate Professor at the University of Tennessee",
+    bio: "Works on open geospatial data and cloud-native infrastructure.",
   },
 } as unknown as Account;
 
 export const Default: Story = {
   args: {
     account,
-    children: <Text size="2">Qiusheng Wu</Text>,
+    children: <Text size="2">Chris Holmes</Text>,
   },
 };
 
@@ -43,7 +43,7 @@ export const Default: Story = {
 export const WithoutBio: Story = {
   args: {
     account: { ...account, metadata_public: {} } as unknown as Account,
-    children: <Text size="2">Qiusheng Wu</Text>,
+    children: <Text size="2">Chris Holmes</Text>,
   },
 };
 
@@ -52,6 +52,6 @@ export const Disabled: Story = {
   args: {
     account,
     showHoverCard: false,
-    children: <Text size="2">Qiusheng Wu (no card on hover)</Text>,
+    children: <Text size="2">Chris Holmes (no card on hover)</Text>,
   },
 };

--- a/src/components/core/AccountInfoHoverCard.stories.tsx
+++ b/src/components/core/AccountInfoHoverCard.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Text } from "@radix-ui/themes";
+import { AccountInfoHoverCard } from "./AccountInfoHoverCard";
+import type { Account } from "@/types";
+
+/**
+ * The card that introduces an account on hover, wherever a name appears in
+ * passing — a product's owner, a connection's owner, a member list.
+ *
+ * **Hover the name to open it.** The card is the whole component, so a
+ * screenshot of the closed state shows nothing.
+ */
+const meta = {
+  title: "Accounts/AccountInfoHoverCard",
+  component: AccountInfoHoverCard,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof AccountInfoHoverCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Cast rather than built out: the card reads four public fields, and a full
+// Account here would be mostly irrelevant scaffolding. No email, so
+// ProfileAvatar falls back to an initial instead of fetching Gravatar — which
+// also keeps the story offline.
+const account = {
+  account_id: "giswqs",
+  name: "Qiusheng Wu",
+  type: "individual",
+  metadata_public: {
+    bio: "Associate Professor at the University of Tennessee",
+  },
+} as unknown as Account;
+
+export const Default: Story = {
+  args: {
+    account,
+    children: <Text size="2">Qiusheng Wu</Text>,
+  },
+};
+
+/** No bio recorded: the card is the identity block alone, not an empty gap. */
+export const WithoutBio: Story = {
+  args: {
+    account: { ...account, metadata_public: {} } as unknown as Account,
+    children: <Text size="2">Qiusheng Wu</Text>,
+  },
+};
+
+/** Suppressed entirely — used where the surrounding row is already the account. */
+export const Disabled: Story = {
+  args: {
+    account,
+    showHoverCard: false,
+    children: <Text size="2">Qiusheng Wu (no card on hover)</Text>,
+  },
+};

--- a/src/components/core/AccountInfoHoverCard.tsx
+++ b/src/components/core/AccountInfoHoverCard.tsx
@@ -1,7 +1,11 @@
 import { Text, Flex, HoverCard } from "@radix-ui/themes";
 import { Account } from "@/types";
 import { AccountIdentity, accountCardSurface } from "./AccountIdentity";
-import { ProfileAvatar } from "../features/profiles";
+// Deep import, not the `../features/profiles` barrel: that barrel also
+// re-exports EditProfileForm and OrganizationMembers, which reach server-only
+// modules. Pulling the whole barrel in for one avatar drags those into any
+// browser bundle that renders an account name.
+import { ProfileAvatar } from "../features/profiles/ProfileAvatar";
 
 interface AccountInfoHoverCardProps {
   account: Account;

--- a/src/components/core/AccountLinks.stories.tsx
+++ b/src/components/core/AccountLinks.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Flex } from "@radix-ui/themes";
+import { AvatarLinkCompact, DisplayNameLink } from "./AccountLinks";
+import type { Account } from "@/types";
+
+/**
+ * The two ways an account is linked to from a list or a byline: with its
+ * avatar, or as a bare name. Both carry the hover card.
+ *
+ * Hover either to see it.
+ */
+const meta = {
+  title: "Accounts/AccountLinks",
+  component: AvatarLinkCompact,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof AvatarLinkCompact>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// No email, so ProfileAvatar shows an initial rather than fetching Gravatar.
+const individual = {
+  account_id: "giswqs",
+  name: "Qiusheng Wu",
+  type: "individual",
+  metadata_public: { bio: "Associate Professor at the University of Tennessee" },
+} as unknown as Account;
+
+const organization = {
+  account_id: "cascadia-research",
+  name: "Cascadia Research",
+  type: "organization",
+  metadata_public: { bio: "Marine mammal research collective." },
+} as unknown as Account;
+
+export const Compact: Story = {
+  args: { account: individual },
+};
+
+export const CompactWithHandle: Story = {
+  args: { account: individual, showAccountId: true },
+};
+
+/** Organizations get a squared avatar; individuals a round one. */
+export const OrganizationAndIndividual: Story = {
+  args: { account: individual },
+  render: () => (
+    <Flex direction="column" gap="3">
+      <AvatarLinkCompact account={individual} />
+      <AvatarLinkCompact account={organization} />
+    </Flex>
+  ),
+};
+
+/** Unlinked — for use inside something that is already a link. */
+export const NotALink: Story = {
+  args: { account: individual, link: false },
+};
+
+export const NameOnly: Story = {
+  args: { account: individual },
+  render: () => <DisplayNameLink account={individual} />,
+};

--- a/src/components/core/AccountLinks.stories.tsx
+++ b/src/components/core/AccountLinks.stories.tsx
@@ -20,10 +20,12 @@ type Story = StoryObj<typeof meta>;
 
 // No email, so ProfileAvatar shows an initial rather than fetching Gravatar.
 const individual = {
-  account_id: "giswqs",
-  name: "Qiusheng Wu",
+  account_id: "cholmes",
+  name: "Chris Holmes",
   type: "individual",
-  metadata_public: { bio: "Associate Professor at the University of Tennessee" },
+  metadata_public: {
+    bio: "Works on open geospatial data and cloud-native infrastructure.",
+  },
 } as unknown as Account;
 
 const organization = {

--- a/src/components/core/AccountLinks.tsx
+++ b/src/components/core/AccountLinks.tsx
@@ -4,7 +4,11 @@ import { AccountInfoHoverCard } from "./AccountInfoHoverCard";
 import { accountUrl } from "@/lib/urls";
 import { Account } from "@/types";
 import Link from "next/link";
-import { ProfileAvatar } from "../features/profiles";
+// Deep import, not the `../features/profiles` barrel: that barrel also
+// re-exports EditProfileForm and OrganizationMembers, which reach server-only
+// modules. Pulling the whole barrel in for one avatar drags those into any
+// browser bundle that renders an account name.
+import { ProfileAvatar } from "../features/profiles/ProfileAvatar";
 
 interface AccountDisplayProps {
   account: Account;

--- a/src/components/core/CopyToClipboard.stories.tsx
+++ b/src/components/core/CopyToClipboard.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Flex } from "@radix-ui/themes";
+import { CopyToClipboard } from "./CopyToClipboard";
+import { MonoText } from "./MonoText";
+
+/**
+ * Copy button that confirms itself: the icon becomes a green check for 1.5s,
+ * then reverts.
+ *
+ * Click it in this frame to see the transition — the confirmation is the whole
+ * behaviour, and it is invisible in a screenshot.
+ */
+const meta = {
+  title: "Controls/CopyToClipboard",
+  component: CopyToClipboard,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof CopyToClipboard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { text: "s3://cascadia-archive/humpback-acoustics" },
+};
+
+/** Where it actually appears: at the end of a value worth copying. */
+export const BesideAValue: Story = {
+  args: { text: "AKIAIOSFODNN7EXAMPLE" },
+  render: (args) => (
+    <Flex align="center" gap="2">
+      <MonoText size="2">AKIAIOSFODNN7EXAMPLE</MonoText>
+      <CopyToClipboard {...args} />
+    </Flex>
+  ),
+};

--- a/src/components/core/DangerZone.stories.tsx
+++ b/src/components/core/DangerZone.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Button, Flex, Text } from "@radix-ui/themes";
+import { LockClosedIcon } from "@radix-ui/react-icons";
+import { DangerZone } from "./DangerZone";
+
+/**
+ * Where irreversible actions live — another section of the page, same heading
+ * and rule as every other, carried in red.
+ *
+ * Purely visual, and the only place in the app it appears is a connection you
+ * happen to be allowed to delete, so this is the practical way to review it.
+ */
+const meta = {
+  title: "Layout/DangerZone",
+  component: DangerZone,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof DangerZone>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: "Delete this connection",
+    description:
+      "Removes the connection record and its stored credentials. The bucket and its objects are not touched.",
+    action: (
+      <Button size="2" color="red" variant="soft">
+        Delete connection
+      </Button>
+    ),
+  },
+};
+
+/**
+ * The action is blocked, and the reason sits under the explanation rather than
+ * beside the button — it is a reason, not a control.
+ */
+export const Blocked: Story = {
+  args: {
+    ...Default.args,
+    action: (
+      <Button size="2" color="red" variant="soft" disabled>
+        Delete connection
+      </Button>
+    ),
+    note: (
+      <Flex align="center" gap="1">
+        <LockClosedIcon width="14" height="14" color="var(--red-11)" />
+        <Text size="1" color="red">
+          Blocked: 3 products still use it. Remove it from each first.
+        </Text>
+      </Flex>
+    ),
+  },
+};

--- a/src/components/core/EditButton.stories.tsx
+++ b/src/components/core/EditButton.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Flex, Text } from "@radix-ui/themes";
+import { Pencil1Icon } from "@radix-ui/react-icons";
+import { EditButton } from "./EditButton";
+
+/** Gear icon linking to an edit page. Ghost by default, so it sits quietly beside a heading. */
+const meta = {
+  title: "Controls/EditButton",
+  component: EditButton,
+  parameters: { layout: "padded" },
+  args: { href: "/edit/account/cascadia-research" },
+} satisfies Meta<typeof EditButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Variants: Story = {
+  render: (args) => (
+    <Flex align="center" gap="3">
+      <EditButton {...args} variant="ghost" />
+      <EditButton {...args} variant="soft" />
+      <EditButton {...args} variant="outline" />
+      <EditButton {...args} variant="solid" />
+    </Flex>
+  ),
+};
+
+/** The icon is a default, not a fixture. */
+export const CustomIcon: Story = {
+  args: { children: <Pencil1Icon width="18" height="18" /> },
+};
+
+export const BesideAHeading: Story = {
+  render: (args) => (
+    <Flex align="center" gap="2">
+      <Text size="4" weight="bold">
+        Cascadia Research
+      </Text>
+      <EditButton {...args} />
+    </Flex>
+  ),
+};

--- a/src/components/core/FormActions.stories.tsx
+++ b/src/components/core/FormActions.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Button } from "@radix-ui/themes";
+import { FormActions } from "./FormActions";
+
+/**
+ * The single action row a form ends with.
+ *
+ * The secondary action is a prop rather than a sibling of the form: passed as a
+ * sibling it produced a second right-aligned row stacked under the submit,
+ * which in a dialog reads as two competing footers.
+ */
+const meta = {
+  title: "Forms/FormActions",
+  component: FormActions,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof FormActions>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { submitLabel: "Save" },
+};
+
+/** Mid-submit: the button reports it rather than the page going quiet. */
+export const Pending: Story = {
+  args: { submitLabel: "Save", pending: true },
+};
+
+export const Disabled: Story = {
+  args: { submitLabel: "Save", disabled: true },
+};
+
+export const WithSecondaryAction: Story = {
+  args: {
+    submitLabel: "Send invitation",
+    secondary: (
+      <Button type="button" size="3" variant="soft" color="gray">
+        Cancel
+      </Button>
+    ),
+  },
+};
+
+/** Failure is reported in the row that caused it, not at the top of the page. */
+export const WithError: Story = {
+  args: {
+    submitLabel: "Save",
+    message: "That account ID is already taken",
+    success: false,
+  },
+};
+
+export const WithSuccess: Story = {
+  args: { submitLabel: "Save", message: "Saved", success: true },
+};

--- a/src/components/core/FormSkeleton.stories.tsx
+++ b/src/components/core/FormSkeleton.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { FormSkeleton } from "./FormSkeleton";
+
+/**
+ * What a form page shows while its data loads. Worth comparing against a real
+ * form — a skeleton whose proportions do not match what replaces it produces a
+ * visible jump on load.
+ */
+const meta = {
+  title: "Forms/FormSkeleton",
+  component: FormSkeleton,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof FormSkeleton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Short: Story = {
+  args: { fieldCount: 2 },
+};
+
+export const WithoutSubmit: Story = {
+  args: { fieldCount: 3, showSubmitButton: false },
+};

--- a/src/components/core/FormTitle.stories.tsx
+++ b/src/components/core/FormTitle.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { FormTitle } from "./FormTitle";
+
+/** The heading a form page opens with. */
+const meta = {
+  title: "Forms/FormTitle",
+  component: FormTitle,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof FormTitle>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { title: "Edit Data Connection" },
+};
+
+export const WithDescription: Story = {
+  args: {
+    title: "Edit Data Connection",
+    description: "Update this connection's settings and credentials.",
+  },
+};

--- a/src/components/core/LinkAway.stories.tsx
+++ b/src/components/core/LinkAway.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { LinkAway } from "./LinkAway";
+
+/** Small "there is more over here" link, with a chevron pointing out of the block. */
+const meta = {
+  title: "Controls/LinkAway",
+  component: LinkAway,
+  parameters: { layout: "padded" },
+  args: { href: "/cascadia-research" },
+} satisfies Meta<typeof LinkAway>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { children: "All products" },
+};
+
+export const LongLabel: Story = {
+  args: { children: "See every product using this data connection" },
+};

--- a/src/components/core/LoginButton.stories.tsx
+++ b/src/components/core/LoginButton.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { LoginButton } from "./LoginButton";
+
+/**
+ * Sign-in link that returns you to the page you were on.
+ *
+ * A plain `<a>`, not next/link: login lives on the Ory flow, an external domain
+ * in production, so it has to be a full page navigation. The `return_to` is
+ * filled in after mount, which is why the href in this frame points at the
+ * Storybook URL rather than the app.
+ */
+const meta = {
+  title: "Controls/LoginButton",
+  component: LoginButton,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof LoginButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const CustomLabel: Story = {
+  args: { children: "Sign in" },
+};

--- a/src/components/core/LoginRequired.stories.tsx
+++ b/src/components/core/LoginRequired.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { LoginRequired } from "./LoginRequired";
+
+/**
+ * What an unauthenticated visitor gets instead of a redirect: the sign-in
+ * status page, with a button that knows where to send them back to.
+ *
+ * It is <StatusPage type="unauthenticated"> plus <LoginButton>, kept as its own
+ * component so every gated page shows the same thing.
+ */
+const meta = {
+  title: "Feedback/LoginRequired",
+  component: LoginRequired,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof LoginRequired>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/core/MonoText.stories.tsx
+++ b/src/components/core/MonoText.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Flex, Text } from "@radix-ui/themes";
+import { MonoText } from "./MonoText";
+
+/**
+ * Text in the code face, for things that are typed rather than written:
+ * handles, ids, bucket names, prefixes.
+ *
+ * It is a one-line wrapper over Radix's Text, and exists so the font is chosen
+ * in one place — the face is a `--code-font-family` var, not a literal, so the
+ * story is also the check that the webfont actually loaded.
+ */
+const meta = {
+  title: "Typography/MonoText",
+  component: MonoText,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof MonoText>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { children: "cascadia-research/humpback-acoustics" },
+};
+
+/** Beside prose, which is the point: it should read as a different kind of thing. */
+export const AgainstProse: Story = {
+  args: { children: "@giswqs" },
+  render: (args) => (
+    <Flex direction="column" gap="2">
+      <Text size="2">Qiusheng Wu</Text>
+      <MonoText {...args} size="1" color="gray" />
+    </Flex>
+  ),
+};
+
+export const Sizes: Story = {
+  args: { children: "s3://cascadia-archive" },
+  render: (args) => (
+    <Flex direction="column" gap="2">
+      <MonoText {...args} size="1" />
+      <MonoText {...args} size="2" />
+      <MonoText {...args} size="3" />
+    </Flex>
+  ),
+};

--- a/src/components/core/MonoText.stories.tsx
+++ b/src/components/core/MonoText.stories.tsx
@@ -25,10 +25,10 @@ export const Default: Story = {
 
 /** Beside prose, which is the point: it should read as a different kind of thing. */
 export const AgainstProse: Story = {
-  args: { children: "@giswqs" },
+  args: { children: "@cholmes" },
   render: (args) => (
     <Flex direction="column" gap="2">
-      <Text size="2">Qiusheng Wu</Text>
+      <Text size="2">Chris Holmes</Text>
       <MonoText {...args} size="1" color="gray" />
     </Flex>
   ),

--- a/src/components/core/SectionHeader.stories.tsx
+++ b/src/components/core/SectionHeader.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Button, Flex, Text, TextField } from "@radix-ui/themes";
+import { SectionHeader } from "./SectionHeader";
+
+/**
+ * How a long form is broken into readable blocks: a bold label, a rule, and
+ * whatever the section contains.
+ *
+ * The `color` prop carries the whole header, rule included — a grey rule under
+ * a red heading reads as the section having stopped being dangerous halfway
+ * down. Compare Default with Danger.
+ */
+const meta = {
+  title: "Layout/SectionHeader",
+  component: SectionHeader,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof SectionHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: "Identity",
+    children: (
+      <Flex direction="column" gap="2">
+        <TextField.Root size="3" placeholder="Connection name" />
+      </Flex>
+    ),
+  },
+};
+
+export const WithDescription: Story = {
+  args: {
+    title: "Key layout",
+    description: "Where a product's objects land inside the bucket.",
+    children: (
+      <TextField.Root size="3" placeholder="{{repository.account_id}}/" />
+    ),
+  },
+};
+
+export const WithRightButton: Story = {
+  args: {
+    title: "Data connections",
+    rightButton: <Button size="1">New connection</Button>,
+    children: (
+      <Text size="2" color="gray">
+        Two connections.
+      </Text>
+    ),
+  },
+};
+
+/** Red throughout, which is how <DangerZone> is built. */
+export const Danger: Story = {
+  args: {
+    title: "Danger zone",
+    color: "red",
+    children: (
+      <Text size="2" color="gray">
+        Irreversible actions live here.
+      </Text>
+    ),
+  },
+};
+
+/**
+ * The reason the component exists: consecutive sections have to read as
+ * separate blocks rather than one continuous column of fields.
+ */
+export const Consecutive: Story = {
+  args: { title: "Identity" },
+  render: () => (
+    <>
+      <SectionHeader title="Identity">
+        <TextField.Root size="3" placeholder="Connection name" />
+      </SectionHeader>
+      <SectionHeader title="Backend">
+        <TextField.Root size="3" placeholder="Bucket" />
+      </SectionHeader>
+      <SectionHeader title="Policy">
+        <TextField.Root size="3" placeholder="Required flag" />
+      </SectionHeader>
+    </>
+  ),
+};

--- a/src/components/core/Skeleton.stories.tsx
+++ b/src/components/core/Skeleton.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Flex } from "@radix-ui/themes";
+import { Skeleton } from "./Skeleton";
+
+/**
+ * Loading placeholder. The pulse comes from a keyframe in `globals.css`, so
+ * this story is also the check that the animation survives a theme change.
+ */
+const meta = {
+  title: "Feedback/Skeleton",
+  component: Skeleton,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof Skeleton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Line: Story = {
+  args: { height: "16px", width: "240px" },
+};
+
+/** Roughly the shape of a heading over a paragraph. */
+export const Block: Story = {
+  args: {},
+  render: () => (
+    <Flex direction="column" gap="2">
+      <Skeleton height="32px" width="300px" />
+      <Skeleton height="16px" width="400px" />
+      <Skeleton height="16px" width="360px" />
+    </Flex>
+  ),
+};

--- a/src/components/core/SmallColumnContainer.stories.tsx
+++ b/src/components/core/SmallColumnContainer.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Text } from "@radix-ui/themes";
+import { SmallColumnContainer } from "./SmallColumnContainer";
+
+/**
+ * Centred column that caps line length on text-heavy pages.
+ *
+ * The story frame is already narrow, so set the Storybook viewport wide to see
+ * it do anything — the cap is what it is for.
+ */
+const meta = {
+  title: "Layout/SmallColumnContainer",
+  component: SmallColumnContainer,
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof SmallColumnContainer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const filler =
+  "Source Cooperative is a neutral, non-profit data-sharing utility that allows trusted organizations to share data without purchasing a data portal SaaS subscription or managing infrastructure.";
+
+export const Default: Story = {
+  args: {
+    children: (
+      <Text as="p" size="3">
+        {filler}
+      </Text>
+    ),
+  },
+};
+
+export const Narrow: Story = {
+  args: {
+    maxWidth: "400px",
+    children: (
+      <Text as="p" size="3">
+        {filler}
+      </Text>
+    ),
+  },
+};

--- a/src/components/core/StatusPage.stories.tsx
+++ b/src/components/core/StatusPage.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { StatusPage } from "./StatusPage";
+
+/**
+ * The three dead ends: not found, not allowed, not signed in.
+ *
+ * One component rather than three pages so they cannot drift into three
+ * different-looking apologies. `minHeight` is dropped to `auto` here — the
+ * default centres in 60vh, which in a story frame is mostly empty space.
+ */
+const meta = {
+  title: "Feedback/StatusPage",
+  component: StatusPage,
+  parameters: { layout: "padded" },
+  args: { minHeight: "auto" },
+} satisfies Meta<typeof StatusPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const NotFound: Story = {
+  args: { type: "not-found" },
+};
+
+export const NotAuthorized: Story = {
+  args: { type: "not-authorized" },
+};
+
+export const Unauthenticated: Story = {
+  args: { type: "unauthenticated" },
+};
+
+/** Callers can replace any of it; the icon is what stays. */
+export const CustomCopy: Story = {
+  args: {
+    type: "not-found",
+    title: "No such product",
+    description: "This account has no product by that name.",
+    actionText: "Back to the account",
+    actionHref: "/",
+  },
+};
+
+export const WithoutAction: Story = {
+  args: { type: "not-authorized", showAction: false },
+};

--- a/src/components/features/data-connections/ConnectionRow.stories.tsx
+++ b/src/components/features/data-connections/ConnectionRow.stories.tsx
@@ -1,0 +1,138 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Button, Flex, Text, TextField } from "@radix-ui/themes";
+import { ChevronRightIcon } from "@radix-ui/react-icons";
+import {
+  ConnectionList,
+  ConnectionMarker,
+  ConnectionRow,
+  ConnectionsEmpty,
+} from "./ConnectionRow";
+
+/**
+ * One data connection in a list.
+ *
+ * Two different lists render the same entity — an account's connections, and
+ * the ones backing a product — so they share this row. The point of the
+ * component is that they cannot drift apart, which is exactly the claim a
+ * story can settle and a screenshot of one page cannot.
+ */
+const meta = {
+  title: "Data connections/ConnectionRow",
+  component: ConnectionRow,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof ConnectionRow>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const title = (name: string) => (
+  <Text size="2" weight="medium">
+    {name}
+  </Text>
+);
+
+export const Default: Story = {
+  args: {
+    title: title("[PROD] AWS Open Data (US-West-2)"),
+    meta: "s3 · aws-opendata-us-west-2 · us-west-2 · system",
+    aside: (
+      <Text size="1" color="gray">
+        public
+      </Text>
+    ),
+    actions: <ChevronRightIcon color="var(--gray-9)" />,
+  },
+  render: (args) => (
+    <ConnectionList>
+      <ConnectionRow {...args} />
+    </ConnectionList>
+  ),
+};
+
+/**
+ * Read-only is the one state worth marking. It is deliberate configuration,
+ * not a fault, so it is marked where true and unmentioned where false.
+ */
+export const WithMarker: Story = {
+  args: {
+    ...Default.args,
+    markers: <ConnectionMarker>Read only</ConnectionMarker>,
+  },
+  render: Default.render,
+};
+
+/** The tinted strip is for a value that can be edited without leaving the row. */
+export const WithFooter: Story = {
+  args: {
+    ...Default.args,
+    footer: (
+      <Flex align="center" gap="2">
+        <Text size="1" color="gray">
+          Prefix
+        </Text>
+        <TextField.Root size="1" defaultValue="rainfall/" style={{ flex: 1 }} />
+        <Button size="1" variant="soft">
+          Save
+        </Button>
+      </Flex>
+    ),
+  },
+  render: Default.render,
+};
+
+/**
+ * The reason this is one bordered container with hairlines rather than a card
+ * each: a card per connection looked fine at three rows and fell apart at
+ * thirty, which an account holding every regional Open Data connection has.
+ */
+export const AList: Story = {
+  args: Default.args,
+  render: () => (
+    <ConnectionList>
+      <ConnectionRow
+        title={title("[PROD] Azure Open Data (West Europe)")}
+        markers={<ConnectionMarker>Read only</ConnectionMarker>}
+        meta="azure · opendatastore/westeurope · westeurope · system"
+        aside={
+          <Text size="1" color="gray">
+            public
+          </Text>
+        }
+        actions={<ChevronRightIcon color="var(--gray-9)" />}
+      />
+      <ConnectionRow
+        title={title("RLE Assessment Files")}
+        markers={<ConnectionMarker>Read only</ConnectionMarker>}
+        meta="gcs · rle-files · Tyler Erickson"
+        aside={
+          <Text size="1" color="gray">
+            public, unlisted
+          </Text>
+        }
+        actions={<ChevronRightIcon color="var(--gray-9)" />}
+      />
+      <ConnectionRow
+        title={title("Cascadia Archive")}
+        meta="s3 · cascadia-archive · us-west-2 · Cascadia Research"
+        aside={
+          <Text size="1" color="gray">
+            permits nothing
+          </Text>
+        }
+        actions={<ChevronRightIcon color="var(--gray-9)" />}
+      />
+    </ConnectionList>
+  ),
+};
+
+/** Shared so the account list and the product list cannot disagree about it. */
+export const Empty: Story = {
+  args: Default.args,
+  render: () => (
+    <ConnectionList>
+      <ConnectionsEmpty>
+        Create a data connection to get started.
+      </ConnectionsEmpty>
+    </ConnectionList>
+  ),
+};

--- a/src/components/features/data-connections/DataConnectionsList.stories.tsx
+++ b/src/components/features/data-connections/DataConnectionsList.stories.tsx
@@ -1,0 +1,121 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { DataConnectionsList } from "./DataConnectionsList";
+import type { Account, DataConnection } from "@/types";
+import { DataProvider } from "@/types";
+
+/**
+ * An account's data connections, or every connection in the admin view.
+ *
+ * The identifier line reads backend · bucket · region · owner — which backend,
+ * which bucket, which region, whose. The connection id is deliberately absent:
+ * it is slugified from the name directly above it.
+ */
+const meta = {
+  title: "Data connections/DataConnectionsList",
+  component: DataConnectionsList,
+  parameters: { layout: "padded" },
+  args: { editHref: (id: string) => `/admin/data-connections/${id}` },
+} satisfies Meta<typeof DataConnectionsList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Cast once, at the boundary: the list reads a handful of fields, and building
+// valid DataConnections here would be pages of irrelevant scaffolding.
+const connections = [
+  {
+    data_connection_id: "aws-opendata-us-west-2",
+    name: "[PROD] AWS Open Data (US-West-2)",
+    details: {
+      provider: DataProvider.S3,
+      bucket: "aws-opendata-us-west-2",
+      base_prefix: "",
+      region: "us-west-2",
+    },
+    read_only: true,
+    allowed_visibilities: ["public"],
+  },
+  {
+    data_connection_id: "azure-opendata-west-europe",
+    name: "[PROD] Azure Open Data (West Europe)",
+    details: {
+      provider: DataProvider.Azure,
+      account_name: "opendatastore",
+      container_name: "westeurope",
+      base_prefix: "",
+      region: "westeurope",
+    },
+    read_only: true,
+    allowed_visibilities: ["public"],
+  },
+  {
+    data_connection_id: "rle-files",
+    name: "RLE Assessment Files",
+    owner: "tyler",
+    details: {
+      provider: DataProvider.GCS,
+      bucket: "rle-files",
+      base_prefix: "",
+    },
+    read_only: true,
+    allowed_visibilities: ["public", "unlisted"],
+  },
+  {
+    data_connection_id: "cascadia-archive",
+    name: "Cascadia Archive",
+    owner: "cascadia-research",
+    details: {
+      provider: DataProvider.S3,
+      bucket: "cascadia-archive",
+      base_prefix: "",
+      region: "us-west-2",
+    },
+    read_only: false,
+    // Permits nothing, which the row states rather than leaving blank.
+    allowed_visibilities: [],
+  },
+] as unknown as DataConnection[];
+
+const ownerAccounts = {
+  tyler: {
+    account_id: "tyler",
+    name: "Tyler Erickson",
+    type: "individual",
+  },
+  "cascadia-research": {
+    account_id: "cascadia-research",
+    name: "Cascadia Research",
+    type: "organization",
+  },
+} as unknown as Record<string, Account>;
+
+/**
+ * An account's own list. Ownership is omitted: every connection here has the
+ * same owner, so printing it on each row says nothing.
+ */
+export const AccountScoped: Story = {
+  args: { connections },
+};
+
+/**
+ * The admin view, where ownership varies and is therefore worth showing —
+ * as quiet text on the identifier line, not a chip. Four outlined labels per
+ * row read as a wall, and nothing inside a wall stands out.
+ */
+export const AdminWithOwners: Story = {
+  args: { connections, ownerAccounts },
+};
+
+/** An owner id that no longer resolves to an account falls back to the raw id. */
+export const UnresolvableOwner: Story = {
+  args: {
+    connections: [
+      { ...connections[0], owner: "deleted-account" } as DataConnection,
+    ],
+    ownerAccounts: {},
+  },
+};
+
+export const Empty: Story = {
+  args: { connections: [] },
+};

--- a/src/components/features/products/ProductDataUnavailable.stories.tsx
+++ b/src/components/features/products/ProductDataUnavailable.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { ProductDataUnavailable } from "./ProductDataUnavailable";
+
+/**
+ * Shown when a viewer who *is* authorized still can't read the data — freshly
+ * minted credentials that haven't propagated, or a proxy that is down.
+ *
+ * It degrades in place rather than throwing to the route error boundary, which
+ * would blank the whole product. That is the reason it exists and the reason
+ * it is hard to see: reproducing it in the app means breaking the data proxy.
+ */
+const meta = {
+  title: "Products/ProductDataUnavailable",
+  component: ProductDataUnavailable,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof ProductDataUnavailable>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** The proxy returned AccessDenied — usually credentials still propagating. */
+export const AccessDenied: Story = {};
+
+/** The backend was unreachable, so the contents could not be loaded at all. */
+export const BackendUnreachable: Story = {
+  args: {
+    message:
+      "We couldn't reach the storage backend for this product. Try again in a moment.",
+  },
+};
+
+/**
+ * `details` is passed only for viewers who can edit the product — the gating
+ * happens server-side, so this is what a maintainer sees and a reader never
+ * does.
+ */
+export const WithMaintainerDetails: Story = {
+  args: {
+    details:
+      "AccessDenied: User: arn:aws:sts::000000000000:assumed-role/source-proxy/session is not authorized to perform: s3:GetObject on resource: arn:aws:s3:::cascadia-archive/humpback-acoustics/manifest.json",
+  },
+};

--- a/src/components/features/products/ProductsSkeleton.stories.tsx
+++ b/src/components/features/products/ProductsSkeleton.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { ProductsSkeleton } from "./ProductsSkeleton";
+
+/**
+ * What the product list shows while it loads.
+ *
+ * Worth putting beside the real list: a skeleton whose proportions do not match
+ * what replaces it produces a visible jump the moment data arrives.
+ */
+const meta = {
+  title: "Products/ProductsSkeleton",
+  component: ProductsSkeleton,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof ProductsSkeleton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+/** Where the surrounding page already owns the filters. */
+export const WithoutFilters: Story = {
+  args: { showFilters: false },
+};

--- a/src/components/features/products/TagList.stories.tsx
+++ b/src/components/features/products/TagList.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { TagList } from "./TagList";
+
+/** A product's tags, each linking to the filtered product list. */
+const meta = {
+  title: "Products/TagList",
+  component: TagList,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof TagList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { tags: ["bathymetry", "acoustics", "cetaceans"] },
+};
+
+/** Nothing tagged: it should collapse rather than leave a gap. */
+export const Empty: Story = {
+  args: { tags: [] },
+};
+
+/** Real products carry a lot of these; the row has to wrap, not scroll. */
+export const Many: Story = {
+  args: {
+    tags: [
+      "bathymetry",
+      "acoustics",
+      "cetaceans",
+      "remote-sensing",
+      "north-pacific",
+      "time-series",
+      "cloud-optimized",
+      "public-domain",
+      "salish-sea",
+      "hydrophone",
+    ],
+  },
+};
+
+export const LongTag: Story = {
+  args: { tags: ["synthetic-aperture-radar-interferometry", "sar"] },
+};

--- a/src/components/features/profiles/ProfileAvatar.stories.tsx
+++ b/src/components/features/profiles/ProfileAvatar.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Flex } from "@radix-ui/themes";
+import { ProfileAvatar } from "./ProfileAvatar";
+import type { Account } from "@/types";
+
+/**
+ * An account's picture, with a three-step fallback: an uploaded
+ * `profile_image`, then Gravatar for individuals with a primary email, then
+ * the first letter of the display name.
+ *
+ * Shape carries the account type — individuals are round, organizations
+ * squared — which is the only thing distinguishing them in a mixed list.
+ */
+const meta = {
+  title: "Profiles/ProfileAvatar",
+  component: ProfileAvatar,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof ProfileAvatar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const individual = {
+  account_id: "giswqs",
+  name: "Qiusheng Wu",
+  type: "individual",
+} as unknown as Account;
+
+const organization = {
+  account_id: "cascadia-research",
+  name: "Cascadia Research",
+  type: "organization",
+} as unknown as Account;
+
+/** No image and no email: the initial. */
+export const Initial: Story = {
+  args: { account: individual },
+};
+
+/** Round for a person, squared for an organization. */
+export const Shapes: Story = {
+  args: { account: individual },
+  render: () => (
+    <Flex align="center" gap="3">
+      <ProfileAvatar account={individual} />
+      <ProfileAvatar account={organization} />
+    </Flex>
+  ),
+};
+
+export const Sizes: Story = {
+  args: { account: individual },
+  render: () => (
+    <Flex align="center" gap="3">
+      <ProfileAvatar account={individual} size="1" />
+      <ProfileAvatar account={individual} size="2" />
+      <ProfileAvatar account={individual} size="4" />
+      <ProfileAvatar account={individual} size="6" />
+    </Flex>
+  ),
+};
+
+/**
+ * An uploaded image wins over both fallbacks. Inline SVG rather than a hosted
+ * URL so the story does not depend on the network.
+ */
+export const WithImage: Story = {
+  args: {
+    account: {
+      ...individual,
+      metadata_public: {
+        profile_image:
+          "data:image/svg+xml," +
+          encodeURIComponent(
+            '<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96">' +
+              '<rect width="96" height="96" fill="#4a7ba7"/>' +
+              '<circle cx="48" cy="38" r="16" fill="#fff"/>' +
+              '<ellipse cx="48" cy="82" rx="26" ry="22" fill="#fff"/></svg>'
+          ),
+      },
+    } as unknown as Account,
+  },
+};

--- a/src/components/features/profiles/ProfileAvatar.stories.tsx
+++ b/src/components/features/profiles/ProfileAvatar.stories.tsx
@@ -21,8 +21,8 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const individual = {
-  account_id: "giswqs",
-  name: "Qiusheng Wu",
+  account_id: "cholmes",
+  name: "Chris Holmes",
   type: "individual",
 } as unknown as Account;
 

--- a/src/components/features/profiles/ProfileLocation.stories.tsx
+++ b/src/components/features/profiles/ProfileLocation.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { ProfileLocation } from "./ProfileLocation";
+
+/** Where an account says it is, with a globe beside it. */
+const meta = {
+  title: "Profiles/ProfileLocation",
+  component: ProfileLocation,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof ProfileLocation>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { location: "Knoxville, Tennessee" },
+};
+
+/** Free text, so it can be as long as someone types. */
+export const Long: Story = {
+  args: {
+    location: "Department of Geography and Sustainability, Knoxville, Tennessee",
+  },
+};

--- a/src/components/features/profiles/ProfileLocation.stories.tsx
+++ b/src/components/features/profiles/ProfileLocation.stories.tsx
@@ -12,12 +12,13 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  args: { location: "Knoxville, Tennessee" },
+  args: { location: "San Francisco, California" },
 };
 
 /** Free text, so it can be as long as someone types. */
 export const Long: Story = {
   args: {
-    location: "Department of Geography and Sustainability, Knoxville, Tennessee",
+    location:
+      "Rural Municipality of Portage la Prairie, Manitoba, Canada",
   },
 };

--- a/src/components/features/profiles/WebsiteLink.stories.tsx
+++ b/src/components/features/profiles/WebsiteLink.stories.tsx
@@ -19,21 +19,21 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Generic: Story = {
-  args: { url: "https://cascadiaresearch.org" },
+  args: { url: "https://cholmes.org" },
 };
 
 export const KnownHosts: Story = {
-  args: { url: "https://github.com/giswqs" },
+  args: { url: "https://github.com/cholmes" },
   render: () => (
     <Flex direction="column" gap="2">
-      <WebsiteLink url="https://github.com/giswqs" />
-      <WebsiteLink url="https://www.linkedin.com/in/giswqs" />
-      <WebsiteLink url="https://wetlands.io" />
+      <WebsiteLink url="https://github.com/cholmes" />
+      <WebsiteLink url="https://www.linkedin.com/in/cholmes" />
+      <WebsiteLink url="https://cholmes.org" />
     </Flex>
   ),
 };
 
 /** A bare hostname is upgraded to https rather than treated as a relative path. */
 export const WithoutScheme: Story = {
-  args: { url: "wetlands.io" },
+  args: { url: "cholmes.org" },
 };

--- a/src/components/features/profiles/WebsiteLink.stories.tsx
+++ b/src/components/features/profiles/WebsiteLink.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Flex } from "@radix-ui/themes";
+import { WebsiteLink } from "./WebsiteLink";
+
+/**
+ * A link on a profile, with an icon chosen from the hostname.
+ *
+ * The icon is the whole behaviour — GitHub and LinkedIn get their marks, and
+ * everything else a generic link — so seeing the set side by side is the only
+ * way to check the matching works.
+ */
+const meta = {
+  title: "Profiles/WebsiteLink",
+  component: WebsiteLink,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof WebsiteLink>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Generic: Story = {
+  args: { url: "https://cascadiaresearch.org" },
+};
+
+export const KnownHosts: Story = {
+  args: { url: "https://github.com/giswqs" },
+  render: () => (
+    <Flex direction="column" gap="2">
+      <WebsiteLink url="https://github.com/giswqs" />
+      <WebsiteLink url="https://www.linkedin.com/in/giswqs" />
+      <WebsiteLink url="https://wetlands.io" />
+    </Flex>
+  ),
+};
+
+/** A bare hostname is upgraded to https rather than treated as a relative path. */
+export const WithoutScheme: Story = {
+  args: { url: "wetlands.io" },
+};


### PR DESCRIPTION
**Stacked on #514** — review that one first. This branch adds feature-level stories; #514 covers `components/core`.

The stack is not optional here: #514 stops `AccountInfoHoverCard` pulling the `../features/profiles` barrel, and without that fix `DataConnectionsList` throws `__filename is not defined` on render.

**Eight components, 27 stories.**

## Chosen for what the app makes expensive to reach

- **`ConnectionRow`** and its `ConnectionList`, `ConnectionMarker` and empty state. The premise of #504 was that an account's connections and a product's mirrors must not drift apart — a story of the shared row is the only place both can be seen at once. Includes the many-row case that motivated dropping card-per-connection, and the editable footer.
- **`DataConnectionsList`** — account-scoped (ownership omitted, since every row has the same owner) and admin (ownership as quiet text, not a chip), plus an owner id that no longer resolves to an account.
- **`ProductDataUnavailable`** — reproducing this in the app means breaking the data proxy. All three forms, including the error detail that is only ever sent to maintainers.
- **`ProfileAvatar`** — the fallback chain, and the round/squared shapes that are the only thing distinguishing a person from an organization in a mixed list.
- **`TagList`**, **`ProductsSkeleton`**, **`WebsiteLink`**, **`ProfileLocation`** — smaller, but each has a case worth pinning: ten tags wrapping, a skeleton whose proportions have to match the real list, hostname-based icon matching, an over-long location.

## Fixtures are cast at the boundary

These components read a handful of fields. A valid `DataConnection` or `Account` here would be pages of scaffolding obscuring what the story shows, so the fixtures are plain objects cast once. `ProfileAvatar`'s image story embeds an inline SVG rather than a hosted URL, so no story depends on the network.

## Verified by rendering

`storybook build` compiles stories without executing them — on #514 it passed clean while eleven stories threw on mount. Every story here was rendered in a browser and checked for the error overlay and an empty root:

```
PASS 93/93 — all stories rendered
```

(93 = this branch's 27 plus #514's 66.)

`tsc` clean · jest 62 suites / 546 tests · `next lint` 0 errors · `storybook build` succeeds.

## Scope note

This is the first time the Storybook covers anything outside `components/core`, which is a change in what it is *for*. I kept to presentational components with light dependencies — nothing here reaches a server action or the database. Forms like `DataConnectionForm` and `EditProfileForm` are deliberately absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mnsg8m1dXZ5z5ig5xMtkE
