### PR TITLE
fix(profiles): keep website link icons from collapsing on narrow screens

### DIFF
--- a/src/components/features/profiles/WebsiteLink.tsx
+++ b/src/components/features/profiles/WebsiteLink.tsx
@@ -9,18 +9,25 @@ interface WebsiteLinkProps {
   url: string;
 }
 
+// Icons are flex children; without this a long URL squeezes them to nothing.
+const iconProps = {
+  width: "16",
+  height: "16",
+  style: { flexShrink: 0 },
+} as const;
+
 function getIcon(url: string) {
   const hostname = new URL(url).hostname.toLowerCase();
 
   if (hostname.includes("github.com")) {
-    return <GitHubLogoIcon width="16" height="16" />;
+    return <GitHubLogoIcon {...iconProps} />;
   }
 
   if (hostname.includes("linkedin.com")) {
-    return <LinkedInLogoIcon width="16" height="16" />;
+    return <LinkedInLogoIcon {...iconProps} />;
   }
 
-  return <Link2Icon width="16" height="16" />;
+  return <Link2Icon {...iconProps} />;
 }
 
 export function WebsiteLink({ url }: WebsiteLinkProps) {
@@ -33,6 +40,7 @@ export function WebsiteLink({ url }: WebsiteLinkProps) {
         target="_blank"
         rel="noopener noreferrer"
         underline="always"
+        style={{ wordBreak: "break-all", minWidth: 0 }}
       >
         {url}
       </Link>


### PR DESCRIPTION
## Problem

On narrow (mobile) viewports, a profile's LinkedIn website link rendered with **no icon at all**, and the GitHub icon was visibly squeezed — while the generic link icon on a shorter URL looked fine.

The icons aren't at fault. `WebsiteLink` lays out `[icon] [url]` in a `Flex` row, and a long URL (`https://www.linkedin.com/in/cholmes`) overflows that row. Since the 16px SVGs are shrinkable flex children, they absorb the entire overflow: LinkedIn's collapsed to zero width, GitHub's got clipped, and the shorter `cholmes.org` row had enough slack that its icon survived — which is why the bug looked inconsistent.

## Fix

- `flexShrink: 0` on all three icons, via a shared `iconProps` — they keep their 16px regardless of the row's width.
- `wordBreak: "break-all"` + `minWidth: 0` on the `Link`, so the URL wraps instead of forcing the row wider than the container.

One file, no new dependencies.

## Testing

`npx tsc --noEmit` reports nothing in `WebsiteLink.tsx` (the remaining output is the repo's pre-existing `storybook` module-resolution errors, unrelated to this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)