### PR TITLE
docs(storybook): story the object browser — file tree, breadcrumbs, and object detail

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -6,6 +6,21 @@ const config: StorybookConfig = {
   // which is exactly what this addon checks. Jest stays the test runner, so no
   // addon-vitest.
   addons: ["@storybook/addon-a11y", "@storybook/addon-docs"],
+  // CONFIG.storage.endpoint reads NEXT_PUBLIC_S3_ENDPOINT and has no fallback,
+  // so without this any story rendering a source URL shows "undefined/..." and
+  // reads as a bug in the product rather than a gap in the environment. A
+  // `define` rather than Storybook's `env`: the Next builder inlines
+  // NEXT_PUBLIC_* at build time from the real environment and never sees it.
+  // The real public endpoint, since these stories are published.
+  viteFinal: async (config) => ({
+    ...config,
+    define: {
+      ...config.define,
+      "process.env.NEXT_PUBLIC_S3_ENDPOINT": JSON.stringify(
+        "https://data.source.coop"
+      ),
+    },
+  }),
   framework: "@storybook/nextjs-vite",
   staticDirs: ["../public"],
 };

--- a/src/components/display/BreadcrumbNav.stories.tsx
+++ b/src/components/display/BreadcrumbNav.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { BreadcrumbNav } from "./BreadcrumbNav";
+
+/**
+ * Where you are inside a product's objects, and the way back up.
+ *
+ * The last segment is deliberately not a link when it is the current
+ * directory — it goes where you already are — but it becomes one as soon as a
+ * `fileName` sits below it.
+ *
+ * Deep paths truncate to the first two and last two segments with an ellipsis
+ * between. That rule only shows itself past four segments, which is exactly
+ * the case a real product rarely gives you on demand.
+ */
+const meta = {
+  title: "Object browser/BreadcrumbNav",
+  component: BreadcrumbNav,
+  parameters: { layout: "padded" },
+  args: { baseUrl: "/cascadia-research/humpback-acoustics" },
+} satisfies Meta<typeof BreadcrumbNav>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** At the root, "root" is plain text rather than a link back to itself. */
+export const Root: Story = {
+  args: { path: [] },
+};
+
+export const OneLevel: Story = {
+  args: { path: ["recordings"] },
+};
+
+/** Four segments still fit; nothing is elided. */
+export const AtTheTruncationLimit: Story = {
+  args: { path: ["recordings", "2019", "site-a", "raw"] },
+};
+
+/** Past four, so the middle collapses to an ellipsis. */
+export const Truncated: Story = {
+  args: {
+    path: ["recordings", "2019", "site-a", "raw", "flac", "hydrophone-3"],
+  },
+};
+
+/**
+ * Viewing a file: the directory that contains it becomes a link, because it is
+ * somewhere you can now go back to.
+ */
+export const OnAFile: Story = {
+  args: {
+    path: ["recordings", "2019"],
+    fileName: "site-a-20190712-0800.flac",
+  },
+};
+
+/** A single segment long enough to crowd the row. */
+export const LongSegment: Story = {
+  args: {
+    path: ["continuous-passive-acoustic-monitoring-deployments-2019-2024"],
+  },
+};

--- a/src/components/features/products/object-browser/DirectoryList.stories.tsx
+++ b/src/components/features/products/object-browser/DirectoryList.stories.tsx
@@ -1,5 +1,8 @@
+import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Flex } from "@radix-ui/themes";
 import { DirectoryList } from "./DirectoryList";
+import { BreadcrumbNav } from "@/components/display/BreadcrumbNav";
 import {
   S3CredentialsProvider,
   UploadProvider,
@@ -134,4 +137,81 @@ export const Virtualized: Story = {
       )
     ),
   },
