### PR TITLE
docs(storybook): story the analytics surfaces — usage card, product page, admin chart

### DIFF
--- a/src/components/features/analytics/AdminBreakdownChart.stories.tsx
+++ b/src/components/features/analytics/AdminBreakdownChart.stories.tsx
@@ -1,0 +1,235 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { OTHER_KEY } from "@/lib/clients/analytics";
+import { AdminBreakdownChart } from "./AdminBreakdownChart";
+
+/**
+ * The stacked traffic chart on `/admin/analytics` — the admin-only explorer.
+ *
+ * Seeing any of this in the app takes an admin session, a configured
+ * Analytics Engine token, and enough real traffic to fill the range; changing
+ * what it renders means editing the URL and waiting on a live query. The
+ * states below are the ones that shape the chart, and each of them is a
+ * different query away in the app: how many series survive before the rest
+ * fold into "Other", how wide the buckets are, and which metric ranks them.
+ *
+ * Two behaviours are live here and worth trying. The **metric toggle** is
+ * client state seeded from `?metric=`, so it switches bytes/requests without
+ * a query. The **SQL dialog** opens whenever `queries` is non-empty.
+ *
+ * **Drill-down is not.** Clicking or dragging a bucket calls `router.push`
+ * with a narrower range for the server to re-query — against Storybook's
+ * mocked router that goes nowhere. The drag rectangle still tracks the
+ * pointer, which is the part worth reviewing here; the navigation is not.
+ */
+const meta = {
+  component: AdminBreakdownChart,
+  title: "Features/Analytics/AdminBreakdownChart",
+  parameters: { layout: "padded" },
+  args: { otherKey: OTHER_KEY, initialMetric: "bytes" },
+} satisfies Meta<typeof AdminBreakdownChart>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Fixed, so tick labels do not move between two runs.
+const RANGE_END = Date.UTC(2026, 7, 31);
+const MINUTE_MS = 60_000;
+
+const wobble = (i: number, seed = 0) =>
+  (Math.sin(i * 1.7 + seed) + Math.sin(i * 0.41 + seed) + 2) / 4;
+
+/** ISO bucket starts, oldest first, ending at RANGE_END. */
+const makeBuckets = (count: number, bucketMinutes: number) =>
+  Array.from({ length: count }, (_, i) =>
+    new Date(
+      RANGE_END - (count - i) * bucketMinutes * MINUTE_MS,
+    ).toISOString(),
+  );
+
+/**
+ * Per-bucket bytes/requests for each series. Series are ranked by total, so
+ * each one gets a smaller share than the last — a flat split would hide
+ * whether the stacking order is right. Absent keys mean zero in the real
+ * shape, so a series that has fallen to nothing is simply left out.
+ */
+function makePoints(
+  buckets: string[],
+  series: string[],
+  bytesPerRequest = 26_000_000,
+): Record<string, { bytes: number; requests: number }>[] {
+  return buckets.map((_, bucket) =>
+    Object.fromEntries(
+      series.flatMap((key, rank) => {
+        const requests = Math.round(
+          (900 / (rank + 1)) * (0.45 + wobble(bucket, rank * 3)),
+        );
+        if (requests === 0) return [];
+        return [[key, { requests, bytes: requests * bytesPerRequest }]];
+      }),
+    ),
+  );
+}
+
+const totalsOf = (
+  points: Record<string, { bytes: number; requests: number }>[],
+  uniqueIps: number,
+  countries: number,
+) => {
+  const sum = (field: "bytes" | "requests") =>
+    points.reduce(
+      (acc, bucket) =>
+        acc + Object.values(bucket).reduce((b, v) => b + v[field], 0),
+      0,
+    );
+  return { bytes: sum("bytes"), requests: sum("requests"), uniqueIps, countries };
+};
+
+/** Whole-range wall clock, which is what the bandwidth stat divides by. */
+const elapsed = (count: number, bucketMinutes: number) =>
+  count * bucketMinutes * 60;
+
+// Two products under `miskatonic` and two under `black-mesa`, because an
+// account with one product tells you nothing about a view grouped by product.
+const products = [
+  "miskatonic/abyssal-acoustics",
+  "black-mesa/anomalous-materials",
+  "miskatonic/deep-sea-imagery",
+  "acoltrane/coastal-lidar",
+];
+
+const dailyBuckets = makeBuckets(28, 1440);
+const dailyPoints = makePoints(dailyBuckets, products);
+
+/** Four products over 28 daily buckets — the view the page opens on. */
+export const Default: Story = {
+  args: {
+    buckets: dailyBuckets,
+    bucketMinutes: 1440,
+    series: products,
+    points: dailyPoints,
+    totals: totalsOf(dailyPoints, 41_882, 96),
+    elapsedSeconds: elapsed(28, 1440),
+  },
+};
+
+// Six ranked series plus the folded remainder: the limit the palette is sized
+// for, so this is the most colours the chart will ever show at once.
+const foldedSeries = [
+  ...products,
+  "black-mesa/sector-c-telemetry",
+  "mingus/harbor-bathymetry",
+  OTHER_KEY,
+];
+const foldedPoints = makePoints(dailyBuckets, foldedSeries);
+
+/**
+ * More groups than the chart can colour, so everything past the top six is
+ * summed into "Other". `seriesColor` gives that key a fixed grey rather than
+ * the next hue in the palette — the thing to check is that the grey band sits
+ * at the top of every stack and never borrows a series colour.
+ */
+export const WithOtherSeries: Story = {
+  args: {
+    buckets: dailyBuckets,
+    bucketMinutes: 1440,
+    series: foldedSeries,
+    points: foldedPoints,
+    totals: totalsOf(foldedPoints, 88_204, 143),
+    elapsedSeconds: elapsed(28, 1440),
+  },
+};
+
+const singleSeries = ["miskatonic/abyssal-acoustics"];
+const singlePoints = makePoints(dailyBuckets, singleSeries);
+
+/**
+ * One group — what a filtered-down query leaves. Nothing stacks, so this is
+ * where a stacked chart tends to look wrong for being technically correct.
+ */
+export const SingleSeries: Story = {
+  args: {
+    buckets: dailyBuckets,
+    bucketMinutes: 1440,
+    series: singleSeries,
+    points: singlePoints,
+    totals: totalsOf(singlePoints, 2_104, 28),
+    elapsedSeconds: elapsed(28, 1440),
+  },
+};
+
+const minuteBuckets = makeBuckets(120, 1);
+const minutePoints = makePoints(minuteBuckets, products, 1_400_000);
+
+/**
+ * Minute buckets, the finest the explorer offers and the end of the drill-down
+ * chain. Sub-daily buckets put a time on every tick label, and 120 bars is
+ * dense enough to show whether the axis thins them sensibly.
+ */
+export const MinuteBuckets: Story = {
+  args: {
+    buckets: minuteBuckets,
+    bucketMinutes: 1,
+    series: products,
+    points: minutePoints,
+    totals: totalsOf(minutePoints, 1_890, 44),
+    elapsedSeconds: elapsed(120, 1),
+  },
+};
+
+const weeklyBuckets = makeBuckets(13, 10080);
+const weeklyPoints = makePoints(weeklyBuckets, products, 620_000_000);
+
+/**
+ * Weekly buckets over a full retention window. Above daily, the tooltip label
+ * gains a `+ 6d` span suffix rather than naming an end date — a quarter of
+ * traffic in thirteen bars.
+ */
+export const WeeklyBuckets: Story = {
+  args: {
+    buckets: weeklyBuckets,
+    bucketMinutes: 10080,
+    series: products,
+    points: weeklyPoints,
+    totals: totalsOf(weeklyPoints, 214_660, 171),
+    elapsedSeconds: elapsed(13, 10080),
+  },
+};
+
+/**
+ * Opened from a URL carrying `?metric=requests`, so the toggle starts on
+ * requests. Ranking is by bytes either way, which is why the tall band is not
+ * always the one on top here.
+ */
+export const RankedByRequests: Story = {
+  args: {
+    buckets: dailyBuckets,
+    bucketMinutes: 1440,
+    series: products,
+    points: dailyPoints,
+    totals: totalsOf(dailyPoints, 41_882, 96),
+    elapsedSeconds: elapsed(28, 1440),
+    initialMetric: "requests",
+  },
+};
+
+/**
+ * With the executed SQL attached, which is what puts the code button beside
+ * the metric toggle. Two statements, because the timeseries and the ranked
+ * totals are separate queries — and they are long, single-line, and the
+ * dialog has to stay readable anyway.
+ */
+export const WithSql: Story = {
+  name: "With SQL",
+  args: {
+    buckets: dailyBuckets,
+    bucketMinutes: 1440,
+    series: products,
+    points: dailyPoints,
+    totals: totalsOf(dailyPoints, 41_882, 96),
+    elapsedSeconds: elapsed(28, 1440),
+    queries: [
+      "SELECT intDiv(toUInt32(timestamp), 86400) * 86400 AS bucket, concat(blob1, '/', blob2) AS key, sum(double1 * _sample_interval) AS bytes, sum(_sample_interval) AS requests FROM product_downloads WHERE timestamp >= toDateTime('2026-08-03 00:00:00') AND timestamp < toDateTime('2026-08-31 00:00:00') AND blob4 = 'GET' AND double2 IN (200.0, 206.0) AND blob2 != '' GROUP BY bucket, key ORDER BY bucket ASC FORMAT JSON",
+      "SELECT concat(blob1, '/', blob2) AS key, sum(double1 * _sample_interval) AS bytes, sum(_sample_interval) AS requests FROM product_downloads WHERE timestamp >= toDateTime('2026-08-03 00:00:00') AND timestamp < toDateTime('2026-08-31 00:00:00') AND blob4 = 'GET' AND double2 IN (200.0, 206.0) AND blob2 != '' GROUP BY key ORDER BY bytes DESC LIMIT 25 FORMAT JSON",
+    ],
+  },
+};

