### PR TITLE
perf(globe): load the clouds texture in parallel with the globe texture

### DIFF
--- a/src/components/features/globe/LiveGlobe.stories.tsx
+++ b/src/components/features/globe/LiveGlobe.stories.tsx
@@ -11,40 +11,50 @@ const PER_TICK = 6;
 /**
  * Sample traffic. The colo codes are real Cloudflare datacenters, because
  * LiveGlobe looks each one up in `locations.json` to place its dot; the
- * accounts and request counts are invented. One deliberately long product name
- * keeps the popup's truncation visible.
+ * accounts and request counts are invented.
+ *
+ * The counts are deliberately small. A dot is sized
+ * `8 * (1 + min(2, log10(1 + n) / 2))` px, so it caps out at 24px by n = 9999,
+ * and anything in the thousands renders as a near-maximum blob — several times
+ * the area of a real one, and all within a few px of each other however the
+ * counts differ. Keeping the spread to 1..160 puts them on the part of the
+ * curve where the size difference is legible, with a typical dot close to what
+ * production draws.
+ *
+ * One deliberately long product name keeps the popup's truncation visible, and
+ * the quietest datacenters exercise its singular "1 request".
  */
 const FEED: { colo: string; n: number; p: [string, number][] }[] = [
   {
     colo: "EWR",
-    n: 4820,
+    n: 160,
     p: [
-      ["demo-org/global-land-cover", 2140],
-      ["demo-lab/coastal-bathymetry", 980],
+      ["demo-org/global-land-cover", 96],
+      ["demo-lab/coastal-bathymetry", 41],
     ],
   },
-  { colo: "LHR", n: 3110, p: [["demo-org/global-land-cover", 1870]] },
+  { colo: "LAX", n: 80, p: [["demo-org/global-land-cover", 52]] },
   {
     colo: "FRA",
-    n: 2740,
+    n: 42,
     p: [
-      ["demo-lab/annual-surface-water-extent-mosaics-2024", 1520],
-      ["demo-org/elevation-tiles", 640],
+      ["demo-lab/annual-surface-water-extent-mosaics-2024", 24],
+      ["demo-org/elevation-tiles", 11],
     ],
   },
-  { colo: "NRT", n: 1980, p: [["demo-lab/coastal-bathymetry", 1120]] },
-  { colo: "SIN", n: 1640, p: [["demo-org/elevation-tiles", 910]] },
-  { colo: "GRU", n: 1290, p: [["demo-org/global-land-cover", 720]] },
-  { colo: "JNB", n: 880, p: [["demo-lab/coastal-bathymetry", 410]] },
-  { colo: "SYD", n: 760, p: [["demo-org/elevation-tiles", 380]] },
-  { colo: "LAX", n: 3460, p: [["demo-org/global-land-cover", 2010]] },
-  { colo: "ORD", n: 2210, p: [["demo-lab/coastal-bathymetry", 1180]] },
-  { colo: "AMS", n: 1870, p: [["demo-org/elevation-tiles", 990]] },
-  { colo: "CPT", n: 540, p: [["demo-lab/coastal-bathymetry", 260]] },
-  { colo: "BOM", n: 1420, p: [["demo-org/global-land-cover", 830]] },
-  { colo: "SCL", n: 470, p: [["demo-org/elevation-tiles", 210]] },
-  { colo: "YYZ", n: 1650, p: [["demo-lab/coastal-bathymetry", 900]] },
-  { colo: "MAD", n: 1130, p: [["demo-org/global-land-cover", 610]] },
+  { colo: "LHR", n: 26, p: [["demo-org/global-land-cover", 15]] },
+  { colo: "ORD", n: 16, p: [["demo-lab/coastal-bathymetry", 9]] },
+  { colo: "AMS", n: 10, p: [["demo-org/elevation-tiles", 6]] },
+  { colo: "NRT", n: 7, p: [["demo-lab/coastal-bathymetry", 4]] },
+  { colo: "SIN", n: 5, p: [["demo-org/elevation-tiles", 3]] },
+  { colo: "YYZ", n: 4, p: [["demo-lab/coastal-bathymetry", 2]] },
+  { colo: "BOM", n: 3, p: [["demo-org/global-land-cover", 2]] },
+  { colo: "GRU", n: 3, p: [["demo-org/global-land-cover", 2]] },
+  { colo: "MAD", n: 2, p: [["demo-org/global-land-cover", 1]] },
+  { colo: "SYD", n: 2, p: [["demo-org/elevation-tiles", 1]] },
+  { colo: "JNB", n: 1, p: [["demo-lab/coastal-bathymetry", 1]] },
+  { colo: "CPT", n: 1, p: [["demo-lab/coastal-bathymetry", 1]] },
+  { colo: "SCL", n: 1, p: [["demo-org/elevation-tiles", 1]] },
 ];
 
 /**

--- a/src/components/features/globe/LiveGlobe.stories.tsx
+++ b/src/components/features/globe/LiveGlobe.stories.tsx
@@ -1,0 +1,158 @@
+import { useEffect } from "react";
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { LiveGlobe } from "./LiveGlobe";
+
+/** How often the stand-in socket publishes a tick. */
+const TICK_MS = 1500;
+
+/** How many datacenters each tick reports. */
+const PER_TICK = 6;
+
+/**
+ * Sample traffic. The colo codes are real Cloudflare datacenters, because
+ * LiveGlobe looks each one up in `locations.json` to place its dot; the
+ * accounts and request counts are invented. One deliberately long product name
+ * keeps the popup's truncation visible.
+ */
+const FEED: { colo: string; n: number; p: [string, number][] }[] = [
+  {
+    colo: "EWR",
+    n: 4820,
+    p: [
+      ["demo-org/global-land-cover", 2140],
+      ["demo-lab/coastal-bathymetry", 980],
+    ],
+  },
+  { colo: "LHR", n: 3110, p: [["demo-org/global-land-cover", 1870]] },
+  {
+    colo: "FRA",
+    n: 2740,
+    p: [
+      ["demo-lab/annual-surface-water-extent-mosaics-2024", 1520],
+      ["demo-org/elevation-tiles", 640],
+    ],
+  },
+  { colo: "NRT", n: 1980, p: [["demo-lab/coastal-bathymetry", 1120]] },
+  { colo: "SIN", n: 1640, p: [["demo-org/elevation-tiles", 910]] },
+  { colo: "GRU", n: 1290, p: [["demo-org/global-land-cover", 720]] },
+  { colo: "JNB", n: 880, p: [["demo-lab/coastal-bathymetry", 410]] },
+  { colo: "SYD", n: 760, p: [["demo-org/elevation-tiles", 380]] },
+  { colo: "LAX", n: 3460, p: [["demo-org/global-land-cover", 2010]] },
+  { colo: "ORD", n: 2210, p: [["demo-lab/coastal-bathymetry", 1180]] },
+  { colo: "AMS", n: 1870, p: [["demo-org/elevation-tiles", 990]] },
+  { colo: "CPT", n: 540, p: [["demo-lab/coastal-bathymetry", 260]] },
+  { colo: "BOM", n: 1420, p: [["demo-org/global-land-cover", 830]] },
+  { colo: "SCL", n: 470, p: [["demo-org/elevation-tiles", 210]] },
+  { colo: "YYZ", n: 1650, p: [["demo-lab/coastal-bathymetry", 900]] },
+  { colo: "MAD", n: 1130, p: [["demo-org/global-land-cover", 610]] },
+];
+
+/**
+ * Stands in for the analytics socket, so the globe carries traffic without a
+ * network of any kind. Implements only the four members LiveGlobe touches:
+ * `readyState`, `onmessage`, `onclose` and `close()`, plus the `CLOSING`
+ * constant it compares against.
+ */
+class MockTrafficSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  readyState: number = MockTrafficSocket.OPEN;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onclose: (() => void) | null = null;
+
+  private timer: ReturnType<typeof setInterval>;
+  private tick = 0;
+
+  constructor() {
+    // A tick on the next turn rather than in the constructor: LiveGlobe assigns
+    // onmessage after `new`, so anything published here would land on nobody.
+    setTimeout(() => this.publish(), 0);
+    this.timer = setInterval(() => this.publish(), TICK_MS);
+  }
+
+  private publish() {
+    // A window walking the feed, not a random sample, so the story looks the
+    // same on every visit and dots refresh instead of all ageing out together.
+    const offset = this.tick++ * 2;
+    const locations = Array.from(
+      { length: PER_TICK },
+      (_, i) => FEED[(offset + i) % FEED.length],
+    );
+    this.onmessage?.({ data: JSON.stringify({ type: "tick", locations }) });
+  }
+
+  close() {
+    clearInterval(this.timer);
+    this.readyState = MockTrafficSocket.CLOSED;
+    // ponytail: deliberately silent — LiveGlobe reconnects on close, and a
+    // story that reconnects on unmount would leave sockets ticking behind the
+    // docs page. Nothing here exercises the reconnect path.
+  }
+}
+
+/**
+ * Swaps the global WebSocket for the run of the story.
+ *
+ * The swap happens during render rather than in an effect because React runs a
+ * child's effects before its parent's: from a decorator effect, LiveGlobe would
+ * already be holding a real socket.
+ */
+let realWebSocket: typeof WebSocket | undefined;
+
+function withMockTraffic(Story: React.ComponentType) {
+  realWebSocket ??= window.WebSocket;
+  window.WebSocket = MockTrafficSocket as unknown as typeof WebSocket;
+  useEffect(() => {
+    return () => {
+      if (realWebSocket) window.WebSocket = realWebSocket;
+    };
+  }, []);
+  return <Story />;
+}
+
+/**
+ * The globe on the landing page: a WebGL earth run through an ordered-dither
+ * post-process, turning it into a 1-bit halftone that inverts with the theme.
+ *
+ * Every few seconds it marks the datacenters that served product data in the
+ * last window. A dot grows with that datacenter's request count and fades as it
+ * ages out, or as it rounds the limb; hover one for the location and its
+ * busiest products.
+ *
+ * The globe sizes itself from `width` and `height` rather than from its
+ * container — on the landing page a `ResizeObserver` supplies them. This story
+ * passes fixed numbers, and replaces the analytics socket with a stand-in that
+ * replays a fixed loop of sample traffic, so nothing here reaches the network
+ * beyond the two textures.
+ */
+const meta = {
+  title: "Features/Globe/LiveGlobe",
+  component: LiveGlobe,
+  decorators: [withMockTraffic],
+  args: {
+    wsUrl: "wss://example.invalid/live-traffic",
+    width: 560,
+    height: 560,
+    showClouds: true,
+  },
+  parameters: {
+    a11y: {
+      // The canvas is decorative and kept out of the tab order; the wrapper
+      // carries role="img" and the label.
+      test: "todo",
+    },
+  },
+} satisfies Meta<typeof LiveGlobe>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * The globe as the landing page renders it. The cloud shell is a second sphere
+ * just above the surface, rotating slowly against the earth's own spin, which
+ * is what gives the dither its drifting texture.
+ */
+export const Default: Story = {};

