### PR TITLE
docs(agents): require docs.source.coop and data.source.coop ADR updates alongside changes

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -17,6 +17,23 @@ on:
 jobs:
   review:
     uses: source-cooperative/.github/.github/workflows/claude-pr-review.yml@main
+    with:
+      # The shared prompt hunts bugs and says to skip nits, so the "Docs and
+      # ADRs" section of CLAUDE.md would never be enforced on its own even
+      # though the reviewer has it in context. This is what makes it checked.
+      extra_instructions: |
+        Also check the documentation requirement in CLAUDE.md's "Docs and ADRs"
+        section. Read the PR description with `gh pr view`. When the diff
+        changes a user-facing flow documented at docs.source.coop (creating an
+        account or a product, data upload, bring-your-own-bucket, the data
+        proxy) or moves a decision recorded in data.source.coop's `adrs/`
+        (authorization, STS credentials, API keys, outbound federation), the
+        description has to name the affected doc or ADR — linking the PR that
+        updates it, or saying why it still holds. A description that is silent
+        on a change of that shape is itself the finding, since silence reads
+        the same whether the docs were checked or forgotten. Report these in a
+        final **Docs** section, advisory and never blocking, omitted when the
+        diff touches neither.
     # Granted here because a called workflow can only maintain or reduce the
     # caller's token permissions, never elevate them.
     permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,31 @@ the real layout has, so it invents overflow the page doesn't have.
 The JSDoc above `meta`, and above each story export, is published prose on
 ui.source.coop — not a code comment. Write it for a reader.
 
+## Docs and ADRs
+
+Two repositories outside this one hold prose that a change here can quietly
+invalidate. Check both while the change is still in your head — whoever finds a
+stale page a month from now has no idea which PR made it stale.
+
+[docs.source.coop](https://github.com/source-cooperative/docs.source.coop) is the
+user-facing documentation. A change to a flow a user walks through — creating an
+account or a product, uploading data, bringing your own bucket — dates the page
+in `docs/using-source/` that describes it, and a change to how the platform is
+put together dates `docs/about-source/`.
+
+[data.source.coop](https://github.com/source-cooperative/data.source.coop) is the
+data proxy, and its `adrs/` directory records the decisions this app shares with
+it: authorization, STS credentials, API keys, outbound federation. An ADR records
+a decision, not the code that implements it, so a change that merely implements
+one leaves it alone. A change that moves the decision needs a new ADR, or an
+amendment to the one it supersedes, in that repository.
+
+The PR description says which way it went: name the doc or ADR the change
+affects and link the PR carrying that update, or name the ones you checked and
+say why they still hold. "Checked the data-proxy ADRs; 005 still describes the
+model" is worth writing, because silence reads the same whether the docs were
+checked or forgotten.
+
 ## Pull requests
 
 A PR that touches the UI links the stories it affects, on that branch's Storybook


### PR DESCRIPTION
## What I'm changing

A change in this repo can quietly invalidate prose that lives in two other repositories, and nothing here says so. This adds that convention and makes the PR review actually check it.

- **`CLAUDE.md` gains a "Docs and ADRs" section.** It names what each sibling repo holds — the user-facing pages at [docs.source.coop](https://github.com/source-cooperative/docs.source.coop), and the decision records in [data.source.coop](https://github.com/source-cooperative/data.source.coop)'s `adrs/` — and asks the PR description to say which way it went: name the doc or ADR the change affects and link the PR carrying that update, or name the ones you checked and why they still hold.
- **`AGENTS.md` is a symlink to `CLAUDE.md`.** The repo had no `AGENTS.md`; agents looking for either name now find the same conventions, with one file to keep current.
- **`.github/workflows/claude-review.yml` passes the check to the reviewer.**

## How I did it

The distinction the section draws for ADRs is the one worth reading twice: an ADR records a *decision*, not the code implementing it, so a PR that merely implements an existing ADR leaves it alone. Only a PR that moves the decision needs a new ADR or an amendment.

For the review: the org-wide prompt in [`source-cooperative/.github`](https://github.com/source-cooperative/.github/blob/main/.github/workflows/claude-pr-review.yml) asks for correctness and security findings and explicitly says to skip nits. The reviewer does have `CLAUDE.md` in context, but nothing directs it at this section, so on its own the convention would sit there unenforced. Rather than fork the shared prompt, the caller uses the `extra_instructions` input the reusable workflow already exposes for this. `gh pr view` is already in its allowed tools, so it can read the description it is being asked to judge.

The findings are **advisory and never blocking**, in the same spirit as the ponytail section — a reviewer that cannot see the sibling repos should not hold a merge on its guess about them. Say the word if you would rather it block.

## How you can test it

- `AGENTS.md` resolves to `CLAUDE.md` and is committed as a symlink (mode `120000`), not a copy of the file.
- `.github/workflows/claude-review.yml` parses as YAML; its pre-existing Prettier warning is unchanged by this PR, and CI lints source with ESLint rather than Prettier on workflows.
- **This PR will not be auto-reviewed**, so the new instructions are not exercised here: the caller has `paths-ignore: .github/workflows/**`, because the action cannot validate against modified workflow files. The first PR after this one that leaves workflows alone is where the **Docs** section shows up.

### Docs impact

Per the convention this PR introduces: nothing user-facing changes, so no docs.source.coop page is affected, and no decision moves, so no data.source.coop ADR needs amending. Contributor-facing conventions live in `CLAUDE.md` and `CONTRIBUTING.md`; `CONTRIBUTING.md`'s PR checklist still holds as written, and this stays in `CLAUDE.md` rather than being duplicated there.

No UI changes, so no Storybook stories are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuptGTaeitSnDz2yyy5a8R