--- a/src/components/features/analytics/ProductAnalyticsView.stories.tsx
+++ b/src/components/features/analytics/ProductAnalyticsView.stories.tsx
@@ -1,0 +1,189 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import {
+  FREQUENCY_BINS,
+  type ProductBreakdowns,
+  type UsagePoint,
+  type UsageTotals,
+  type UsageUsers,
+} from "@/lib/clients/analytics";
+import { ProductAnalyticsView } from "./ProductAnalyticsView";
+
+/**
+ * The body of the product analytics page, behind the manager-only ANALYTICS
+ * tab: stats over a downloads chart, a by-country ranking, and a top-files
+ * table, with audience numbers on the USERS tab.
+ *
+ * Reaching this in the app takes a product you can manage, 28 days of real
+ * traffic against it, and a working Analytics Engine token — which is why the
+ * states that matter here are the ones nobody sees until a user reports them.
+ * `breakdowns` arriving as `null` while the day series is fine is the big one:
+ * it is a separate query, it fails on its own, and the page has to degrade to
+ * a sentence rather than to an empty panel.
+ *
+ * The USERS tab is one click away in every story below.
+ */
+const meta = {
+  component: ProductAnalyticsView,
+  title: "Features/Analytics/ProductAnalyticsView",
+  parameters: { layout: "padded" },
+  args: { accountId: "miskatonic", productId: "abyssal-acoustics" },
+} satisfies Meta<typeof ProductAnalyticsView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Fixed, so the axis labels do not move between two runs.
+const TODAY = Date.UTC(2026, 7, 31);
+const DAY_MS = 86_400_000;
+
+const wobble = (i: number, seed = 0) =>
+  (Math.sin(i * 1.7 + seed) + Math.sin(i * 0.41 + seed) + 2) / 4;
+
+function makeDays(
+  length: number,
+  requestsAt: (i: number) => number,
+): UsagePoint[] {
+  return Array.from({ length }, (_, i) => {
+    const requests = Math.round(requestsAt(i));
+    return {
+      date: new Date(TODAY - (length - 1 - i) * DAY_MS).toISOString(),
+      requests,
+      bytes: requests * 41_000_000,
+      countries:
+        requests === 0 ? 0 : Math.min(48, 3 + Math.round(requests / 90)),
+    };
+  });
+}
+
+const totalsOf = (days: UsagePoint[], countries: number): UsageTotals => ({
+  requests: days.reduce((sum, d) => sum + d.requests, 0),
+  bytes: days.reduce((sum, d) => sum + d.bytes, 0),
+  countries,
+});
+
+/**
+ * A heavy-tailed downloads-per-IP histogram: most addresses take one file, a
+ * few mirror the whole product. The real `distribution` is zero-filled across
+ * every bin, so this builds from FREQUENCY_BINS rather than from a written-out
+ * list that would drift if the bins changed.
+ */
+const distribution = (ipsAt: (index: number) => number) =>
+  FREQUENCY_BINS.map((bin, i) => ({
+    label: bin.label,
+    ips: Math.round(ipsAt(i)),
+  }));
+
+const users: UsageUsers = {
+  uniqueIps: 3_412,
+  registered: 2_180,
+  anonRequests: 6_940,
+  distribution: distribution((i) => 2_400 / Math.pow(1.9, i)),
+};
+
+const breakdowns: ProductBreakdowns = {
+  countries: [
+    { code: "US", name: "United States", requests: 4_210 },
+    { code: "DE", name: "Germany", requests: 1_880 },
+    { code: "GB", name: "United Kingdom", requests: 1_140 },
+    { code: "JP", name: "Japan", requests: 760 },
+    { code: "BR", name: "Brazil", requests: 402 },
+  ],
+  otherCountries: { count: 32, requests: 1_290 },
+  files: [
+    { path: "catalog.parquet", requests: 3_120, bytes: 150_396_837_440 },
+    {
+      path: "derived/detections.parquet",
+      requests: 1_884,
+      bytes: 15_849_474_048,
+    },
+    { path: "README.md", requests: 1_402, bytes: 3_000_280 },
+    {
+      path: "recordings/2019/site-a-20190712-0800.flac",
+      requests: 640,
+      bytes: 78_643_200_000,
+    },
+    {
+      path: "derived/spectrograms/site-a-20190712.png",
+      requests: 318,
+      bytes: 700_922_880,
+    },
+  ],
+};
+
+const steady = makeDays(28, (i) => 180 + wobble(i) * 260);
+const base = { days: steady, totals: totalsOf(steady, 37), users, breakdowns };
+
+/** A managed product with a month of ordinary traffic. */
+export const Default: Story = { args: base };
+
+/**
+ * The country and top-files queries failed while the day series succeeded —
+ * `getProductBreakdowns` returns `null` on its own. Both panels fall back to a
+ * line of explanation, which is the point of the state: the page still says
+ * something rather than showing two empty boxes.
+ */
+export const BreakdownsUnavailable: Story = {
+  args: { ...base, breakdowns: null },
+};
+
+/**
+ * Downloads happened, but none of them resolved to a file — the country
+ * ranking is populated and the table is not. The two panels come from one
+ * query but render independently, so it is worth knowing the layout holds.
+ */
+export const NoFileDownloads: Story = {
+  args: { ...base, breakdowns: { ...breakdowns, files: [] } },
+};
+
+/**
+ * One country and no "others" row, against paths long enough to need
+ * truncating. Deep prefixes are normal for this kind of product, and the file
+ * column is the narrowest thing on the page.
+ */
+export const LongPathsOneCountry: Story = {
+  args: {
+    ...base,
+    breakdowns: {
+      countries: [{ code: "US", name: "United States", requests: 4_210 }],
+      otherCountries: null,
+      files: [
+        {
+          path: "recordings/site-a-hydrophone-array/continuous-passive-acoustic-monitoring/20190712T080000Z-to-20190712T090000Z.flac",
+          requests: 812,
+          bytes: 99_774_464_000,
+        },
+        { path: "a.txt", requests: 4, bytes: 4 },
+        { path: "full-archive.tar", requests: 2, bytes: 8_796_093_022_208 },
+      ],
+    },
+  },
+};
+
+const quiet = makeDays(28, () => 0);
+
+/**
+ * A managed product with nothing to report. Every number is zero, and the
+ * daily average divides by a full window rather than by the number of days
+ * that saw traffic — which is the arithmetic worth eyeballing here.
+ */
+export const NoTraffic: Story = {
+  args: {
+    ...base,
+    days: quiet,
+    totals: totalsOf(quiet, 0),
+    users: {
+      uniqueIps: 0,
+      registered: 0,
+      anonRequests: 0,
+      distribution: distribution(() => 0),
+    },
+    breakdowns: { countries: [], otherCountries: null, files: [] },
+  },
+};
+
+const week = makeDays(7, (i) => 210 + wobble(i, 3) * 140);
+
+/** The 7-day window, the narrowest the page offers. */
+export const SevenDayWindow: Story = {
+  args: { ...base, days: week, totals: totalsOf(week, 19) },
+};

