### PR TITLE
docs(storybook): give Cascadia Archive an owner so it filters on owner change

### DIFF
--- a/src/components/features/products/ProductCreationForm.stories.tsx
+++ b/src/components/features/products/ProductCreationForm.stories.tsx
@@ -43,6 +43,9 @@ const dataConnections = [
   {
     data_connection_id: "cascadia-archive",
     name: "Cascadia Archive",
+    // Owned: only Cascadia Research's products may use it, so it drops out of
+    // the picker when the owner switches to an individual.
+    owner: "cascadia-research",
     read_only: false,
     allowed_visibilities: [ProductVisibility.Public, ProductVisibility.Unlisted],
     details: {
@@ -66,7 +69,10 @@ const dataConnections = [
   },
 ] as unknown as DataConnection[];
 
-/** One possible owner, so there is no owner decision to make. */
+/**
+ * One possible owner, so there is no owner decision to make — and only the
+ * unowned shared connection is on offer.
+ */
 export const Create: Story = {
   args: {
     potentialOwnerAccounts: [individual],
@@ -74,7 +80,11 @@ export const Create: Story = {
   },
 };
 
-/** Several owners: the choice appears, and the preselection comes from ?owner=. */
+/**
+ * Several owners: the choice appears, and the preselection comes from ?owner=.
+ * Switching the owner to Chris Holmes drops Cascadia Archive from the storage
+ * picker, since Cascadia Research owns it.
+ */
 export const ChoosingAnOwner: Story = {
   args: {
     potentialOwnerAccounts: [individual, organization],


### PR DESCRIPTION
## What

Adds `owner: "cascadia-research"` to the Cascadia Archive mock connection in `ProductCreationForm.stories.tsx`, and updates two story doc comments to match.

## Why

`ProductCreationForm` already filters the storage picker by connection owner:

```ts
dataConnections.filter(
  (dc) => (!dc.owner || dc.owner === forAccountId) && dc.allowed_visibilities.length > 0
)
```

But every mock connection in the story was unowned, so changing the owner in **Choosing an Owner** produced no visible change — the story couldn't demonstrate the behaviour it exists to show.

## Effect

In **Choosing an Owner**, the form starts on Cascadia Research with both connections available. Switching the owner to Chris Holmes drops Cascadia Archive and falls back to the shared AWS Open Data connection.

Side effect: the **Create** story (individual owner only) now offers just the read-only AWS Open Data connection. Documented rather than worked around — that is the realistic shape for a personal account with no owned storage.

## Notes

No component change; mock data only. The edit sits inside an `as unknown as DataConnection[]` cast, so it carries no type risk. No test added — this form isn't unit-testable here (React 19 `useActionState` under RTL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)