### PR TITLE
fix(analytics): let the metrics row reflow instead of running off a phone

### DIFF
--- a/src/components/features/analytics/AdminBreakdownChart.tsx
+++ b/src/components/features/analytics/AdminBreakdownChart.tsx
@@ -26,7 +26,7 @@ import {
   YAxis,
 } from "recharts";
 import { formatBytes } from "@/lib/format";
-import { parseActiveIndex, Stat } from "./panels";
+import { parseActiveIndex, Stat, StatRow } from "./panels";
 import { HELP, mono } from "./style";
 import { seriesColor } from "./palette";
 
@@ -235,7 +235,7 @@ export function AdminBreakdownChart({
         wrap="wrap"
         style={{ borderBottom: "1px solid var(--gray-4)" }}
       >
-        <Flex style={{ flexGrow: 1 }}>
+        <StatRow style={{ flexGrow: 1 }}>
           <Stat
             label="Requests"
             help={HELP.requests}
@@ -245,27 +245,23 @@ export function AdminBreakdownChart({
             label="Data served"
             help={HELP.served}
             value={formatBytes(totals.bytes, 1)}
-            divider
           />
           <Stat
             label="Avg bandwidth"
             help={HELP.bandwidth}
             value={byteRate(totals.bytes / elapsedSeconds)}
-            divider
           />
           <Stat
             label="Unique IPs"
             help={HELP.uniqueIpsSampled}
             value={plain.format(totals.uniqueIps)}
-            divider
           />
           <Stat
             label="Countries"
             help={HELP.countries}
             value={plain.format(totals.countries)}
-            divider
           />
-        </Flex>
+        </StatRow>
         <Flex gap="2" align="center">
           <SegmentedControl.Root
             size="1"

--- a/src/components/features/analytics/ProductAnalyticsView.stories.tsx
+++ b/src/components/features/analytics/ProductAnalyticsView.stories.tsx
@@ -187,3 +187,14 @@ const week = makeDays(7, (i) => 210 + wobble(i, 3) * 140);
 export const SevenDayWindow: Story = {
   args: { ...base, days: week, totals: totalsOf(week, 19) },
 };
+
+/**
+ * The page at phone width. Four metrics do not fit across a phone, so the
+ * stats row becomes two rows of two rather than a single row that cannot
+ * shrink and pushes COUNTRIES off the side. The chart and the country ranking
+ * stack here as well.
+ */
+export const Mobile: Story = {
+  args: base,
+  globals: { viewport: { value: "mobile1", isRotated: false } },
+};

--- a/src/components/features/analytics/ProductAnalyticsView.tsx
+++ b/src/components/features/analytics/ProductAnalyticsView.tsx
@@ -19,6 +19,7 @@ import {
   mono,
   numberFormat,
   Stat,
+  StatRow,
   UsersContent,
 } from "./panels";
 
@@ -68,7 +69,7 @@ export function ProductAnalyticsView({
       </Tabs.List>
 
       <Tabs.Content value="downloads">
-        <Flex mt="3" pb="3" style={{ borderBottom: "1px solid var(--gray-4)" }}>
+        <StatRow mt="3" pb="3" style={{ borderBottom: "1px solid var(--gray-4)" }}>
           <Stat
             label="Downloads"
             help={HELP.downloads}
@@ -78,21 +79,18 @@ export function ProductAnalyticsView({
             label="Daily avg"
             help={HELP.dailyAvg}
             value={numberFormat.format(Math.round(totals.requests / days.length))}
-            divider
           />
           <Stat
             label="Data served"
             help={HELP.served}
             value={formatBytes(shown.bytes, 1)}
-            divider
           />
           <Stat
             label="Countries"
             help={HELP.countries}
             value={numberFormat.format(shown.countries)}
-            divider
           />
-        </Flex>
+        </StatRow>
 
         <Grid columns={{ initial: "1", md: "5" }} gap="6" mt="4">
           <Box style={{ gridColumn: "span 3" }}>

--- a/src/components/features/analytics/UsagePanel.stories.tsx
+++ b/src/components/features/analytics/UsagePanel.stories.tsx
@@ -147,3 +147,17 @@ const week = makeDays(7, (i) => 210 + wobble(i, 3) * 140);
 export const ShortWindow: Story = {
   args: { days: week, totals: totalsOf(week, 19) },
 };
+
+/**
+ * The card at phone width, where the stats row has to give up its single
+ * line. The metrics reflow onto a second row rather than running off the side
+ * of the card, and the hairline dividers still fall only between neighbours —
+ * never down the left edge of a row.
+ *
+ * Worth reading next to `HighVolume`, whose numbers these are: the widest
+ * value in the row is what decides how many metrics fit across.
+ */
+export const Mobile: Story = {
+  args: HighVolume.args,
+  globals: { viewport: { value: "mobile1", isRotated: false } },
+};

--- a/src/components/features/analytics/UsagePanel.tsx
+++ b/src/components/features/analytics/UsagePanel.tsx
@@ -10,6 +10,7 @@ import {
   HoverCaption,
   numberFormat,
   Stat,
+  StatRow,
 } from "./panels";
 
 // Kept here for its existing unit tests / import sites.
@@ -32,7 +33,7 @@ export function UsagePanel({ days, totals }: UsagePanelProps) {
 
   return (
     <>
-      <Flex mt="3" pb="3" style={{ borderBottom: "1px solid var(--gray-4)" }}>
+      <StatRow mt="3" pb="3" style={{ borderBottom: "1px solid var(--gray-4)" }}>
         <Stat
           label="Downloads"
           help={HELP.downloads}
@@ -42,15 +43,13 @@ export function UsagePanel({ days, totals }: UsagePanelProps) {
           label="Data served"
           help={HELP.served}
           value={formatBytes(shown.bytes, 1)}
-          divider
         />
         <Stat
           label="Countries"
           help={HELP.countries}
           value={numberFormat.format(shown.countries)}
-          divider
         />
-      </Flex>
+      </StatRow>
 
       <Flex mt="3" direction="column">
         <HoverCaption days={days} hovered={hovered} />

--- a/src/components/features/analytics/panels.tsx
+++ b/src/components/features/analytics/panels.tsx
@@ -68,25 +68,51 @@ export function MonoLabel({
   return help ? <Tooltip content={help}>{label}</Tooltip> : label;
 }
 
+/**
+ * Row of Stats. An auto-fitting grid rather than a flex row: the values are
+ * nowrap, so a flex row cannot shrink below their combined width and instead
+ * overflows a narrow card. Here the metrics reflow onto further rows.
+ *
+ * Every Stat carries its own left divider and the grid is pulled left by one
+ * divider plus its padding, so the leading column of each row is clipped back
+ * to flush — no stat needs to know whether it starts a row.
+ *
+ * That clip is also why the minimum track is as wide as it is: it would hide
+ * a value that outgrew its column just as quietly as it hides the divider,
+ * and 120px holds the widest of these a product realistically reports — a
+ * ten-character downloads count.
+ */
+export function StatRow({
+  children,
+  ...props
+}: React.ComponentProps<typeof Box>) {
+  return (
+    <Box {...props} style={{ overflow: "hidden", ...props.style }}>
+      <Box
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(120px, 1fr))",
+          rowGap: "var(--space-3)",
+          marginLeft: -13,
+        }}
+      >
+        {children}
+      </Box>
+    </Box>
+  );
+}
+
 export function Stat({
   label,
   help,
   value,
-  divider,
 }: {
   label: string;
   help: string;
   value: string;
-  divider?: boolean;
 }) {
   return (
-    <Box
-      pl={divider ? "3" : "0"}
-      style={{
-        flexGrow: 1,
-        ...(divider && { borderLeft: "1px solid var(--gray-4)" }),
-      }}
-    >
+    <Box pl="3" style={{ borderLeft: "1px solid var(--gray-4)" }}>
       <MonoLabel help={help}>{label}</MonoLabel>
       <Text
         as="div"
@@ -189,7 +215,7 @@ export function DownloadsChart({
 export function UsersContent({ users }: { users: UsageUsers }) {
   return (
     <>
-      <Flex mt="3" pb="3" style={{ borderBottom: "1px solid var(--gray-4)" }}>
+      <StatRow mt="3" pb="3" style={{ borderBottom: "1px solid var(--gray-4)" }}>
         <Stat
           label="Unique IPs"
           help={HELP.uniqueIps}
@@ -199,15 +225,13 @@ export function UsersContent({ users }: { users: UsageUsers }) {
           label="Registered"
           help={HELP.registered}
           value={compactFormat.format(Math.round(users.registered)).toLowerCase()}
-          divider
         />
         <Stat
           label="Anon downloads"
           help={HELP.anon}
           value={compactFormat.format(Math.round(users.anonRequests)).toLowerCase()}
-          divider
         />
-      </Flex>
+      </StatRow>
 
       <Box mt="3">
         <MonoLabel help={HELP.distribution}>IPs by download count</MonoLabel>


### PR DESCRIPTION
The metrics row on the analytics card and the product analytics page runs off
the side of a phone. It is a flex row of boxes whose values are
`white-space: nowrap`, so the row has a hard minimum width and nothing in it
can shrink below that. On a phone the minimum is wider than the viewport: the
card is `overflow: hidden`, so it cut COUNTRIES in half, and the analytics page
pushed it off the screen entirely.

It is now an auto-fitting grid — `repeat(auto-fit, minmax(120px, 1fr))` — so
the metrics wrap onto further rows at whatever width stops fitting them, rather
than overflowing. No breakpoints: the row responds to the space it is actually
given, which matters because the same row appears in a narrow card in a page
column and across a full-width admin page.

The dividers are the reason this needed more than `flex-wrap`. Each Stat now
carries its own left divider unconditionally and the grid is pulled left by one
divider plus its padding, so the leading column of every row is clipped back to
flush. A stat no longer has to be told whether it starts a row, which is not
knowable once the row can wrap — and the `divider` prop is gone.

That same clip is why the minimum track is 120px rather than as small as it
could be: it would hide a value that outgrew its column just as quietly as it
hides the divider. 120px holds the widest value these metrics realistically
report — a ten-character downloads count — measured against the rendered mono
face rather than estimated.

The row is shared, so this also covers the USERS tab and the admin traffic
explorer. The admin explorer's five metrics still sit on one line at its real
width (`Container size="4"`, ~1080px for the header); they wrap in Storybook
only because the preview decorator caps stories at 720px.

## Stories

New `Mobile` stories pin the small-mobile viewport so the wrapped row is
reviewable:

- [UsagePanel / Mobile](https://source-coop-ui-git-fix-analytics-stats-mobile-radiantearth.vercel.app/?path=/story/features-analytics-usagepanel--mobile)
- [ProductAnalyticsView / Mobile](https://source-coop-ui-git-fix-analytics-stats-mobile-radiantearth.vercel.app/?path=/story/features-analytics-productanalyticsview--mobile)

Unchanged at desktop width, worth a look for the divider clipping:

- [UsagePanel / HighVolume](https://source-coop-ui-git-fix-analytics-stats-mobile-radiantearth.vercel.app/?path=/story/features-analytics-usagepanel--high-volume)
- [AdminBreakdownChart / Default](https://source-coop-ui-git-fix-analytics-stats-mobile-radiantearth.vercel.app/?path=/story/features-analytics-adminbreakdownchart--default)

## Testing

`tsc --noEmit`, `next lint` on the analytics directory, and the two analytics
jest suites (5 tests) pass. The wrapped row was checked in a browser at 320px
and 390px viewports across the card, both tabs of the analytics page, and the
admin chart; no value is clipped in any of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AymtofAVE91sxdFjzqrARG