--- a/src/components/features/analytics/UsagePanel.stories.tsx
+++ b/src/components/features/analytics/UsagePanel.stories.tsx
@@ -1,0 +1,149 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Card } from "@radix-ui/themes";
+import { SectionHeader } from "@/components/core/SectionHeader";
+import type { UsagePoint, UsageTotals } from "@/lib/clients/analytics";
+import { MonoLabel } from "./panels";
+import { HELP } from "./style";
+import { UsagePanel } from "./UsagePanel";
+
+/**
+ * The analytics card on a product page — downloads, data served, countries,
+ * over a daily bar chart. Every viewer sees it, signed in or not.
+ *
+ * `UsageCard`, the thing actually mounted in the product layout, is an async
+ * server component whose first line awaits `getUsage`, so it cannot have
+ * stories of its own. The decorator below reproduces its chrome — the Card
+ * and the SectionHeader with the day count — around the panel that does all
+ * the rendering, which is as close to the real card as a browser can get.
+ *
+ * Each state here is a different product's traffic, and in the app you would
+ * have to find such a product to see it: one with no downloads at all, one
+ * that got linked from somewhere big on a single day, one serving petabytes.
+ * Hovering a bar swaps the stats row to that day — that part is live here.
+ */
+const meta = {
+  component: UsagePanel,
+  title: "Features/Analytics/UsagePanel",
+  parameters: { layout: "padded" },
+  decorators: [
+    (Story, context) => (
+      <Card size={{ initial: "2", sm: "1" }} style={{ flexShrink: 0 }}>
+        <SectionHeader
+          title="Analytics"
+          rightButton={
+            <MonoLabel help={HELP.window}>
+              {(context.args.days as UsagePoint[]).length} days
+            </MonoLabel>
+          }
+        >
+          <Story />
+        </SectionHeader>
+      </Card>
+    ),
+  ],
+} satisfies Meta<typeof UsagePanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// A fixed "today" rather than Date.now(): the axis labels are part of what a
+// reviewer is checking, and they should not move between two runs.
+const TODAY = Date.UTC(2026, 7, 31);
+const DAY_MS = 86_400_000;
+
+/** ISO UTC day start, `back` days before the last day of the window. */
+const dayStart = (index: number, length: number) =>
+  new Date(TODAY - (length - 1 - index) * DAY_MS).toISOString();
+
+/**
+ * Deterministic wobble in [0, 1]. Real traffic is neither flat nor random,
+ * and a story that reshuffles itself on reload is useless for spotting a
+ * chart regression — two sines beat both.
+ */
+const wobble = (i: number, seed = 0) =>
+  (Math.sin(i * 1.7 + seed) + Math.sin(i * 0.41 + seed) + 2) / 4;
+
+/** A window of days from a per-day downloads function. */
+function makeDays(
+  length: number,
+  requestsAt: (i: number) => number,
+  bytesPerRequest = 41_000_000,
+): UsagePoint[] {
+  return Array.from({ length }, (_, i) => {
+    const requests = Math.round(requestsAt(i));
+    return {
+      date: dayStart(i, length),
+      requests,
+      bytes: requests * bytesPerRequest,
+      // Countries track volume loosely and plateau — a busy day is not a day
+      // when forty new countries appeared.
+      countries: requests === 0 ? 0 : Math.min(48, 3 + Math.round(requests / 90)),
+    };
+  });
+}
+
+/** Totals are the window's sums, except countries, which is a distinct count. */
+function totalsOf(days: UsagePoint[], countries: number): UsageTotals {
+  return {
+    requests: days.reduce((sum, d) => sum + d.requests, 0),
+    bytes: days.reduce((sum, d) => sum + d.bytes, 0),
+    countries,
+  };
+}
+
+const steady = makeDays(28, (i) => 180 + wobble(i) * 260);
+
+/** A product with regular traffic — the shape most cards have. */
+export const Default: Story = {
+  args: { days: steady, totals: totalsOf(steady, 37) },
+};
+
+const quiet = makeDays(28, () => 0);
+
+/**
+ * Published but never downloaded. The card still renders — an empty chart and
+ * three zeros, rather than the card hiding itself, which is what `null` from
+ * `getUsage` (unconfigured or failed) does instead.
+ */
+export const NoDownloads: Story = {
+  args: { days: quiet, totals: totalsOf(quiet, 0) },
+};
+
+const spike = makeDays(28, (i) =>
+  // One day of front-page traffic, two orders of magnitude over the baseline.
+  i === 21 ? 24_000 : 60 + wobble(i, 2) * 90,
+);
+
+/**
+ * Linked from somewhere large on one day. The interesting part is the other
+ * 27 bars: on a linear axis they are one pixel of nothing next to the spike,
+ * which is the honest rendering but worth looking at deliberately.
+ */
+export const TrafficSpike: Story = {
+  args: { days: spike, totals: totalsOf(spike, 92) },
+};
+
+const petabyte = makeDays(
+  28,
+  (i) => 140_000 + wobble(i, 5) * 90_000,
+  2_400_000_000,
+);
+
+/**
+ * A heavily used product, to check the stats row survives numbers that are
+ * wide in every column at once — six-figure downloads beside petabytes.
+ */
+export const HighVolume: Story = {
+  args: { days: petabyte, totals: totalsOf(petabyte, 148) },
+};
+
+const week = makeDays(7, (i) => 210 + wobble(i, 3) * 140);
+
+/**
+ * Seven days rather than 28. The card is pinned to `USAGE_DAYS` in the app,
+ * so this window is only reachable through the full analytics page — but the
+ * panel is the same one, and it has to hold up with a quarter of the bars.
+ */
+export const ShortWindow: Story = {
+  args: { days: week, totals: totalsOf(week, 19) },
+};


