### PR TITLE
docs(storybook): generate a docs page per component, with the story source

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -49,11 +49,8 @@ const themeProps = {
 } as const;
 
 const preview: Preview = {
-  // addon-docs was already installed, but nothing generated a docs page, so the
-  // source viewer it provides had nowhere to appear -- a component's stories
-  // showed the rendered result and never the JSX behind it. This gives every
-  // component a Docs page: the JSDoc above `meta`, a props table from the TS
-  // types, and each story with its code.
+  // A docs page per component: the JSDoc above `meta`, a props table from the
+  // types, and each story's source. Without it addon-docs has no page to fill.
   tags: ["autodocs"],
   parameters: {
     // DynamicForm calls useRouter from next/navigation; without this the app
@@ -87,9 +84,8 @@ const preview: Preview = {
   decorators: [
     (Story, context) => {
       const appearance = context.globals.appearance as "light" | "dark";
-      // .radix-themes is min-height:100vh. A story view is one story to a
-      // frame, so that is what we want there -- but a docs page stacks every
-      // story, and each block would be a full screen of mostly whitespace.
+      // .radix-themes is min-height:100vh -- right for one story to a frame,
+      // but a docs page stacks them into screens of whitespace.
       const fillsFrame = context.viewMode !== "docs";
       return (
         <Theme

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -49,6 +49,12 @@ const themeProps = {
 } as const;
 
 const preview: Preview = {
+  // addon-docs was already installed, but nothing generated a docs page, so the
+  // source viewer it provides had nowhere to appear -- a component's stories
+  // showed the rendered result and never the JSX behind it. This gives every
+  // component a Docs page: the JSDoc above `meta`, a props table from the TS
+  // types, and each story with its code.
+  tags: ["autodocs"],
   parameters: {
     // DynamicForm calls useRouter from next/navigation; without this the app
     // router mock is never mounted and the story throws
@@ -81,8 +87,16 @@ const preview: Preview = {
   decorators: [
     (Story, context) => {
       const appearance = context.globals.appearance as "light" | "dark";
+      // .radix-themes is min-height:100vh. A story view is one story to a
+      // frame, so that is what we want there -- but a docs page stacks every
+      // story, and each block would be a full screen of mostly whitespace.
+      const fillsFrame = context.viewMode !== "docs";
       return (
-        <Theme {...themeProps} appearance={appearance}>
+        <Theme
+          {...themeProps}
+          appearance={appearance}
+          style={fillsFrame ? undefined : { minHeight: 0 }}
+        >
           <div style={{ padding: 24, maxWidth: 720 }}>
             <Story />
           </div>


### PR DESCRIPTION
## Problem

You can't see the React behind any story — which is most of what a frontend
developer wants from a component catalog.

`@storybook/addon-docs` was already installed and registered in `main.ts`, but
nothing enabled autodocs (`grep -rn autodocs .storybook src` returns nothing).
The source viewer that addon provides lives in a Docs page's canvas blocks, so
with no Docs page generated it had nowhere to appear. Hence a sidebar where each
component lists only its stories, and a panel with just Controls / Actions /
Interactions / Accessibility.

## Fix

`tags: ["autodocs"]` in `preview.tsx`. Every component now gets a page with:

- the JSDoc above `meta` as prose,
- a props table generated from the TS types (descriptions, defaults, controls),
- each story rendered with **Show code** / **Copy code**.

The story files already carry good doc comments, so this mostly surfaces writing
that was already in the repo.

### The min-height half

`.radix-themes` is `min-height: 100vh`. That's right for a story view — one
story to a frame — but a docs page stacks every story, so each block rendered a
full screen of mostly whitespace (measured 1049px per block on a 5-story page).
Dropped in docs only, keyed off `context.viewMode`, so story view is unchanged.

## A caveat that turned out not to apply

Storybook's dynamic source normally reconstructs JSX from `args`, which can
under-report stories that use a `render` function — and 20+ of the 42 story
files use one. Checked it rather than assuming: it serializes them faithfully,
wrapper and all. `MonoText`'s `AgainstProse` renders as the full
`<Flex direction="column" gap="2">…</Flex>` tree with resolved props. So no
`docs.source.type` override is needed.

## Testing

- `npm run build-storybook` — exits 0.
- `npx tsc --noEmit -p tsconfig.typecheck.json` — nothing in `preview.tsx`.
- Index reports 42 docs pages for 42 story files, 152 stories.
- Loaded the five riskiest docs pages (DynamicForm, DataConnectionForm,
  DataConnectionsList, DirectoryList, ProductSummaryCard); every story block
  renders and no page shows an error overlay. The two that tripped an
  error-text grep were the stories' own JSDoc describing past `__filename` bugs.
- Checked both light and dark appearance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoNCbzms6gPxEbKCgSPe9L
