### PR TITLE
fix(data-connections): put the ID note between the label and the value

### DIFF
--- a/src/components/features/data-connections/DataConnectionForm.tsx
+++ b/src/components/features/data-connections/DataConnectionForm.tsx
@@ -395,19 +395,20 @@ export function DataConnectionForm({
             {/* The id is derived, not asked for — but it is permanent and shows
                 up in URLs and as the storage key, so it is shown rather than
                 sprung on the user after saving. */}
-            <Field label="ID" group>
-              <Flex align="center" gap="2">
-                <Code size="2" variant="ghost" color="gray">
-                  {derivedId || "—"}
-                </Code>
-                <Text size="1" color="gray">
-                  {mode === "edit"
-                    ? "Permanent; renaming does not move it."
-                    : derivedId
-                      ? "Made from the name. Permanent once created."
-                      : "Add a few letters or numbers to the name."}
-                </Text>
-              </Flex>
+            <Field
+              label="ID"
+              help={
+                mode === "edit"
+                  ? "Permanent; renaming does not move it."
+                  : derivedId
+                    ? "Made from the name. Permanent once created."
+                    : "Add a few letters or numbers to the name."
+              }
+              group
+            >
+              <Code size="2" variant="ghost" color="gray">
+                {derivedId || "—"}
+              </Code>
             </Field>
 
           </Flex>


### PR DESCRIPTION
The ID field in the data connection form hung its note off to the right of the derived id, so the one field in the Identity section read differently from every other one, and the note was easy to mistake for part of the value itself.

`Field` already renders its `help` prop between the label and the control — the anatomy the Name field directly above it uses — so this just moves the note into that slot.

**Before**

```
ID
foo-bar  Made from the name. Permanent once created.
```

**After**

```
ID
Made from the name. Permanent once created.
foo-bar
```

As `help`, the note also lands in `aria-describedby` for the group, which the inline `<Text>` never was.

No test: the form has no suite and this is markup placement only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