+};
+
+// A whole product's objects, flat, the way the listing API returns them.
+// Directories carry a trailing slash; `childrenOf` slices one level out.
+const tree: ProductObject[] = [
+  object("recordings/", 0, "directory"),
+  object("recordings/2019/", 0, "directory"),
+  object("recordings/2019/site-a-20190712-0800.flac", 122_880_000),
+  object("recordings/2019/site-a-20190712-0900.flac", 121_453_312),
+  object("recordings/2020/", 0, "directory"),
+  object("recordings/2020/site-b-20200103-1100.flac", 98_566_144),
+  object("derived/", 0, "directory"),
+  object("derived/spectrograms/", 0, "directory"),
+  object("derived/spectrograms/site-a-20190712.png", 2_204_160),
+  object("derived/detections.parquet", 8_412_672),
+  object("README.md", 2_140),
+  object("catalog.parquet", 48_204_112),
+];
+
+/** One level of `tree`, given a prefix — what the server returns per path. */
+function childrenOf(objects: ProductObject[], prefix: string): ProductObject[] {
+  return objects.filter((o) => {
+    if (!o.path.startsWith(prefix) || o.path === prefix) return false;
+    const rest = o.path.slice(prefix.length).replace(/\/$/, "");
+    return !rest.includes("/");
+  });
+}
+
+/**
+ * Browsing, wired up.
+ *
+ * In the app a directory is a `<Link>` and the server re-fetches the listing
+ * for the new URL. Storybook has no server and a mocked router, so clicks go
+ * nowhere. This holds the prefix in state and intercepts clicks on links into
+ * this product, which is a stand-in for the routing rather than the routing
+ * itself — but it makes the thing you actually want to check, moving up and
+ * down a tree with the breadcrumb keeping pace, reviewable here.
+ */
+function BrowsableTree({ product }: { product: Product }) {
+  const [prefix, setPrefix] = useState("");
+  const base = `/${product.account_id}/${product.product_id}`;
+  const segments = prefix ? prefix.replace(/\/$/, "").split("/") : [];
+
+  return (
+    <Flex
+      direction="column"
+      gap="3"
+      onClickCapture={(event) => {
+        const link = (event.target as HTMLElement).closest("a");
+        const href = link?.getAttribute("href");
+        if (!href || !href.startsWith(base)) return;
+        // A row's href carries the object path verbatim, so a directory
+        // already ends in "/", while a breadcrumb's does not. Normalise before
+        // comparing, or every directory click looks like an unknown path.
+        const next = href
+          .slice(base.length)
+          .replace(/^\//, "")
+          .replace(/\/$/, "");
+        // Files have no listing to show, so only directories move the prefix.
+        if (next && !tree.some((o) => o.path === `${next}/`)) return;
+        event.preventDefault();
+        setPrefix(next ? `${next}/` : "");
+      }}
+    >
+      <BreadcrumbNav path={segments} baseUrl={base} />
+      <DirectoryList
+        product={product}
+        objects={childrenOf(tree, prefix)}
+        prefix={prefix}
+      />
+    </Flex>
+  );
+}
+
+export const Browsable: Story = {
+  args: { product, objects: [], prefix: "" },
+  render: (args) => <BrowsableTree product={args.product} />,
 };

--- a/src/components/features/products/object-browser/DirectoryList.stories.tsx
+++ b/src/components/features/products/object-browser/DirectoryList.stories.tsx
@@ -68,77 +68,6 @@ const object = (
     checksum: "d41d8cd98f00b204e9800998ecf8427e",
   }) as ProductObject;
 
