### PR TITLE
fix(data-connections): give the prefix preview a label of its own

### DIFF
--- a/src/components/features/data-connections/DataConnectionForm.tsx
+++ b/src/components/features/data-connections/DataConnectionForm.tsx
@@ -671,11 +671,11 @@ export function DataConnectionForm({
               label="Example Prefix"
               help={
                 <>
-                  A product at{" "}
+                  Where a product at{" "}
                   <Code size="1" variant="ghost">
                     example-org/rainfall
                   </Code>{" "}
-                  would be stored at
+                  would be stored.
                 </>
               }
             >

--- a/src/components/features/data-connections/DataConnectionForm.tsx
+++ b/src/components/features/data-connections/DataConnectionForm.tsx
@@ -652,42 +652,45 @@ export function DataConnectionForm({
               errors={state.fieldErrors?.prefix_template}
             >
               {(props) => (
-                <Flex direction="column" gap="2">
-                  <TextField.Root
-                    {...props}
-                    type="text"
-                    name="prefix_template"
-                    value={prefixTemplate}
-                    onChange={(event) => setPrefixTemplate(event.target.value)}
-                    size="3"
-                  />
-                  {/* A worked example, rather than describing the substitution in
-                      prose and leaving the reader to run it in their head. */}
-                  <Box
-                    p="2"
-                    style={{
-                      border: "1px solid var(--gray-6)",
-                      backgroundColor: "var(--gray-2)",
-                    }}
-                  >
-                    <Text as="p" size="1" color="gray">
-                      A product at{" "}
-                      <Code size="1" variant="ghost">
-                        example-org/rainfall
-                      </Code>{" "}
-                      would be stored at
-                    </Text>
-                    <Code
-                      size="1"
-                      variant="ghost"
-                      color="gray"
-                      style={{ wordBreak: "break-all" }}
-                    >
-                      {resolvedLocation}
-                    </Code>
-                  </Box>
-                </Flex>
+                <TextField.Root
+                  {...props}
+                  type="text"
+                  name="prefix_template"
+                  value={prefixTemplate}
+                  onChange={(event) => setPrefixTemplate(event.target.value)}
+                  size="3"
+                />
               )}
+            </Field>
+
+            {/* A worked example, rather than describing the substitution in
+                prose and leaving the reader to run it in their head. */}
+            <Field
+              group
+              label="Example Prefix"
+              help={
+                <>
+                  A product at{" "}
+                  <Code size="1" variant="ghost">
+                    example-org/rainfall
+                  </Code>{" "}
+                  would be stored at
+                </>
+              }
+            >
+              <Box
+                p="2"
+                style={{
+                  border: "1px solid var(--gray-6)",
+                  backgroundColor: "var(--gray-2)",
+                  borderRadius: "var(--radius-2)",
+                  overflowX: "auto",
+                  fontSize: "var(--font-size-1)",
+                }}
+                asChild
+              >
+                <pre>{resolvedLocation}</pre>
+              </Box>
             </Field>
 
           </Flex>


### PR DESCRIPTION
Follow-up to #501.

The worked example added there hung off the bottom of the Prefix Template control, so it read as part of that field rather than as its own thing.

**Now:**
- **Label:** "Example Prefix" — the same `Field` anatomy as every other field, with `group` since it's a read-only display, not a control.
- **Help:** "A product at `example-org/rainfall` would be stored at" moves into the help slot, where every other field's guidance already lives.
- **Box:** contains only `<pre>{resolvedLocation}</pre>`. Monospace, `overflow-x: auto` so a long prefix scrolls instead of breaking mid-path — the old `wordBreak: "break-all"` split paths at arbitrary characters.

No behavior change: `exampleLocation` and its tests are untouched.

## Testing

- `npx tsc --noEmit` — no errors in `DataConnectionForm.tsx` (pre-existing errors elsewhere in analytics/Storybook files are unrelated).
- `npx jest src/components/features/data-connections` — 4 suites, 26 tests, all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)