### PR TITLE
fix(breadcrumbs): keep segments on one baseline when they wrap

### DIFF
--- a/src/components/display/BreadcrumbNav.tsx
+++ b/src/components/display/BreadcrumbNav.tsx
@@ -95,7 +95,7 @@ export function BreadcrumbNav({
   }
 
   return (
-    <Flex>
+    <Flex align="center" wrap="wrap">
       {/* Root link */}
       <div style={{ lineHeight: "22px" }}>
         {isRoot ? (


### PR DESCRIPTION
On narrow viewports the object-browser breadcrumbs rendered with staggered heights, and the trailing chevron ran off the right edge of the screen.

**Cause:** the outer `Flex` in `BreadcrumbNav` had no `align` or `wrap`. Children stretched to the full row height, and because each segment centers its own content vertically, they drifted apart as soon as one segment wrapped to two lines. With no wrapping, the row overflowed the viewport instead of breaking.

**Fix:** `<Flex align="center" wrap="wrap">` — one line.

Verified `tsc --noEmit` surfaces nothing new for this file (only the repo's pre-existing missing-`@storybook/nextjs-vite` errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)