### PR TITLE
fix(profiles): let the organization list reflow on mobile

### DIFF
--- a/src/components/core/AccountLinks.tsx
+++ b/src/components/core/AccountLinks.tsx
@@ -27,12 +27,12 @@ export function AvatarLinkCompact({
   link?: boolean;
 }) {
   const content = (
-    <>
-      <ProfileAvatar account={props.account} size={size} />
-      <Text size="2" ml="2">
-        {props.account.name}
-      </Text>
-    </>
+    <Flex gap="2" align="center" asChild>
+      <span>
+        <ProfileAvatar account={props.account} size={size} />
+        <Text size="2">{props.account.name}</Text>
+      </span>
+    </Flex>
   );
 
   return (

--- a/src/components/features/profiles/IndividualProfile.stories.tsx
+++ b/src/components/features/profiles/IndividualProfile.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { IndividualProfile } from "./IndividualProfile";
+import type { IndividualAccount, OrganizationalAccount } from "@/types";
+
+/**
+ * A person's profile page. The organization list is the interesting part: it
+ * is a grid that drops to one column on a phone, where three columns left
+ * long names wrapping around their avatars.
+ *
+ * See the Mobile story for that case.
+ */
+const meta = {
+  title: "Features/Profiles/IndividualProfile",
+  component: IndividualProfile,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof IndividualProfile>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// No email, so ProfileAvatar shows an initial rather than fetching Gravatar.
+const account = {
+  account_id: "cholmes",
+  name: "Chris Holmes",
+  type: "individual",
+  metadata_public: {
+    bio: "Works on open geospatial data and cloud-native infrastructure.",
+  },
+} as unknown as IndividualAccount;
+
+// Real names, long ones included -- they are what breaks the layout.
+const organizations = [
+  { account_id: "portolan-mirrors", name: "portolan-mirrors" },
+  { account_id: "kerner-lab", name: "Kerner Lab" },
+  { account_id: "planet", name: "Planet" },
+  { account_id: "taylor-geospatial", name: "Taylor Geospatial" },
+  { account_id: "fields-of-the-world", name: "Fields of The World" },
+  {
+    account_id: "fiboa",
+    name: "Field Boundaries for Agriculture (fiboa)",
+  },
+].map(
+  (org) =>
+    ({
+      ...org,
+      type: "organization",
+      metadata_public: {},
+    }) as unknown as OrganizationalAccount
+);
+
+export const Default: Story = {
+  args: {
+    account,
+    organizations,
+    isOwner: false,
+    ownedProducts: [],
+    contributedProducts: [],
+    canEdit: false,
+    canCreateProduct: false,
+  },
+};
+
+/** The regression this layout exists for: one column, no wrapped names. */
+export const Mobile: Story = {
+  args: Default.args,
+  globals: { viewport: { value: "mobile1", isRotated: false } },
+};
+
+export const NoOrganizations: Story = {
+  args: { ...Default.args, organizations: [] },
+};

--- a/src/components/features/profiles/IndividualProfile.tsx
+++ b/src/components/features/profiles/IndividualProfile.tsx
@@ -112,7 +112,7 @@ export function IndividualProfile({
           <Heading size="4" mb="2">
             Organizations
           </Heading>
-          <Grid columns="3" gap="4">
+          <Grid columns={{ initial: "1", xs: "2", sm: "3" }} gap="4">
             {organizations.map((org) => (
               <AvatarLinkCompact account={org} key={org.account_id} />
             ))}


### PR DESCRIPTION
## Problem

On a phone the profile's **Organizations** list was unreadable: the grid is pinned at three columns, so each column is ~110px wide and long names wrap over three lines. The avatar makes it worse — the name wraps *underneath* the avatar instead of sitting beside it, so the rows no longer read as rows.

## Fix

- `IndividualProfile` — the organizations grid is now `{ initial: "1", xs: "2", sm: "3" }`: one column below 520px, two below 768px, three above.
- `AvatarLinkCompact` — the link's content was a fragment. The anchor is a flex item, so it is blockified, and the avatar and the name ended up as inline-level siblings in normal flow. Wrapping them in a flex row keeps the name beside the avatar at any width. This helps every other place the component is used (membership tables, product metadata, org members) for the same reason.

## Storybook

New `IndividualProfile.stories.tsx` captures the element, with the same six organizations as the report (including "Field Boundaries for Agriculture (fiboa)"):

- `Default` — the three-column layout.
- `Mobile` — the same profile at the `mobile1` viewport, i.e. the regression case.
- `NoOrganizations` — the section is absent.

## Checks

- `next lint` clean on the three files; `tsc` clean (the story's `globals.viewport` typechecks).
- The existing profile page test passes.
- Rendered the story's args under RTL: the org grid emits `rt-r-gtc-1 xs:rt-r-gtc-2 sm:rt-r-gtc-3`, and the anchor's first child is `rt-Flex rt-r-ai-center`.

## Not in scope

The metadata grid just above (Websites / ORCID) is also a fixed `columns="3"` and will be tight on the same screens. Left alone — say the word and it is the same one-line change.