--- a/src/components/features/globe/LiveGlobe.tsx
+++ b/src/components/features/globe/LiveGlobe.tsx
@@ -12,6 +12,7 @@ import {
   MeshPhongMaterial,
   Object3D,
   SphereGeometry,
+  Texture,
   TextureLoader,
   Vector2,
   Vector3,
@@ -59,6 +60,23 @@ const MAX_DOT_SCALE = 3; // busiest-datacenter dot grows up to 3x the base size
 
 // Monotonic ID counter — shared across instances, but always unique
 let nextPointId = 0;
+
+// The clouds texture, requested as soon as this module evaluates.
+//
+// three-globe only fires onGlobeReady once its own globeImageUrl texture has
+// finished loading, so anything that waits on the globe — including this
+// component's scene-setup effect — queues the clouds behind a completed
+// download instead of alongside it. Even a mount effect here is too late:
+// React runs the <Globe> child's effect, and three-globe's synchronous scene
+// build, before any effect of ours. Module scope is the one point that beats
+// both, and this module is only ever imported to render the globe.
+//
+// Never disposed: it outlives any single mount so a remount reuses it.
+const cloudsTexture = new Promise<Texture>((resolve) => {
+  new TextureLoader().load("/img/clouds.webp", resolve, undefined, () => {
+    // Leave the promise pending — same as before: no texture, no clouds.
+  });
+});
 
 // Cheap structural compare for the top-products list (≤5 entries) so the
 // selected popup only re-renders when its contents actually change.
@@ -160,7 +178,7 @@ export function LiveGlobe({
 
       // Add clouds
       if (showClouds) {
-        new TextureLoader().load("/img/clouds.webp", (texture) => {
+        cloudsTexture.then((texture) => {
           if (cancelled || !globe) return;
           clouds = new Mesh(
             new SphereGeometry(
@@ -430,9 +448,7 @@ export function LiveGlobe({
         ditherPassRef.current = null;
         if (clouds) {
           globe?.scene().remove(clouds);
-          const mat = clouds.material as MeshPhongMaterial;
-          mat.map?.dispose();
-          mat.dispose();
+          (clouds.material as MeshPhongMaterial).dispose();
           clouds.geometry.dispose();
         }
         // Clear overlay DOM


### PR DESCRIPTION
## What

Requests `/img/clouds.webp` when `LiveGlobe.tsx` evaluates, instead of from the
scene-setup effect that waits on `onGlobeReady`.

## Why

On staging the globe fades in bare and the clouds pop in separately; on
production it fades in whole. The difference is that production is still
serving the pre-#472 HTML, which preloads both textures:

```
$ curl -s https://source.coop/ | grep 'rel="preload".*img'
<link rel="preload" href="/img/earth-blue-marble.jpg" as="image"/>
<link rel="preload" href="/img/clouds.png" as="image"/>
```

Those hints downloaded both textures in parallel with the HTML, so by the time
the component mounted they were both cached and landed in the same frame.
#472 removed them — correctly, they cost 6.5 MB on the critical path — which
exposed a sequencing bug the preloads had been hiding.

Nothing requests a texture until hydration, and then the two requests are
strictly serialized:

1. `<Globe globeImageUrl="/img/earth-blue-marble.webp">` requests the globe texture.
2. three-globe fires `onReady` **only after that texture finishes loading**
   (`three-globe/dist/three-globe.mjs:711`).
3. `onGlobeReady` sets a ref, and a `setInterval(…, 100)` polls it
   (`LiveGlobe.tsx:99`), adding up to another 100 ms.
4. Only then does the scene-setup effect run — and that is where the clouds
   were first requested.
5. That same effect calls `setSceneReady(true)`, starting the 0.5 s canvas
   fade **without waiting for the clouds**.

So the clouds request could not begin until the globe texture had fully
downloaded, and the fade started at that same moment.

## Why module scope

A mount effect is still too late. React runs a child's effects before its
parent's, so `<Globe>`'s effect — and three-globe's synchronous scene build —
both run before anything `LiveGlobe` schedules. Measured on an effect-based
version of this fix, the clouds request still trailed the globe texture by
121 ms, and still landed after it had finished downloading.

Module scope is the one point that beats both. `LiveGlobe` is only ever
imported to render the globe (one call site, `HeroGlobe`, `ssr: false`), so
there is no path that pays for the texture without using it.

## Measured

Resource Timing on the branch, globe mounted from a cold module load:

| | request starts |
|---|---|
| `clouds.webp` | 33098 ms |
| `earth-blue-marble.webp` | 33833 ms |

The clouds now start **735 ms before** the globe texture, rather than after it
finishes. (Absolute numbers are dev-server figures; the ordering is the point.)

## Also

The clouds material has bound the texture as `alphaMap` since #473, so the
teardown's `mat.map?.dispose()` had been disposing nothing. Dropped it — the
texture is shared now and deliberately outlives any single mount, so a remount
reuses it.

## Storybook

`LiveGlobe` takes everything it renders from props, imports no server actions,
and Storybook already serves `public/` via `staticDirs` -- so it can have a
story, and an earlier version of this description was wrong to say otherwise.
It now has one.

https://source-coop-ui-git-fix-globe-clouds-parallel-load-radiantearth.vercel.app/?path=/story/features-globe-liveglobe--default

The only thing the component reaches for on its own is the analytics socket, so
a decorator swaps the global `WebSocket` for a stand-in that replays a fixed
loop of sample traffic across real Cloudflare colo codes. The globe carries
dots, the hover popup shows locations and products, and nothing touches
production. The swap happens during render rather than in an effect for the
same ordering reason as the fix above: React runs a child's effects before its
parent's.

No `WithoutClouds` counterpart -- `HeroGlobe` always passes `showClouds`, so a
clouds-less globe is not a state the product has.

This is a story for a component that had none, not a record of this PR's
change: the render path is untouched and the globe looks the same. Only the
moment the texture is requested moves.

## Verification

- `npm run type-check` -- 0 errors (the earlier count of 74 in this description
  was missing-Storybook-dependency noise in an incomplete local install)
- `npm run lint` -- clean; no findings in either changed file
- Story rendered locally: globe draws with clouds, dots arrive from the mock
  feed and refresh rather than ageing out, and hovering one shows the
  datacenter and its products
- Resource Timing in that story confirms the ordering above -- `clouds.webp`
  ahead of `earth-blue-marble.webp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZ7pZ6B8StcxgUH1dba7hh
