### PR TITLE
fix(data-connections): let a connection row wrap instead of collapsing on mobile

### DIFF
--- a/src/components/features/data-connections/ConnectionRow.tsx
+++ b/src/components/features/data-connections/ConnectionRow.tsx
@@ -57,30 +57,49 @@ export function ConnectionRow({
         marginTop: "-1px",
       }}
     >
-      <Flex justify="between" align="center" gap="3" px="4" py="3">
-        <Box minWidth="0">
-          <Flex align="center" gap="2" wrap="wrap">
-            {title}
-            {markers}
-          </Flex>
-          {meta && (
-            <Text
-              size="1"
-              color="gray"
-              style={{
-                fontFamily: "var(--code-font-family)",
-                display: "block",
-                wordBreak: "break-all",
-              }}
-            >
-              {meta}
-            </Text>
-          )}
-        </Box>
-        <Flex align="center" gap="3" flexShrink="0">
-          {aside}
-          {actions}
+      <Flex align="start" gap="3" px="4" py="3">
+        {/* The aside wraps below the name when the two no longer fit side by
+            side; actions stay on the name's line, since a control that moves
+            around is harder to hit than a label that does. */}
+        <Flex
+          justify="between"
+          align="center"
+          gap="3"
+          wrap="wrap"
+          flexGrow="1"
+          minWidth="0"
+        >
+          {/* A floor on the name column, so a narrow screen wraps the aside
+              rather than squeezing the name to a word per line. `min()` keeps
+              the floor from overflowing a container narrower than it is. */}
+          <Box flexGrow="1" style={{ minWidth: "min(13rem, 100%)" }}>
+            <Flex align="center" gap="2" wrap="wrap">
+              {title}
+              {markers}
+            </Flex>
+            {meta && (
+              <Text
+                size="1"
+                color="gray"
+                style={{
+                  fontFamily: "var(--code-font-family)",
+                  display: "block",
+                  wordBreak: "break-all",
+                }}
+              >
+                {meta}
+              </Text>
+            )}
+          </Box>
+          {aside && <Box ml="auto">{aside}</Box>}
         </Flex>
+        {actions && (
+          // Pinned to the name's line rather than the row's centre, so a row
+          // that has wrapped does not leave its control floating mid-height.
+          <Flex align="center" flexShrink="0" style={{ minHeight: "1.5rem" }}>
+            {actions}
+          </Flex>
+        )}
       </Flex>
       {footer && (
         <Box


### PR DESCRIPTION
## The problem

On a phone, a data connection row gave its right-hand column all the width it
asked for and left the name whatever remained — often a few characters.

`ConnectionRow` laid the row out as `minWidth: 0` name column next to a
`flexShrink: 0` cluster of visibility text + chevron. Flexbox honours that
literally: the right side never yields, so at ~360px the name column collapsed.
Names broke a word per line, the mono identifier line broke mid-token, and the
`READ ONLY` chip overflowed its box and overlapped the visibility text beside it.

## Before / after

Both at a 390px-wide viewport, `DataConnectionsList` → `AdminWithOwners`.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/source-cooperative/source.coop/assets/conn-row-mobile-screenshots/before.png" width="300"> | <img src="https://raw.githubusercontent.com/source-cooperative/source.coop/assets/conn-row-mobile-screenshots/after.png" width="300"> |

Note in the before: `aws-opendata-us-wes / t-2`, `Cascadia Resear / ch`, and
`public, unlisted` pressed up against the `READ ONLY` chip. On a narrower phone
than this the chip and the text overlap outright.

## The fix

Two changes in `ConnectionRow`, no media query:

- The name column claims a floor of `min(13rem, 100%)`, so when the aside no
  longer fits beside it the aside wraps underneath instead of squeezing it.
  `min()` keeps the floor from overflowing a container narrower than itself.
- `actions` moved out of the wrapping group, so a control stays on the name's
  line. A chevron that drifts to the vertical middle of a wrapped row is
  ugly; a menu button that does is harder to hit.

## Reviewing

No deployed Storybook, so locally:

```
npm run storybook
```

The two components that share this row, both worth a look at a narrow window:

- `Features/Data connections/DataConnectionsList` → `AdminWithOwners`
  (chevron + visibility aside)
- `Features/Data connections/ProductMirrorsManager` → `Default`
  (dropdown button in `actions`, no aside, plus the footer strip)
- `Features/Data connections/ConnectionRow` → `AList`, `WithFooter` for the
  primitive itself

I checked both at 390px and at ~1040px. Desktop is unchanged except that the
chevron now sits on the title's line rather than centred against the whole
two-line row.

## Checks

- `npx tsc --noEmit` clean
- `npx jest src/components/features/data-connections` — 4 suites, 26 tests pass

---

The before/after PNGs live on the `assets/conn-row-mobile-screenshots` branch so
they stay out of this diff. Delete that branch whenever this is merged and the
images are no longer wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
