### PR TITLE
docs(storybook): group the membership stories, and drop one that showed nothing

### DIFF
--- a/src/components/features/accounts/InviteMemberForm.stories.tsx
+++ b/src/components/features/accounts/InviteMemberForm.stories.tsx
@@ -1,9 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { InviteMemberForm } from "./InviteMemberForm";
-import type { Account, Product } from "@/types";
+import type { Account } from "@/types";
 
 /**
- * Invite someone to an organization, or to a single product.
+ * Invite someone to an organization.
  *
  * Small, but worth a story for one reason: **this is the dialog the account
  * picker's suggestion list was clipped inside.** It sits in a `Dialog.Content`
@@ -14,9 +14,16 @@ import type { Account, Product } from "@/types";
  * **Open the dialog and type two or more characters** into the User field. The
  * suggestions come from the mocked `searchAccounts`; the list should overflow
  * the dialog rather than being clipped by it.
+ *
+ * There is no product-scoped story. Passing a `product` changes only two hidden
+ * fields — `organization_id` and `product_id` — so it renders identically, and
+ * a story showing the same thing twice teaches that they differ when they do
+ * not. Worth noting while looking at this: in the product case the description
+ * still reads "join {organization.name}", naming the organization rather than
+ * the product.
  */
 const meta = {
-  title: "Accounts/InviteMemberForm",
+  title: "Memberships/InviteMemberForm",
   component: InviteMemberForm,
   parameters: { layout: "padded" },
 } satisfies Meta<typeof InviteMemberForm>;
@@ -30,17 +37,6 @@ const organization = {
   type: "organization",
 } as unknown as Account;
 
-const product = {
-  account_id: "cascadia-research",
-  product_id: "humpback-acoustics",
-  title: "Humpback Acoustics",
-} as unknown as Product;
-
-export const ToAnOrganization: Story = {
+export const Default: Story = {
   args: { organization },
-};
-
-/** Scoped to one product rather than the whole organization. */
-export const ToAProduct: Story = {
-  args: { organization, product },
 };

--- a/src/components/features/settings/MembershipsTable.stories.tsx
+++ b/src/components/features/settings/MembershipsTable.stories.tsx
@@ -18,7 +18,7 @@ import {
  * `revokeMembership` is an `fn()` stub, so the row actions do nothing.
  */
 const meta = {
-  title: "Settings/MembershipsTable",
+  title: "Memberships/MembershipsTable",
   component: MembershipsTable,
   parameters: { layout: "padded" },
 } satisfies Meta<typeof MembershipsTable>;


### PR DESCRIPTION
`InviteMemberForm` moves from **Accounts/** to **Memberships/**, and `MembershipsTable` from **Settings/**, so the two sit together.

`Accounts/` keeps three stories. `Settings/` had only the one, so that section disappears rather than sitting in the sidebar with a single entry.

## Also: `ToAProduct` is deleted

You asked whether the two invite stories differ. They don't — and that's a defect in my story, not a question about the component.

Passing a `product` changes exactly two **hidden** fields:

```tsx
hiddenFields={{
  organization_id: product ? product.account_id : organization.account_id,
  product_id: product?.product_id,
}}
```

Title, description, fields and button are identical, so `ToAProduct` rendered pixel-for-pixel the same as `ToAnOrganization`. Two stories showing the same thing assert a difference that isn't there — the exact failure mode this Storybook exists to avoid. The remaining story now describes the product case instead of staging it.

## One thing worth a separate look

While checking this: inviting to a **product** still shows

> Invite a user to join **Cascadia Research** as a member.

naming the *organization*, not the product. That reads as a copy bug, but it's a behaviour change rather than a Storybook one, so I've noted it in the story docs and left the component alone.

## Verification

`tsc` clean · jest 65 suites / 567 tests · `next lint` 0 errors · `storybook build` succeeds, with both stories under `Memberships/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mnsg8m1dXZ5z5ig5xMtkE