### PR TITLE
fix(profiles): truncate long website links instead of wrapping them

### DIFF
--- a/src/components/features/profiles/IndividualProfile.tsx
+++ b/src/components/features/profiles/IndividualProfile.tsx
@@ -72,7 +72,7 @@ export function IndividualProfile({
       </Box>
 
       <Box mb="6">
-        <Grid columns="3" gap="4">
+        <Grid columns={{ initial: "1", xs: "2", sm: "3" }} gap="4">
           {account.metadata_public.domains &&
             account.metadata_public.domains.length > 0 && (
               <Box>

--- a/src/components/features/profiles/WebsiteLink.stories.tsx
+++ b/src/components/features/profiles/WebsiteLink.stories.tsx
@@ -1,13 +1,14 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
-import { Flex } from "@radix-ui/themes";
+import { Box, Flex } from "@radix-ui/themes";
 import { WebsiteLink } from "./WebsiteLink";
 
 /**
  * A link on a profile, with an icon chosen from the hostname.
  *
- * The icon is the whole behaviour — GitHub and LinkedIn get their marks, and
- * everything else a generic link — so seeing the set side by side is the only
- * way to check the matching works.
+ * Two things to check here. The icon matching — GitHub and LinkedIn get their
+ * marks, everything else a generic link — which only reads side by side. And
+ * the shortening: profiles show these in a narrow column, so the URL is elided
+ * in the middle rather than allowed to wrap. See Truncation.
  */
 const meta = {
   title: "Features/Profiles/WebsiteLink",
@@ -33,7 +34,34 @@ export const KnownHosts: Story = {
   ),
 };
 
-/** A bare hostname is upgraded to https rather than treated as a relative path. */
+/**
+ * A bare hostname is upgraded to https rather than treated as a relative path.
+ * It renders the same as Generic, since the scheme is dropped from the display
+ * text either way — the difference is only in the href and the title.
+ */
 export const WithoutScheme: Story = {
   args: { url: "acoltrane.org" },
+};
+
+/**
+ * The narrow column profiles actually show these in. A long URL keeps its host
+ * and the end of its path, so two links to the same site stay apart, with the
+ * full URL on the title attribute.
+ *
+ * The character budget is a guess at the column width, so the last row is the
+ * one to watch: a single unbroken segment has no boundary to snap to, and CSS
+ * truncation catches whatever the guess overshoots.
+ */
+export const Truncation: Story = {
+  args: { url: "https://github.com/source-cooperative/source.coop/tree/main" },
+  render: () => (
+    <Box width="200px">
+      <Flex direction="column" gap="2">
+        <WebsiteLink url="https://acoltrane.org" />
+        <WebsiteLink url="https://www.linkedin.com/in/some-very-long-handle" />
+        <WebsiteLink url="https://github.com/source-cooperative/source.coop/tree/main" />
+        <WebsiteLink url="https://example.com/one-single-extremely-long-path-segment" />
+      </Flex>
+    </Box>
+  ),
 };

--- a/src/components/features/profiles/WebsiteLink.tsx
+++ b/src/components/features/profiles/WebsiteLink.tsx
@@ -4,6 +4,7 @@ import {
   GitHubLogoIcon,
   LinkedInLogoIcon,
 } from "@radix-ui/react-icons";
+import { formatUrl } from "@/lib/format";
 
 interface WebsiteLinkProps {
   url: string;
@@ -31,18 +32,25 @@ function getIcon(url: string) {
 }
 
 export function WebsiteLink({ url }: WebsiteLinkProps) {
-  url = url.startsWith("http") ? url : `https://${url}`;
+  const href = url.startsWith("http") ? url : `https://${url}`;
   return (
     <Flex gap="2" align="center">
-      {getIcon(url)}
+      {getIcon(href)}
       <Link
-        href={url}
+        href={href}
         target="_blank"
         rel="noopener noreferrer"
         underline="always"
-        style={{ wordBreak: "break-all", minWidth: 0 }}
+        title={href}
+        // formatUrl's budget guesses at the column width; truncate is the
+        // backstop when the guess is generous. It only bites because the link
+        // is a direct flex child: Radix resets the <a> to display:inline, where
+        // overflow does not apply, and flex blockifies it. Don't wrap it in a
+        // Box without reproducing a minWidth:0 chain.
+        truncate
+        style={{ minWidth: 0 }}
       >
-        {url}
+        {formatUrl(href)}
       </Link>
     </Flex>
   );

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,0 +1,65 @@
+import { formatUrl } from "./format";
+
+describe("formatUrl", () => {
+  it("drops the scheme, a leading www, and a trailing slash", () => {
+    expect(formatUrl("https://cholmes.org")).toBe("cholmes.org");
+    expect(formatUrl("http://www.cholmes.org/")).toBe("cholmes.org");
+    expect(formatUrl("cholmes.org")).toBe("cholmes.org");
+    expect(formatUrl("https://example.com/path/")).toBe("example.com/path");
+  });
+
+  it("leaves a URL that already fits alone", () => {
+    expect(formatUrl("https://example.com/a/b/c")).toBe("example.com/a/b/c");
+    // Exactly at the budget still counts as fitting.
+    const exact = "a".repeat(30) + ".io";
+    expect(formatUrl(exact, exact.length)).toBe(exact);
+  });
+
+  it("keeps the host and as many whole trailing segments as fit", () => {
+    expect(
+      formatUrl("https://github.com/source-cooperative/source.coop/tree/main")
+    ).toBe("github.com/…/tree/main");
+    expect(
+      formatUrl("https://example.com/a/bbbbbbbbbbbbbbbbbbbbbbbbbb/c")
+    ).toBe("example.com/…/c");
+  });
+
+  it("cuts inside the last segment when no boundary fits", () => {
+    expect(formatUrl("https://www.linkedin.com/in/some-very-long-handle")).toBe(
+      "linkedin.com/…e-very-long-handle"
+    );
+  });
+
+  it("keeps a query and a hash, which are what distinguish the link", () => {
+    expect(formatUrl("https://example.com/a/b/verylongpage?ref=x#top", 24)).toBe(
+      "example.com/…e?ref=x#top"
+    );
+  });
+
+  it("tail-cuts a host that busts the budget on its own", () => {
+    const host = "a-really-quite-long-hostname.example.com";
+    const expected = host.slice(0, 31) + "…";
+    expect(formatUrl(host)).toBe(expected);
+    // The path is irrelevant once the host alone does not fit.
+    expect(formatUrl(`https://${host}/some/path`)).toBe(expected);
+  });
+
+  it("passes a non-ASCII host through", () => {
+    expect(formatUrl("https://例え.jp/ページ")).toBe("例え.jp/ページ");
+  });
+
+  it("never exceeds the budget, whatever the shape of the URL", () => {
+    const urls = [
+      "https://cholmes.org",
+      "https://www.linkedin.com/in/some-very-long-handle",
+      "https://github.com/source-cooperative/source.coop/tree/main",
+      "https://a-really-quite-long-hostname.example.com/x/y/z",
+      "https://example.com/one-single-extremely-long-path-segment",
+    ];
+    for (const max of [12, 20, 32, 60]) {
+      for (const url of urls) {
+        expect(formatUrl(url, max).length).toBeLessThanOrEqual(max);
+      }
+    }
+  });
+});

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -52,4 +52,51 @@ export function formatDate(date: string, includeTime: boolean = false): string {
   }).format(dateObj);
 
   return `${day} ${month} ${year} ${time}`;
-} 
+}
+
+const ELLIPSIS = "…";
+
+/**
+ * Shorten a URL to something readable in a narrow column: the scheme and a
+ * leading "www." go, and the middle is elided so the host and the end of the
+ * path both survive. A plain tail-cut ("github.com/source-coop…") would make
+ * two links to the same site indistinguishable.
+ *
+ * The budget is characters, not measured width, so it is a guess at the column.
+ * Pair it with CSS truncation as a backstop and the full URL on a title.
+ *
+ * @param url The URL to shorten, with or without a scheme
+ * @param maxLength Maximum characters in the result (default 32)
+ * @returns A display string, never longer than maxLength
+ */
+export function formatUrl(url: string, maxLength: number = 32): string {
+  const display = url
+    .replace(/^https?:\/\//i, "")
+    .replace(/^www\./i, "")
+    .replace(/\/$/, "");
+
+  if (display.length <= maxLength) return display;
+
+  const slash = display.indexOf("/");
+  const host = slash === -1 ? display : display.slice(0, slash);
+  const path = slash === -1 ? "" : display.slice(slash);
+
+  // A host that busts the budget on its own has no middle worth keeping.
+  if (!path || host.length + 2 > maxLength) {
+    return display.slice(0, maxLength - 1) + ELLIPSIS;
+  }
+
+  const budget = maxLength - host.length - 2; // pay for the host and "/…"
+
+  // ponytail: longest tail starting at a "/", so it reads as whole segments.
+  // A width-measuring version would fit better; only worth it if this misfits.
+  for (let i = 0; i < path.length; i++) {
+    if (path[i] === "/" && path.length - i <= budget) {
+      return host + "/" + ELLIPSIS + path.slice(i);
+    }
+  }
+
+  // One very long segment: cut inside it, dropping leading punctuation.
+  const tail = path.slice(path.length - budget).replace(/^[^\p{L}\p{N}]+/u, "");
+  return host + "/" + ELLIPSIS + tail;
+}


### PR DESCRIPTION
Rebased onto current `main` and re-scoped: this was "make the URL wrap nicely", and #528 has since landed the icon half of that fix. What is left is the text itself.

## The problem

#528 stopped the icons collapsing, but reached for `word-break: break-all` to deal with the text. That breaks a URL at *any* character, so it wraps mid-token — `https://cholmes.` / `org` — and a three-line link is still the widest thing in a narrow column.

The website/ORCID grid underneath it is also three fixed columns, about 110px each on a phone. No amount of cleverness with the text rescues a 110px column, and the ORCID beside it cannot wrap at all.

## Before / after

Phone, 375px viewport — the grid reflows, which is the larger half of this fix:

![Phone, before and after](https://raw.githubusercontent.com/source-cooperative/source.coop/assets/website-link-truncation/phone.png)

Desktop, a ~300px grid track:

![Desktop, before and after](https://raw.githubusercontent.com/source-cooperative/source.coop/assets/website-link-truncation/desktop.png)

## The change

**`formatUrl` in `src/lib/format.ts`.** Drops the scheme and a leading `www.`, then elides the middle, keeping the host whole and as many trailing path segments as the budget allows. A plain tail-cut (`github.com/source-coop…`) would render two links to the same site identically, which is the thing worth avoiding — the icon already tells you it is GitHub, so the end of the path is the informative part. `github.com/…/tree/main` rather than `https://github.com/source-cooper…`.

The full URL goes on a `title` attribute, following `DirectoryRow.tsx:167`, the one other place the codebase exposes a truncated value.

**Radix `truncate` stays as a backstop.** The budget is characters, not measured width, so it is a guess at the column; `truncate` catches whatever the guess overshoots. Worth knowing for anyone editing this later: it only bites because the link is a *direct flex child*. Radix resets the `<a>` to `display: inline`, where `overflow` does not apply at all, and flex blockifies it. Wrapping it in a `Box` would silently stop it working.

**The grid** now follows the same ladder #530 gave the organization grid below it.

## Trade-offs

- The displayed text is now shorter than the link target, so copying the text gives the shortened form. The `href` and `title` both carry the full URL.
- A path with no boundary that fits falls back to a cut inside the last segment: `linkedin.com/…e-very-long-handle`. Snapping forward to the next `-` would be a second arbitrary rule for one shape of URL, and the `title` carries the truth either way.
- The budget of 32 is deliberately a shade generous — better to let CSS clip a slightly-too-long string than to over-elide one that had room.

## Testing

New `src/lib/format.test.ts` — there was no test file for this module. Eight cases: scheme/`www.`/trailing-slash stripping, under-budget passthrough at exactly the budget, whole trailing segments kept, the mid-segment fallback, long-host tail-cut, query and hash surviving into the tail, non-ASCII passthrough, and a property check across budgets `[12, 20, 32, 60]` asserting the result never exceeds the budget — that last one catches off-by-ones in all three return paths at once.

`WebsiteLink.stories.tsx` swaps the `Wrapping` story for `Truncation`, adding a single-unbroken-segment URL since that is the shape the helper handles worst.

Local `jest src/lib` is green (359 tests, 30 suites) and `tsc --noEmit` reports nothing in the touched files. Storybook's devDependencies are not installed in my checkout, so the screenshots above were produced by rendering the same flex/grid markup and the real `formatUrl` at the two widths that actually occur, rather than from Storybook itself — worth an eyeball in Storybook before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
