### PR TITLE
fix(products): truncate a product's DOI instead of overflowing the row

### DIFF
--- a/src/components/features/products/ProductDoi.stories.tsx
+++ b/src/components/features/products/ProductDoi.stories.tsx
@@ -15,11 +15,8 @@ export const Default: Story = {
   args: { doi: "https://doi.org/10.34911/rdnt.gcydkj" },
 };
 
-// The bug this component exists for: a DOI is one unbreakable token, so at
-// phone width it used to push the row past the viewport. Pinning the viewport
-// rather than wrapping the story in a fixed-width box -- a box exactly as wide
-// as the frame has no page padding to absorb the copy button, which reads as an
-// overflow the real page never has.
+// A real viewport, not a fixed-width box: a box as wide as the frame has no
+// page padding, so the copy button overhangs as the real page never does.
 const mobile = {
   globals: { viewport: { value: "mobile1", isRotated: false } },
 };

--- a/src/components/features/products/ProductDoi.stories.tsx
+++ b/src/components/features/products/ProductDoi.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { ProductDoi } from "./ProductDoi";
+
+/** A product's DOI, with a button to copy it. */
+const meta = {
+  title: "Features/Products/ProductDoi",
+  component: ProductDoi,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof ProductDoi>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { doi: "https://doi.org/10.34911/rdnt.gcydkj" },
+};
+
+/**
+ * The bug this component exists for: at phone width the DOI used to push the
+ * row past the viewport. It should now end in an ellipsis, with the copy
+ * button still on screen.
+ */
+export const Narrow: Story = {
+  args: Default.args,
+  decorators: [
+    (Story) => (
+      <div style={{ width: 320, outline: "1px dashed var(--gray-6)" }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+/** Registered DOIs run much longer than the common case. */
+export const LongDoi: Story = {
+  ...Narrow,
+  args: {
+    doi: "https://doi.org/10.5061/dryad.salish-sea-hydrophone-timeseries.2026.v3",
+  },
+};

--- a/src/components/features/products/ProductDoi.stories.tsx
+++ b/src/components/features/products/ProductDoi.stories.tsx
@@ -15,25 +15,21 @@ export const Default: Story = {
   args: { doi: "https://doi.org/10.34911/rdnt.gcydkj" },
 };
 
-/**
- * The bug this component exists for: at phone width the DOI used to push the
- * row past the viewport. It should now end in an ellipsis, with the copy
- * button still on screen.
- */
-export const Narrow: Story = {
-  args: Default.args,
-  decorators: [
-    (Story) => (
-      <div style={{ width: 320, outline: "1px dashed var(--gray-6)" }}>
-        <Story />
-      </div>
-    ),
-  ],
+// The bug this component exists for: a DOI is one unbreakable token, so at
+// phone width it used to push the row past the viewport. Pinning the viewport
+// rather than wrapping the story in a fixed-width box -- a box exactly as wide
+// as the frame has no page padding to absorb the copy button, which reads as an
+// overflow the real page never has.
+const mobile = {
+  globals: { viewport: { value: "mobile1", isRotated: false } },
 };
+
+/** At phone width the DOI should end in an ellipsis, copy button still on screen. */
+export const Narrow: Story = { ...mobile, args: Default.args };
 
 /** Registered DOIs run much longer than the common case. */
 export const LongDoi: Story = {
-  ...Narrow,
+  ...mobile,
   args: {
     doi: "https://doi.org/10.5061/dryad.salish-sea-hydrophone-timeseries.2026.v3",
   },

--- a/src/components/features/products/ProductDoi.tsx
+++ b/src/components/features/products/ProductDoi.tsx
@@ -1,0 +1,25 @@
+import { Text, Flex, Code } from "@radix-ui/themes";
+import { CopyToClipboard } from "@/components/core/CopyToClipboard";
+
+interface ProductDoiProps {
+  doi: string;
+}
+
+/**
+ * A DOI is one long unbreakable token, so on a phone it pushed this row wider
+ * than the viewport. `truncate` clips it to the row instead; the full value
+ * stays reachable through the title and the copy button.
+ */
+export function ProductDoi({ doi }: ProductDoiProps) {
+  return (
+    <Text size="2" color="gray">
+      <Flex align="center" gap="2" my="4">
+        <strong>DOI:</strong>{" "}
+        <Code truncate title={doi}>
+          {doi}
+        </Code>
+        <CopyToClipboard text={doi} />
+      </Flex>
+    </Text>
+  );
+}

--- a/src/components/features/products/ProductDoi.tsx
+++ b/src/components/features/products/ProductDoi.tsx
@@ -5,11 +5,8 @@ interface ProductDoiProps {
   doi: string;
 }
 
-/**
- * A DOI is one long unbreakable token, so on a phone it pushed this row wider
- * than the viewport. `truncate` clips it to the row instead; the full value
- * stays reachable through the title and the copy button.
- */
+// A DOI is one unbreakable token: without `truncate` it pushes the row past a
+// phone's viewport. The full value stays in the title and the copy button.
 export function ProductDoi({ doi }: ProductDoiProps) {
   return (
     <Text size="2" color="gray">

--- a/src/components/features/products/ProductDoi.tsx
+++ b/src/components/features/products/ProductDoi.tsx
@@ -14,7 +14,7 @@ export function ProductDoi({ doi }: ProductDoiProps) {
   return (
     <Text size="2" color="gray">
       <Flex align="center" gap="2" my="4">
-        <strong>DOI:</strong>{" "}
+        <strong>DOI:</strong>
         <Code truncate title={doi}>
           {doi}
         </Code>

--- a/src/components/features/products/ProductSummaryCard.tsx
+++ b/src/components/features/products/ProductSummaryCard.tsx
@@ -1,14 +1,14 @@
 "use server";
 
-import { Heading, Text, Box, Flex, Code } from "@radix-ui/themes";
+import { Heading, Text, Box, Flex } from "@radix-ui/themes";
 import { Actions, type Product } from "@/types";
 import { TagList } from "./TagList";
 import { isAuthorized } from "@/lib/api/authz";
 import { getPageSession } from "@/lib/api/utils";
 import { editProductUrl } from "@/lib/urls";
-import { EditButton, MonoText } from "@/components/core";
+import { EditButton } from "@/components/core";
 import { MarkdownViewer } from "../markdown";
-import { CopyToClipboard } from "@/components/core/CopyToClipboard";
+import { ProductDoi } from "./ProductDoi";
 
 interface ProductSummaryCardProps {
   product: Product;
@@ -34,14 +34,7 @@ export async function ProductSummaryCard({ product }: ProductSummaryCardProps) {
       {product.metadata.tags && product.metadata.tags.length > 0 && (
         <TagList tags={product.metadata.tags} />
       )}
-      {product.metadata.doi && (
-        <Text size="2" color="gray">
-          <Flex align="center" gap="2" my="4">
-            <strong>DOI:</strong> <Code>{product.metadata.doi}</Code>
-            <CopyToClipboard text={product.metadata.doi} />
-          </Flex>
-        </Text>
-      )}
+      {product.metadata.doi && <ProductDoi doi={product.metadata.doi} />}
     </Box>
   );
 }


### PR DESCRIPTION
## Problem

On a phone, a product's DOI ran off the right edge of the screen. A DOI is a
single unbreakable token, so the `[DOI:] [code] [copy]` row could not shrink to
the viewport and pushed the page wider instead.

## Fix

Radix's `Code` already ships a `truncate` prop, so the fix is that one
attribute — no CSS of our own. `truncate` sets `overflow: hidden`, which also
makes the flex item's automatic minimum size 0, so it shrinks to the row rather
than defining it. `title` keeps the full DOI on hover, and the copy button still
copies the whole value.

## Before / after

The `LongDoi` story at Storybook's 320×568 mobile viewport. Before, the DOI wraps
and still runs past the frame, taking the copy button off-screen with it; after,
it ends in an ellipsis and the copy button stays inside the frame.

| Before | After |
| --- | --- |
| <img alt="DOI overflowing the phone viewport, copy button pushed off-screen" src="https://github.com/user-attachments/assets/94825361-0696-4bd2-bf32-0d35174b00d9" /> | <img alt="DOI truncated with an ellipsis, copy button inside the viewport" src="https://github.com/user-attachments/assets/415f6e86-0a83-43f2-9eb0-3341262b7bb5" /> |

## Storybook

The row moved into its own `ProductDoi` component so it can have a story:
`ProductSummaryCard` is an async server component that reads the session, which
Storybook cannot render. `ProductDoi.stories.tsx` covers `Default`, plus `Narrow`
and `LongDoi`, which pin Storybook's 320×568 mobile viewport.

Those two originally wrapped the story in a fixed-width 320px box, which was a
mistake worth recording: a box exactly as wide as the frame has none of the page
padding a real page has. Radix's `IconButton` computes as `box-sizing:
content-box` with `width: 15px` plus 4.4px padding, so layout reserves 15px for a
box that occupies 23.8px — and that ~4px shortfall pushed the copy icon past the
wrapper's edge. It reproduces identically under flex and grid, so it isn't a
flex-shrink bug, and it never reaches the screen in the real page because the
container's padding absorbs it. Pinning a viewport shows what a phone shows.

## Testing

- `npx tsc --noEmit -p tsconfig.typecheck.json` — nothing in the touched files.
- `npx next lint` on all three files — no warnings or errors.
- Rendered `Narrow` and `LongDoi` at the pinned 320×568 viewport: the DOI ends in
  an ellipsis with the copy button comfortably inside the frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoNCbzms6gPxEbKCgSPe9L

