### PR TITLE
refactor(uploader): stop the object browser importing the server through barrels

### DIFF
--- a/src/components/features/products/object-browser/DirectoryList.tsx
+++ b/src/components/features/products/object-browser/DirectoryList.tsx
@@ -4,7 +4,7 @@ import { Box, Text } from "@radix-ui/themes";
 import { ChevronDownIcon } from "@radix-ui/react-icons";
 import { useRef, useState, useEffect } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { MonoText } from "@/components/core";
+import { MonoText } from "@/components/core/MonoText";
 import { asFileNodes, mergeUploadsWithFiles } from "./utils";
 import type { Product, ProductObject } from "@/types";
 import styles from "./ObjectBrowser.module.css";

--- a/src/components/features/products/object-browser/DirectoryListLoading.tsx
+++ b/src/components/features/products/object-browser/DirectoryListLoading.tsx
@@ -1,5 +1,5 @@
 import { Box, Flex } from "@radix-ui/themes";
-import { Skeleton } from "@/components/core";
+import { Skeleton } from "@/components/core/Skeleton";
 
 export default function DirectoryListLoading() {
   return (

--- a/src/components/features/products/object-browser/DirectoryRow.tsx
+++ b/src/components/features/products/object-browser/DirectoryRow.tsx
@@ -21,7 +21,7 @@ import {
 } from "@radix-ui/react-icons";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { MonoText } from "@/components/core";
+import { MonoText } from "@/components/core/MonoText";
 import type { FileNode } from "./utils";
 import type { Product } from "@/types";
 import { formatBytes } from "@/lib/format";

--- a/src/components/features/products/object-browser/ObjectPreviewExternal.tsx
+++ b/src/components/features/products/object-browser/ObjectPreviewExternal.tsx
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { LOGGER } from "@/lib";
+import { LOGGER } from "@/lib/logging";
 import { fileSourceUrl } from "@/lib/urls";
 import { Code } from "@radix-ui/themes";
 import { getExtension } from "@/lib/files";

--- a/src/components/features/products/object-browser/ObjectPreviewInternal.tsx
+++ b/src/components/features/products/object-browser/ObjectPreviewInternal.tsx
@@ -1,4 +1,4 @@
-import { LOGGER } from "@/lib";
+import { LOGGER } from "@/lib/logging";
 import { getStorageClient } from "@/lib/clients/storage";
 import { MarkdownViewer } from "@/components/features/markdown/MarkdownViewer";
 import { TextViewer } from "@/components/features/text/TextViewer";

--- a/src/components/features/products/object-browser/ObjectSummary.tsx
+++ b/src/components/features/products/object-browser/ObjectSummary.tsx
@@ -8,8 +8,10 @@ import type {
 } from "@/types";
 import { DateText } from "@/components/display";
 import { ChecksumVerifier } from "../ChecksumVerifier";
-import { MonoText, CopyToClipboard } from "@/components/core";
-import { fileSourceUrl, formatBytes } from "@/lib";
+import { MonoText } from "@/components/core/MonoText";
+import { CopyToClipboard } from "@/components/core/CopyToClipboard";
+import { fileSourceUrl } from "@/lib/urls";
+import { formatBytes } from "@/lib/format";
 
 interface ObjectSummaryProps {
   product: Product;

--- a/src/components/features/products/object-browser/storeViewer.ts
+++ b/src/components/features/products/object-browser/storeViewer.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { LOGGER } from "@/lib";
+import { LOGGER } from "@/lib/logging";
 import { fileSourceUrl } from "@/lib/urls";
 import { getStorageClient } from "@/lib/clients/storage";
 import type { ProxyCredentials } from "@/lib/actions/proxy-credentials";

--- a/src/components/features/uploader/CredentialsProvider.tsx
+++ b/src/components/features/uploader/CredentialsProvider.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { LOGGER, TemporaryCredentials, getTemporaryCredentials } from "@/lib";
+import { LOGGER } from "@/lib/logging";
+import {
+  type TemporaryCredentials,
+  getTemporaryCredentials,
+} from "@/lib/actions/credentials";
 import {
   createContext,
   useContext,

--- a/src/components/features/uploader/UploadProvider.tsx
+++ b/src/components/features/uploader/UploadProvider.tsx
@@ -10,7 +10,7 @@ import {
   useRef,
 } from "react";
 import { S3UploadService } from "@/lib/services/s3-upload";
-import { getTemporaryCredentials } from "@/lib";
+import { getTemporaryCredentials } from "@/lib/actions/credentials";
 import { useS3Credentials } from "./CredentialsProvider";
 import type { CredentialsScope } from "./CredentialsProvider";
 import { useBeforeUnload } from "@/hooks/useBeforeUnload";

--- a/src/components/features/uploader/UploadsSubmenu.tsx
+++ b/src/components/features/uploader/UploadsSubmenu.tsx
@@ -19,7 +19,8 @@ import {
   ExclamationTriangleIcon,
 } from "@radix-ui/react-icons";
 import { useUploadManager } from "@/components/features/uploader/UploadProvider";
-import { productUrl, formatBytes } from "@/lib";
+import { productUrl } from "@/lib/urls";
+import { formatBytes } from "@/lib/format";
 
 export function UploadsSubmenu() {
   const { uploads, cancelUpload, retryUpload } = useUploadManager();

--- a/src/components/features/uploader/ViewCredentialsDialog.tsx
+++ b/src/components/features/uploader/ViewCredentialsDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { TemporaryCredentials } from "@/lib";
+import type { TemporaryCredentials } from "@/lib/actions/credentials";
 import {
   Dialog,
   Button,
@@ -17,7 +17,7 @@ import {
 } from "@radix-ui/themes";
 import { CopyIcon, CheckIcon, InfoCircledIcon } from "@radix-ui/react-icons";
 import React, { useState } from "react";
-import { MonoText } from "@/components/core";
+import { MonoText } from "@/components/core/MonoText";
 
 interface ViewCredentialsDialogProps {
   credentials: TemporaryCredentials;


### PR DESCRIPTION
`src/lib/index.ts` is:

```ts
export * from "./actions";
export * from "./clients";
```

So importing **one helper** from `@/lib` pulls every server action and every DynamoDB client behind it. Eleven client components were doing that — for a URL builder, a byte formatter, or `LOGGER`.

The uploader is the worst case, and the object browser inherits it:

```
DirectoryList → useUploadManager → UploadProvider → getTemporaryCredentials from "@/lib"
```

The file tree on every product page was carrying the whole server surface into the browser bundle to get one credentials helper.

## The change

Each import now names the module it actually wants — `@/lib/logging`, `@/lib/format`, `@/lib/urls`, `@/lib/actions/credentials`. Same treatment for `@/components/core`, which re-exports `AccountSearchInput` and reaches the account actions through it; the five call sites here only wanted `MonoText`, `Skeleton` or `CopyToClipboard`.

**No behaviour change** — same symbols from the same modules, just addressed directly. This is the third time a barrel has dragged server-only code into a browser bundle in this area (see #514 for `features/profiles`), so it may be worth a lint rule eventually.

## Scope note

I found this trying to give the file tree a Storybook story, and that story is **not** in this PR. `@/lib/actions/credentials` is itself `"use server"`, so `DirectoryList` still reaches a server action legitimately and needs it mocked — which depends on the mocking setup in #517. This is the half that stands on its own merits.

Left alone deliberately: the `@/lib` imports in `src/app/**`, API routes and middleware, where pulling server modules is the point.

## Verification

`tsc` clean · jest 65 suites / 567 tests · `next lint` 0 errors · `storybook build` succeeds.

Worth a look at the bundle-size delta on the product page in preview — I could not measure it here (`next build` needs AWS credentials this environment does not have).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mnsg8m1dXZ5z5ig5xMtkE