### PR DESCRIPTION
Analytics shipped in #421 and never got stories. It is the feature where that
costs the most: every state worth reviewing needs a configured Analytics Engine
token, a product you can manage, and enough real traffic to fill the window —
and for the admin explorer, an admin session and a live query per state. None of
that exists in review.

Three components, chosen because they are where the states live. The other
files in `src/components/features/analytics/` are either thin controls or, like
`UsageCard` and both route pages, `async` server components that fetch — no prop
makes those render in a browser bundle.

### `UsagePanel`

The analytics card every visitor sees on a product page. `UsageCard` is the half
that awaits `getUsage`, so the story renders the presentational half inside a
decorator reproducing the card's Card and SectionHeader chrome.

- [Default](https://source-coop-ui-git-feat-analytics-stories-radiantearth.vercel.app/?path=/story/features-analytics-usagepanel--default)
- [No downloads](https://source-coop-ui-git-feat-analytics-stories-radiantearth.vercel.app/?path=/story/features-analytics-usagepanel--no-downloads) — published, never downloaded. The card still renders zeros; it hides itself only when `getUsage` returns `null`.
- [Traffic spike](https://source-coop-ui-git-feat-analytics-stories-radiantearth.vercel.app/?path=/story/features-analytics-usagepanel--traffic-spike) — one day two orders of magnitude over baseline. The other 27 bars flatten to slivers, which is the honest linear rendering and worth looking at deliberately.
- [High volume](https://source-coop-ui-git-feat-analytics-stories-radiantearth.vercel.app/?path=/story/features-analytics-usagepanel--high-volume) — six-figure downloads beside petabytes, so every column in the stats row is wide at once.
- [Short window](https://source-coop-ui-git-feat-analytics-stories-radiantearth.vercel.app/?path=/story/features-analytics-usagepanel--short-window)

### `ProductAnalyticsView`

The analytics page body, behind the manager-only ANALYTICS tab.

- [Default](https://source-coop-ui-git-feat-analytics-stories-radiantearth.vercel.app/?path=/story/features-analytics-productanalyticsview--default)
- [Breakdowns unavailable](https://source-coop-ui-git-feat-analytics-stories-radiantearth.vercel.app/?path=/story/features-analytics-productanalyticsview--breakdowns-unavailable) — the state that most justifies the file. `getProductBreakdowns` is a separate query that fails on its own, so the day series can be fine while both the country ranking and the file table have nothing. They have to degrade to a sentence rather than to two empty boxes.
- [No file downloads](https://source-coop-ui-git-feat-analytics-stories-radiantearth.vercel.app/?path=/story/features-analytics-productanalyticsview--no-file-downloads)
- [Long paths, one country](https://source-coop-ui-git-feat-analytics-stories-radiantearth.vercel.app/?path=/story/features-analytics-productanalyticsview--long-paths-one-country) — deep prefixes against the narrowest column on the page, and no "others" row.
- [No traffic](https://source-coop-ui-git-feat-analytics-stories-radiantearth.vercel.app/?path=/story/features-analytics-productanalyticsview--no-traffic) — every number zero, and the daily average dividing by a full window.
- [Seven-day window](https://source-coop-ui-git-feat-analytics-stories-radiantearth.vercel.app/?path=/story/features-analytics-productanalyticsview--seven-day-window)

### `AdminBreakdownChart`

The stacked chart on `/admin/analytics` — the largest client component in the
feature, and the one with no tests.

- [Default](https://source-coop-ui-git-feat-analytics-stories-radiantearth.vercel.app/?path=/story/features-analytics-adminbreakdownchart--default)
- [With "Other" series](https://source-coop-ui-git-feat-analytics-stories-radiantearth.vercel.app/?path=/story/features-analytics-adminbreakdownchart--with-other-series) — more groups than the palette colours, so the rest fold into "Other". Worth checking the grey band sits on top of every stack and never borrows a series hue.
- [Single series](https://source-coop-ui-git-feat-analytics-stories-radiantearth.vercel.app/?path=/story/features-analytics-adminbreakdownchart--single-series) — what a filtered-down query leaves, where a stacked chart tends to look wrong for being correct.
- [Minute buckets](https://source-coop-ui-git-feat-analytics-stories-radiantearth.vercel.app/?path=/story/features-analytics-adminbreakdownchart--minute-buckets) — the finest interval, 120 bars, time on every tick label.
- [Weekly buckets](https://source-coop-ui-git-feat-analytics-stories-radiantearth.vercel.app/?path=/story/features-analytics-adminbreakdownchart--weekly-buckets) — above daily the tooltip gains a `+ 6d` span suffix instead of an end date.
- [Ranked by requests](https://source-coop-ui-git-feat-analytics-stories-radiantearth.vercel.app/?path=/story/features-analytics-adminbreakdownchart--ranked-by-requests) — opened from a URL carrying `?metric=requests`.
- [With SQL](https://source-coop-ui-git-feat-analytics-stories-radiantearth.vercel.app/?path=/story/features-analytics-adminbreakdownchart--with-sql) — two statements, because the timeseries and the ranked totals are separate queries.

### Notes

Fixture data is deterministic — two sines rather than `Math.random`, and a fixed
`TODAY` rather than `Date.now()`. Axis labels and bar heights are part of what a
reviewer checks, and a story that reshuffles on reload makes a visual diff
meaningless.

Accounts and products are fictional, following #527: `miskatonic`,
`black-mesa`, `acoltrane`, `mingus`. Two products sit under one account, because
an account with a single product says nothing about a view grouped by product.

Drill-down is the one behaviour not reproduced. Clicking or dragging a bucket
calls `router.push` with a narrower range for the server to re-query, which goes
nowhere against Storybook's mocked router; the drag rectangle still tracks the
pointer. The story says so rather than faking it.

Not storied: `UsageCardSkeleton`, `ProductTabs`, `GroupByChips` and
`AdminFiltersForm` — thin enough that a story would restate the markup. Worth
adding when one grows a state that needs reviewing.

### Testing

- `tsc --noEmit -p tsconfig.typecheck.json` — clean.
- `npx next lint --file src/components/features/analytics` — no warnings or errors.
- `npm run build-storybook` — exit 0.
- Served the static build and loaded all three components in a browser: they
  render, and the console is free of errors and warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjjUz8mKeDoEf2bMQVw2VN
