### PR TITLE
docs: add CLAUDE.md, and cover Storybook in CONTRIBUTING

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,9 +13,17 @@ Every UI change lands in Storybook in the same PR: a new component gets a
 stories removed. A state that can only be reached by clicking through the running
 app is a state nobody reviews.
 
-Async server components can't be storied — they read the session. Extract the
-presentational part and story that; `ProductDoi` beside `ProductSummaryCard` is
-the pattern.
+Stories render in a browser bundle, so a component that fetches its own data
+can't have one. `ProductSummaryCard` is an `async` server component whose first
+act is `await getPageSession()` — cookies and a DynamoDB lookup, neither of which
+exists in the browser — so no prop you pass can make it render.
+
+Split such a component in two: the server half keeps the `async`, the session and
+the permission checks, and passes plain values down; the presentational half is
+an ordinary function of its props, knows nothing about sessions, and is the half
+that gets a story. `ProductDoi` is that half of `ProductSummaryCard` — the card
+calls `<ProductDoi doi={...} />`, and the story renders `ProductDoi` with any DOI
+it likes.
 
 A component that imports a server action needs `sb.mock()` in
 `.storybook/preview.tsx`, or its story fails with `__filename is not defined`.
@@ -37,8 +45,9 @@ https://source-coop-ui-git-<branch-name-with-dashes>-radiantearth.vercel.app/?pa
 ```
 
 Link the specific stories rather than the root, and include a screenshot of
-anything visual. The deploy sits behind Vercel SSO, so for a reviewer without
-access the screenshot is the only thing they can see.
+anything visual — it shows the change in the review itself, and it outlives the
+branch deployment, which goes away with the branch. (Branch deployments ask for a
+Vercel login; ui.source.coop is public.)
 
 The title and description describe the branch as it stands, not as it stood when
 the PR was opened. After pushing to a branch with an open PR, re-read both: if

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,49 @@
+# source.coop
+
+Conventions that aren't visible from the code itself. See
+[CONTRIBUTING.md](CONTRIBUTING.md) for architecture and the PR process.
+
+## Storybook
+
+Stories are published at [ui.source.coop](https://ui.source.coop). Run it locally
+with `npm run storybook`.
+
+Every UI change lands in Storybook in the same PR: a new component gets a
+`.stories.tsx`, a changed one gets its stories updated, a removed one gets its
+stories removed. A state that can only be reached by clicking through the running
+app is a state nobody reviews.
+
+Async server components can't be storied — they read the session. Extract the
+presentational part and story that; `ProductDoi` beside `ProductSummaryCard` is
+the pattern.
+
+A component that imports a server action needs `sb.mock()` in
+`.storybook/preview.tsx`, or its story fails with `__filename is not defined`.
+
+Show responsive behavior by pinning a viewport, never by wrapping a story in a
+fixed-width box. A box exactly as wide as the frame has none of the page padding
+the real layout has, so it invents overflow the page doesn't have.
+
+The JSDoc above `meta`, and above each story export, is published prose on
+ui.source.coop — not a code comment. Write it for a reader.
+
+## Pull requests
+
+A PR that touches the UI links the stories it affects, on that branch's Storybook
+deploy:
+
+```
+https://source-coop-ui-git-<branch-name-with-dashes>-radiantearth.vercel.app/?path=/story/<story-id>
+```
+
+Link the specific stories rather than the root, and include a screenshot of
+anything visual. The deploy sits behind Vercel SSO, so for a reviewer without
+access the screenshot is the only thing they can see.
+
+## Comments
+
+A comment says why the code is the way it is, in the present tense. What it used
+to do, what broke, and what a change fixed belong in the commit message and the PR
+description — that is where someone goes looking for history, and it stays
+accurate there as the code moves on. This matters twice over in story JSDoc, which
+is published.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,14 @@ Link the specific stories rather than the root, and include a screenshot of
 anything visual. The deploy sits behind Vercel SSO, so for a reviewer without
 access the screenshot is the only thing they can see.
 
+The title and description describe the branch as it stands, not as it stood when
+the PR was opened. After pushing to a branch with an open PR, re-read both: if
+the approach has moved on, rewrite them; if they still hold, say so rather than
+leaving it unsaid. A description is read as the spec, so a stale one sends a
+reviewer looking for code that isn't there. Two parts rot first — a Testing
+section asserts checks that may predate the current commits, and a title has to
+keep earning its Conventional Commits type once the work changes shape.
+
 ## Comments
 
 A comment says why the code is the way it is, in the present tense. What it used

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,8 @@
 
 4. **Preview deployments.** Vercel automatically creates preview deployments for PRs from regular contributors. Outside contributions require approval from a regular contributor before a preview is deployed.
 5. **Describe UI changes.** A PR that changes the UI links the stories it affects on that branch's Storybook deployment and includes a screenshot of anything visual. The deployment is behind Vercel SSO, so the screenshot is all a reviewer without access can see.
-6. **Get review and merge** into `main`.
+6. **Keep the PR current.** The title and description describe the branch as it stands. When a push changes the approach, update them — a stale description is read as the spec, and sends a reviewer looking for code that isn't there.
+7. **Get review and merge** into `main`.
 
 ## Deployments
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@
    `feat`, `fix`, `docs`, `test`, `ci`, `refactor`, `perf`, `chore`, `revert`
 
 4. **Preview deployments.** Vercel automatically creates preview deployments for PRs from regular contributors. Outside contributions require approval from a regular contributor before a preview is deployed.
-5. **Describe UI changes.** A PR that changes the UI links the stories it affects on that branch's Storybook deployment and includes a screenshot of anything visual. The deployment is behind Vercel SSO, so the screenshot is all a reviewer without access can see.
+5. **Describe UI changes.** A PR that changes the UI links the stories it affects on that branch's Storybook deployment and includes a screenshot of anything visual — the screenshot shows the change in the review itself, and outlives the branch deployment.
 6. **Keep the PR current.** The title and description describe the branch as it stands. When a push changes the approach, update them — a stale description is read as the spec, and sends a reviewer looking for code that isn't there.
 7. **Get review and merge** into `main`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,8 @@
    `feat`, `fix`, `docs`, `test`, `ci`, `refactor`, `perf`, `chore`, `revert`
 
 4. **Preview deployments.** Vercel automatically creates preview deployments for PRs from regular contributors. Outside contributions require approval from a regular contributor before a preview is deployed.
-5. **Get review and merge** into `main`.
+5. **Describe UI changes.** A PR that changes the UI links the stories it affects on that branch's Storybook deployment and includes a screenshot of anything visual. The deployment is behind Vercel SSO, so the screenshot is all a reviewer without access can see.
+6. **Get review and merge** into `main`.
 
 ## Deployments
 
@@ -73,6 +74,12 @@ Run tests with `npm test`.
 ### UI
 
 [Radix UI](https://www.radix-ui.com/) is the component library. Components are organized into `src/components/core/` (reusable primitives), `src/components/layout/` (page structure), and `src/components/features/` (domain-specific). Forms use `src/components/core/DynamicForm.tsx` with Next.js server actions.
+
+### Storybook
+
+Stories live beside their components as `*.stories.tsx` and are published at [ui.source.coop](https://ui.source.coop); each branch also gets its own deployment. Run it locally with `npm run storybook`.
+
+UI changes carry their stories with them — a new component gets stories, a changed one gets them updated, a removed one gets them deleted. The JSDoc above a story file's `meta` and above each story export is published prose, not a code comment.
 
 ### Server Actions & API Routes
 


### PR DESCRIPTION
## Why

Four things keep having to be restated across sessions, and none of them are
visible from the code:

1. **UI changes belong in Storybook, in the same PR** — added, changed, or
   removed. A state you can only reach by clicking through the running app is a
   state nobody reviews.
2. **A UI PR should link its stories and screenshot anything visual.** The
   screenshot shows the change in the review itself, and outlives the branch
   deployment, which goes away with the branch.
3. **A PR's title and description describe the branch as it stands** — not as it
   stood when the PR was opened. A description is read later as the spec, so a
   stale one sends a reviewer looking for code that isn't there.
4. **Comments say why the code is the way it is, in the present tense.** What it
   used to do and what a change fixed belong in the commit message and PR
   description, where someone actually goes looking for history — and where it
   stays accurate as the code moves on.

`CLAUDE.md` is loaded automatically into every Claude Code session in this repo,
so it is the mechanism that makes these stick without being re-explained.

Rule 3 earned its place during this session: #533 still described a fixed-width
Storybook wrapper, and testing "inside the 320px container", two commits after
both had been replaced by a pinned viewport. It called out the two parts that rot
first — a Testing section asserting checks that predate the current commits, and
a Conventional Commits title that no longer matches the work's shape.

## Also in CLAUDE.md

The Storybook gotchas that otherwise cost an hour to rediscover:

- async server components can't be storied (they read the session) — extract the
  presentational part, as `ProductDoi` does beside `ProductSummaryCard`;
- a component importing a server action needs `sb.mock()` in `preview.tsx`, or
  its story dies on `__filename is not defined`;
- responsive states want a pinned viewport, never a fixed-width wrapper. A box
  exactly as wide as the frame has none of the page padding the real layout has,
  so it invents overflow the page doesn't have. (Learned the hard way in #533.)

## CONTRIBUTING.md

Storybook has been published at ui.source.coop since #498 and was not mentioned
in CONTRIBUTING at all. Adds a Code Conventions section for it, plus two PR
steps: describing UI changes, and keeping the PR current. The gotchas stay in
CLAUDE.md — one copy of each rule, so the two files can't drift.

## Notes

Rules 1–3 are not component-scoped, which is why this is a root `CLAUDE.md`
rather than a scoped `src/components/CLAUDE.md`.

Worth considering separately: much of rule 1 could be enforced rather than
documented — this repo already codifies conventions as `no-restricted-syntax`
rules with a teaching message. A test asserting every component has a sibling
`.stories.tsx` would need an allowlist for the current gaps, so it is left out
here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoNCbzms6gPxEbKCgSPe9L