-/** Directories and files at the root of a product. */
-export const Default: Story = {
-  args: {
-    product,
-    prefix: "",
-    objects: [
-      object("recordings/", 0, "directory"),
-      object("derived/", 0, "directory"),
-      object("README.md", 2_140),
-      object("manifest.json", 18_902),
-      object("catalog.parquet", 48_204_112),
-    ],
-  },
-};
-
-/** Nested one level down. */
-export const InADirectory: Story = {
-  args: {
-    product,
-    prefix: "recordings/",
-    objects: [
-      object("recordings/2019/", 0, "directory"),
-      object("recordings/2020/", 0, "directory"),
-      object("recordings/site-a-20190712-0800.flac", 122_880_000),
-      object("recordings/site-a-20190712-0900.flac", 121_453_312),
-    ],
-  },
-};
-
-/** An empty prefix, rather than a product with nothing in it. */
-export const Empty: Story = {
-  args: { product, objects: [], prefix: "recordings/2021/" },
-};
-
-/**
- * A name long enough to need truncating, beside a one-byte file and a
- * four-terabyte one — what the name and size columns have to survive together.
- */
-export const AwkwardNames: Story = {
-  args: {
-    product,
-    prefix: "",
-    objects: [
-      object(
-        "site-a-hydrophone-array-continuous-passive-acoustic-monitoring-20190712T080000Z-to-20190712T090000Z.flac",
-        122_880_000
-      ),
-      object("a.txt", 1),
-      object("full-archive.tar", 4_398_046_511_104),
-    ],
-  },
-};
-
-/**
- * Past MAX_VISIBLE_ITEMS, so the virtualizer takes over. Worth scrolling: rows
- * are a fixed height and an uploading row is taller, which is where windowed
- * lists usually go wrong.
- */
-export const Virtualized: Story = {
-  args: {
-    product,
-    prefix: "recordings/",
-    objects: Array.from({ length: 250 }, (_, i) =>
-      object(
-        `recordings/site-a-${String(i).padStart(4, "0")}.flac`,
-        60_000_000 + i * 1_024
-      )
-    ),
-  },
-};
-
 // A whole product's objects, flat, the way the listing API returns them.
 // Directories carry a trailing slash; `childrenOf` slices one level out.
 const tree: ProductObject[] = [
@@ -166,7 +95,8 @@ function childrenOf(objects: ProductObject[], prefix: string): ProductObject[] {
 }
 
 /**
- * Browsing, wired up.
+ * The default, because a listing you cannot move around in is half the
+ * component.
  *
  * In the app a directory is a `<Link>` and the server re-fetches the listing
  * for the new URL. Storybook has no server and a mocked router, so clicks go
@@ -211,7 +141,50 @@ function BrowsableTree({ product }: { product: Product }) {
   );
 }
 
-export const Browsable: Story = {
+export const Default: Story = {
   args: { product, objects: [], prefix: "" },
   render: (args) => <BrowsableTree product={args.product} />,
 };
+
+/** An empty prefix, rather than a product with nothing in it. */
+export const Empty: Story = {
+  args: { product, objects: [], prefix: "recordings/2021/" },
+};
+
+/**
+ * A name long enough to need truncating, beside a one-byte file and a
+ * four-terabyte one — what the name and size columns have to survive together.
+ */
+export const AwkwardNames: Story = {
+  args: {
+    product,
+    prefix: "",
+    objects: [
+      object(
+        "site-a-hydrophone-array-continuous-passive-acoustic-monitoring-20190712T080000Z-to-20190712T090000Z.flac",
+        122_880_000
+      ),
+      object("a.txt", 1),
+      object("full-archive.tar", 4_398_046_511_104),
+    ],
+  },
+};
+
+/**
+ * Past MAX_VISIBLE_ITEMS, so the virtualizer takes over. Worth scrolling: rows
+ * are a fixed height and an uploading row is taller, which is where windowed
+ * lists usually go wrong.
+ */
+export const Virtualized: Story = {
+  args: {
+    product,
+    prefix: "recordings/",
+    objects: Array.from({ length: 250 }, (_, i) =>
+      object(
+        `recordings/site-a-${String(i).padStart(4, "0")}.flac`,
+        60_000_000 + i * 1_024
+      )
+    ),
+  },
+};
+

--- a/src/components/features/products/object-browser/DirectoryList.stories.tsx
+++ b/src/components/features/products/object-browser/DirectoryList.stories.tsx
@@ -1,0 +1,137 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { DirectoryList } from "./DirectoryList";
+import {
+  S3CredentialsProvider,
+  UploadProvider,
+} from "@/components/features/uploader";
+import type { Product, ProductObject } from "@/types";
+
+/**
+ * The file tree on a product page.
+ *
+ * Every state below needs real objects behind the data proxy to see in the
+ * app — a deep directory, a name long enough to wrap, an empty prefix, a
+ * thousand rows going through the virtualizer. Here they are props.
+ *
+ * The list and its rows import no server action of their own; they use
+ * `useUploadManager`, so the real upload providers wrap each story below.
+ *
+ * What kept this out of Storybook was not the uploader but a single line:
+ * `logging.ts` used the CommonJS `__filename` global at module scope, so any
+ * browser bundle reaching it threw before rendering. Fixed separately, which
+ * is what this branch is stacked on.
+ */
+const meta = {
+  title: "Object browser/DirectoryList",
+  component: DirectoryList,
+  parameters: { layout: "padded" },
+  // The rows read upload progress from context, so the real providers wrap
+  // every story -- the real ones, not stubs. Nothing here uploads, so no
+  // credential is ever minted and `credentials` needs no mock.
+  decorators: [
+    (Story) => (
+      <S3CredentialsProvider>
+        <UploadProvider>
+          <Story />
+        </UploadProvider>
+      </S3CredentialsProvider>
+    ),
+  ],
+} satisfies Meta<typeof DirectoryList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const product = {
+  account_id: "cascadia-research",
+  product_id: "humpback-acoustics",
+  title: "Humpback Acoustics",
+  metadata: { tags: [], primary_mirror: "archive", mirrors: {} },
+} as unknown as Product;
+
+const object = (
+  path: string,
+  size: number,
+  type: "file" | "directory" = "file"
+): ProductObject =>
+  ({
+    id: path,
+    product_id: "humpback-acoustics",
+    path,
+    size,
+    type,
+    created_at: "2026-03-12T00:00:00Z",
+    updated_at: "2026-03-12T00:00:00Z",
+    checksum: "d41d8cd98f00b204e9800998ecf8427e",
+  }) as ProductObject;
+
+/** Directories and files at the root of a product. */
+export const Default: Story = {
+  args: {
+    product,
+    prefix: "",
+    objects: [
+      object("recordings/", 0, "directory"),
+      object("derived/", 0, "directory"),
+      object("README.md", 2_140),
+      object("manifest.json", 18_902),
+      object("catalog.parquet", 48_204_112),
+    ],
+  },
+};
+
+/** Nested one level down. */
+export const InADirectory: Story = {
+  args: {
+    product,
+    prefix: "recordings/",
+    objects: [
+      object("recordings/2019/", 0, "directory"),
+      object("recordings/2020/", 0, "directory"),
+      object("recordings/site-a-20190712-0800.flac", 122_880_000),
+      object("recordings/site-a-20190712-0900.flac", 121_453_312),
+    ],
+  },
+};
+
+/** An empty prefix, rather than a product with nothing in it. */
+export const Empty: Story = {
+  args: { product, objects: [], prefix: "recordings/2021/" },
+};
+
+/**
+ * A name long enough to need truncating, beside a one-byte file and a
+ * four-terabyte one — what the name and size columns have to survive together.
+ */
+export const AwkwardNames: Story = {
+  args: {
+    product,
+    prefix: "",
+    objects: [
+      object(
+        "site-a-hydrophone-array-continuous-passive-acoustic-monitoring-20190712T080000Z-to-20190712T090000Z.flac",
+        122_880_000
+      ),
+      object("a.txt", 1),
+      object("full-archive.tar", 4_398_046_511_104),
+    ],
+  },
+};
+
+/**
+ * Past MAX_VISIBLE_ITEMS, so the virtualizer takes over. Worth scrolling: rows
+ * are a fixed height and an uploading row is taller, which is where windowed
+ * lists usually go wrong.
+ */
+export const Virtualized: Story = {
+  args: {
+    product,
+    prefix: "recordings/",
+    objects: Array.from({ length: 250 }, (_, i) =>
+      object(
+        `recordings/site-a-${String(i).padStart(4, "0")}.flac`,
+        60_000_000 + i * 1_024
+      )
+    ),
+  },
+};

--- a/src/components/features/products/object-browser/ObjectSummary.stories.tsx
+++ b/src/components/features/products/object-browser/ObjectSummary.stories.tsx
@@ -75,6 +75,8 @@ export const Default: Story = {
 
 /** On S3, so the Cloud URI is an `s3://` address under the mirror's prefix. */
 export const OnS3: Story = {
+  // Storybook title-cases the export name, which turns OnS3 into "On S 3".
+  name: "On S3",
   args: { product, objectInfo, connectionDetails: s3Connection },
 };
 
@@ -83,6 +85,7 @@ export const OnS3: Story = {
  * and container — a different shape, not a different scheme prefix.
  */
 export const OnAzure: Story = {
+  name: "On Azure",
   args: {
     product,
     objectInfo,
@@ -105,6 +108,7 @@ export const OnAzure: Story = {
 
 /** GCS resolves no Cloud URI, so that row is absent rather than blank. */
 export const OnGoogleCloud: Story = {
+  name: "On Google Cloud",
   args: {
     product,
     objectInfo,

--- a/src/components/features/products/object-browser/ObjectSummary.stories.tsx
+++ b/src/components/features/products/object-browser/ObjectSummary.stories.tsx
@@ -1,0 +1,153 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { ObjectSummary } from "./ObjectSummary";
+import {
+  DataProvider,
+  type DataConnection,
+  type Product,
+  type ProductObject,
+} from "@/types";
+
+/**
+ * The detail panel for one object: name, size, content type, when it changed,
+ * where it lives, and a download.
+ *
+ * Two rows are conditional and neither is easy to produce on demand in the app.
+ * **Cloud URI** appears only when the object's connection is known, and its
+ * scheme depends on the provider — `s3://bucket/…` against S3, an
+ * `https://account.blob.core.windows.net/…` URL against Azure, and nothing at
+ * all for GCS. **Checksum** appears only when the object carries a `sha256`,
+ * and brings a verifier that streams the file to check it.
+ *
+ * That verifier is live: pressing it fetches the object, which in Storybook
+ * fails. The button and its states are what this shows, not a passing check.
+ */
+const meta = {
+  title: "Object browser/ObjectSummary",
+  component: ObjectSummary,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof ObjectSummary>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const product = {
+  account_id: "cascadia-research",
+  product_id: "humpback-acoustics",
+  title: "Humpback Acoustics",
+  account: {
+    account_id: "cascadia-research",
+    name: "Cascadia Research",
+    type: "organization",
+  },
+  metadata: { tags: [], primary_mirror: "archive", mirrors: {} },
+} as unknown as Product;
+
+const objectInfo = {
+  id: "recordings/2019/site-a-20190712-0800.flac",
+  product_id: "humpback-acoustics",
+  path: "recordings/2019/site-a-20190712-0800.flac",
+  size: 122_880_000,
+  type: "file",
+  mime_type: "audio/flac",
+  created_at: "2026-03-12T09:41:00Z",
+  updated_at: "2026-03-12T09:41:00Z",
+  checksum: "d41d8cd98f00b204e9800998ecf8427e",
+} as ProductObject;
+
+const s3Connection = {
+  primaryMirror: { connection_id: "cascadia-archive", prefix: "humpback/", is_primary: true },
+  dataConnection: {
+    data_connection_id: "cascadia-archive",
+    name: "Cascadia Archive",
+    details: {
+      provider: DataProvider.S3,
+      bucket: "cascadia-archive",
+      base_prefix: "",
+      region: "us-west-2",
+    },
+  } as unknown as DataConnection,
+};
+
+/** No connection resolved, no checksum recorded: the rows that always exist. */
+export const Default: Story = {
+  args: { product, objectInfo },
+};
+
+/** On S3, so the Cloud URI is an `s3://` address under the mirror's prefix. */
+export const OnS3: Story = {
+  args: { product, objectInfo, connectionDetails: s3Connection },
+};
+
+/**
+ * On Azure the same row is an HTTPS blob URL built from the storage account
+ * and container — a different shape, not a different scheme prefix.
+ */
+export const OnAzure: Story = {
+  args: {
+    product,
+    objectInfo,
+    connectionDetails: {
+      primaryMirror: { connection_id: "azure-open-data", prefix: "humpback/", is_primary: true },
+      dataConnection: {
+        data_connection_id: "azure-open-data",
+        name: "[PROD] Azure Open Data (West Europe)",
+        details: {
+          provider: DataProvider.Azure,
+          account_name: "opendatastore",
+          container_name: "westeurope",
+          base_prefix: "",
+          region: "westeurope",
+        },
+      } as unknown as DataConnection,
+    },
+  },
+};
+
+/** GCS resolves no Cloud URI, so that row is absent rather than blank. */
+export const OnGoogleCloud: Story = {
+  args: {
+    product,
+    objectInfo,
+    connectionDetails: {
+      primaryMirror: { connection_id: "rle-files", prefix: "", is_primary: true },
+      dataConnection: {
+        data_connection_id: "rle-files",
+        name: "RLE Assessment Files",
+        details: {
+          provider: DataProvider.GCS,
+          bucket: "rle-files",
+          base_prefix: "",
+        },
+      } as unknown as DataConnection,
+    },
+  },
+};
+
+/** With a recorded sha256, the checksum row and its verifier appear. */
+export const WithChecksum: Story = {
+  args: {
+    product,
+    connectionDetails: s3Connection,
+    objectInfo: {
+      ...objectInfo,
+      metadata: {
+        sha256:
+          "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+      },
+    } as ProductObject,
+  },
+};
+
+/** A tiny text file rather than a large binary — different size and type. */
+export const SmallTextFile: Story = {
+  args: {
+    product,
+    connectionDetails: s3Connection,
+    objectInfo: {
+      ...objectInfo,
+      path: "README.md",
+      size: 2_140,
+      mime_type: "text/markdown",
+    } as ProductObject,
+  },
+};

--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -109,8 +109,12 @@ export class Logger {
 
 export const LOGGER = Logger.getInstance(CONFIG.environment.isDevelopment);
 LOGGER.registerSensitiveValue(CONFIG.auth.accessToken);
+// A literal, not `__filename`: that is a CommonJS global, and this line runs at
+// import time. Any browser bundle that reached this module -- through a server
+// action, a barrel, or the uploader -- threw `__filename is not defined` before
+// rendering anything, which is why so many components could not be storied.
 LOGGER.debug("Loaded Config", {
   operation: "config",
-  context: __filename,
+  context: "src/lib/logging.ts",
   metadata: { CONFIG },
 });


### PR DESCRIPTION
Stories for the object browser — the file tree, the breadcrumbs above it, and the detail panel for a single object. 16 stories across three components.

The `__filename` fix that made any of this renderable went in separately as #524, which has merged; this PR is stories plus one Storybook config line.

## `DirectoryList` — and it browses

**Default is navigable.** In the app a directory is a `<Link>` and the server re-fetches the listing for the new URL. Storybook has neither a server nor a real router, so clicks went nowhere and every story was one frozen level.

`Default` now holds the prefix in state, derives each listing from a single fixture tree, and intercepts clicks on links into this product. **That is a stand-in for the routing, not the routing itself** — the story says so — but it makes the thing you'd actually want to check reviewable.

Verified in a browser rather than assumed:

- `root` → `recordings` → `2019` shows the two recordings;
- the breadcrumb walks back up through `recordings` to `root`;
- clicking a **file** leaves the listing alone.

The remaining three cover states navigation cannot reach: **Empty** (an empty prefix, not an empty product), **AwkwardNames** (a 100-character filename beside a 1-byte and a 4-terabyte file), and **Virtualized** (250 rows, past `MAX_VISIBLE_ITEMS`).

The two static stories an earlier revision had are gone — the browsable one opens on what `Default` showed, and one click reaches what `InADirectory` showed.

## `BreadcrumbNav`

Six stories. The one that earns its place is **Truncated**: past four segments the path collapses to the first two, an ellipsis, and the last two, and a real product rarely hands you a path that deep on demand. Also the rule that the current directory renders as plain text but the same segment becomes a link once a `fileName` sits below it.

## `ObjectSummary` — the object detail view

Six stories. Its two conditional rows are the point, and both are awkward to arrange in the app:

- **Cloud URI** appears only with a resolved connection, and takes a different *shape* per provider — `s3://bucket/…` on S3, an `https://account.blob.core.windows.net/…` URL on Azure, and **no row at all** on GCS. All three confirmed in a browser.
- **Checksum** appears only when the object carries a `sha256`, and brings the verifier with it. That verifier is live — pressing it fetches the object, which fails here. The button and its states are what the story shows, not a passing check.

## One config line, and why it is needed

`CONFIG.storage.endpoint` reads `NEXT_PUBLIC_S3_ENDPOINT` with no fallback, so every Source URL rendered as `undefined/cascadia-research/…`. On a **published** page that reads as a bug in the product rather than a gap in the environment.

It goes through a Vite `define` rather than Storybook's own `env`: the Next builder inlines `NEXT_PUBLIC_*` at build time from the real environment and never consults `env`. I tried that first and the value stayed `undefined`.

## Providers, not stubs

The real `S3CredentialsProvider` and `UploadProvider` wrap the `DirectoryList` stories through a decorator, because the rows read upload progress from context.

**No `credentials` mock.** Nothing here uploads, so no credential is ever minted. I added the mock, found it unused, and removed it.

## Verification

`tsc` clean · jest 65 suites / 567 tests · `next lint` 0 errors · `storybook build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mnsg8m1dXZ5z5ig5xMtkE
