### PR TITLE
refactor(logging): stop LOGGER using __filename at module scope

### DIFF
--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -109,8 +109,12 @@ export class Logger {
 
 export const LOGGER = Logger.getInstance(CONFIG.environment.isDevelopment);
 LOGGER.registerSensitiveValue(CONFIG.auth.accessToken);
+// A literal, not `__filename`: that is a CommonJS global, and this line runs at
+// import time. Any browser bundle that reached this module -- through a server
+// action, a barrel, or the uploader -- threw `__filename is not defined` before
+// rendering anything, which is why so many components could not be storied.
 LOGGER.debug("Loaded Config", {
   operation: "config",
-  context: __filename,
+  context: "src/lib/logging.ts",
   metadata: { CONFIG },
 });


### PR DESCRIPTION
`src/lib/logging.ts` ends with a module-scope debug call:

```ts
LOGGER.debug("Loaded Config", { operation: "config", context: __filename, ... });
```

`__filename` is a **CommonJS global**, and this line runs on import. Any browser bundle that reached this module threw `ReferenceError: __filename is not defined` before rendering a single element.

The field is just a debug label naming where the log came from, so a literal does the job. One line.

## This is the cause of the crashes worked around in #514, #517 and #520

I had attributed those to server actions dragging the AWS SDK into the browser. **That was wrong.** The actions were only one of several routes to `logging.ts`; the `@/lib` and `@/components/core` barrels were others. The AWS SDK was never the problem.

Verified rather than assumed: with **every** `sb.mock()` disabled, `DataConnectionForm` renders in full.

## What that means for the mocks already merged

They still earn their place — a story submitting a form would otherwise invoke a real server action, and `searchAccounts` returning fixtures is the only way the account picker's suggestion list draws. But *"these components cannot render without mocks"* was not a true reason, and the mock list can likely be trimmed. That deserves its own change rather than being folded in here.

## Worth considering separately

An ESLint rule banning `__filename` / `__dirname` outside `scripts/` would have caught this, and would catch the next one.

## Verification

`tsc` clean · jest 65 suites / 567 tests · `next lint` 0 errors.

The Storybook stories that this unblocks are stacked in #521.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mnsg8m1dXZ5z5ig5xMtkE